### PR TITLE
make slam3d packages use their actual ros package names for autoproj too

### DIFF
--- a/dependency_name_overrides.yml
+++ b/dependency_name_overrides.yml
@@ -7,4 +7,4 @@
 # there defines just "slam3d".
 # To have the manually set package name occur in auto-generated package.xml files, you can define the 
 # name conversion from path to the manula package name here:
-slam/slam3d: slam3d
+#slam/slam3d: slam3d

--- a/ros-2.autobuild
+++ b/ros-2.autobuild
@@ -1,4 +1,3 @@
-import_package "slam/slam3d"
 import_package "slam/g2o" do |pkg|
     pkg.depends_on "suitesparse"
 end
@@ -9,10 +8,11 @@ import_package "slam/pointmatcher" do |pkg|
     pkg.depends_on "slam/nabo"
 end
 
-import_package "slam/slam3d_ros2" do |pkg|
-    pkg.depends_on "slam/slam3d"
-    pkg.depends_on "ament_cmake"
-end
+import_package "slam3d"
+move_package "slam3d", "slam"
+
+colcon_package "slam3d_ros2"
+move_package "slam3d_ros2", "slam"
 
 not_on ["ubuntu", "22.04"] do
     colcon_package "slam/vdb_mapping"

--- a/ros-2.autobuild
+++ b/ros-2.autobuild
@@ -11,8 +11,7 @@ end
 import_package "slam3d"
 move_package "slam3d", "slam"
 
-colcon_package "slam3d_ros2"
-move_package "slam3d_ros2", "slam"
+colcon_package "slam3d_ros2", move_to: "slam"
 
 not_on ["ubuntu", "22.04"] do
     colcon_package "slam/vdb_mapping"

--- a/ros-2.autobuild
+++ b/ros-2.autobuild
@@ -10,8 +10,11 @@ end
 
 import_package "slam3d"
 move_package "slam3d", "slam"
+metapackage "slam/slam3d", "slam3d"
 
-colcon_package "slam3d_ros2", move_to: "slam"
+colcon_package "slam3d_ros2"
+move_package "slam3d_ros2", "slam"
+metapackage "slam/slam3d_ros2", "slam3d_ros2"
 
 not_on ["ubuntu", "22.04"] do
     colcon_package "slam/vdb_mapping"

--- a/source.yml
+++ b/source.yml
@@ -13,10 +13,10 @@ version_control:
   - slam/pointmatcher:
     github: skasperski/libpointmatcher
 
-  - slam/slam3d:
+  - slam3d:
     github: dfki-ric/slam3d
 
-  - slam/slam3d_ros2:
+  - slam3d_ros2:
     github: dfki-ric/slam3d_ros2
 
   - base/cmake:


### PR DESCRIPTION
Currently autoproj doesn't install the dependencies from `slam3d_ros2` package.xml file, maybe because they were overridden in the autobuild definition of the package. 

With this patch we delete these dependencies and have autoproj read the deps from the package.xml file. This however leads to the problem that the slam3d dependency is not found, because it is declared as `slam/slam3d`, here. Therefore we have the packages here declare their actual package name to autoproj, and move them to the desired path in the workspace afterwards.

Not sure, if this is the cleanest approach to address this problem. Any alternatives that would achieve this better would be welcome.