### PR TITLE
adjust dependency to use the original ubuntu packages

### DIFF
--- a/ros-2.osdeps
+++ b/ros-2.osdeps
@@ -39,10 +39,10 @@ tools/class_loader:
     osdep: class_loader
 
 control/urdfdom:
-    osdep: urdfdom
+    osdep: liburdfdom-dev
 
 control/urdfdom_headers:
-    osdep: urdfdom_headers
+    osdep: liburdfdom-headers-dev
 
 openvdb:
     ubuntu: libopenvdb-dev


### PR DESCRIPTION
The ros packages (ros-*-urdfdom and ros-*-urdfdom-headers) install their pc-files in a location where rock packages like `envire/envire_smurf_loader` will fail to find it, without further adjustments.

The standard ubuntu packages seem to satisfy the dependencies equally well, so I'd suggest to switch this here.