### PR TITLE
gui/osg_qt4 does not need to be renamed for qt5

### DIFF
--- a/colcon_imports.autobuild
+++ b/colcon_imports.autobuild
@@ -30,7 +30,7 @@ colcon_import_package "gui/vizkit3d"
 colcon_import_package "gui/osgviz"
 
 colcon_import_package "external/sisl"
-colcon_import_package "gui/osg_qt5"
+colcon_import_package "gui/osg_qt4"
 colcon_import_package "gui/qtpropertybrowser"
 colcon_import_package "base/numeric"
 colcon_import_package "base/boost_serialization"

--- a/source.yml
+++ b/source.yml
@@ -68,9 +68,8 @@ version_control:
     github: rock-core/gui-osgviz
   - external/sisl:
     github: SINTEF-Geometry/SISL
-  - gui/osg_qt5:
+  - gui/osg_qt4:
     github: rock-core/gui-osg_qt4
-    branch: feature/qt5
   - gui/qtpropertybrowser:
     github: abhijitkundu/QtPropertyBrowser
   - base/numeric:


### PR DESCRIPTION
also: compatibility changes were merged to master