### PR TITLE
Improve rosdep import (auto-determine tag)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-/ros.osdeps
-/ubuntu.osdeps

--- a/lib/rosdep_import.rb
+++ b/lib/rosdep_import.rb
@@ -143,7 +143,9 @@ module Ros2
             rostag=getLatestTag(rosversion)
             Autoproj.message "Using tag: #{rostag} of https://github.com/ros/rosdistro to generate osdeps" 
             @osdep_file.puts "# based on https://github.com/ros/rosdistro tag #{rostag}\n#"
+            @osdep_file.puts "# If you need a refresh, call autoproj reconfigure or delete just this file and run autoproj update --config\n#"
             @rosfile.puts "# based on https://raw.githubusercontent.com/ros/rosdistro/refs/heads/master/"+rosversion+"/distribution.yaml\n#"
+            @rosfile.puts "# If you need a refresh, call autoproj reconfigure or delete just this file and run autoproj update --config\n#"
             import_rosdep_osdeps("https://raw.githubusercontent.com/ros/rosdistro/refs/tags/#{rostag}/rosdep/base.yaml")
             import_rosdep_osdeps("https://raw.githubusercontent.com/ros/rosdistro/refs/tags/#{rostag}/rosdep/python.yaml")
             import_rosdep_osdeps("https://raw.githubusercontent.com/ros/rosdistro/refs/tags/#{rostag}/rosdep/ruby.yaml")

--- a/lib/rosdep_import.rb
+++ b/lib/rosdep_import.rb
@@ -1,7 +1,8 @@
 require 'yaml'
 require 'fileutils'
 require 'open-uri'
-
+require 'json'
+require 'net/http'
 # Importer for rosdep definition files
 # use the import() function to save osdeps for a specific ros version, e.g. import("humble")
 
@@ -18,6 +19,42 @@ module Ros2
         def close()
             @osdep_file.close()
             @rosfile.close()
+        end
+
+        def getLatestTag(rosdistro)
+            page = 1
+            new_data = 100
+            all_tags = Array.new
+        
+            # tags are paginated in gitlab, at max we can get 100 entries per page.
+            while new_data == 100 do
+                data = Net::HTTP.get URI("https://api.github.com/repos/ros/rosdistro/tags?page=#{page}&per_page=100")
+                tags = JSON.parse(data)
+                begin
+                    all_tags.concat tags
+                rescue
+                    puts "cound not get tag information from gitlab api:"
+                    puts tags
+                    return ""
+                end
+                #puts "page #{page} data: #{tags.size}"
+                new_data = tags.size
+                page += 1
+            end
+        
+            #dates = Array.new
+            all_tags.each do |tag|
+                sp = tag['name'].split('/')
+                if (sp[0] == rosdistro) then
+                    # just need the fist entry (latest tag)
+                    return rosdistro + '/' + sp[1]
+                    #puts sp[1]
+                    #dates.push(sp[1])
+                    #break # just need the fist entry (latest tag)
+                end
+            end
+            return ""
+        
         end
 
         def check_pip_gem(osentry)
@@ -102,8 +139,9 @@ module Ros2
             end
         end
 
-        def import(rosversion, date)
-            rostag=rosversion+"/"+date
+        def import(rosversion)
+            rostag=getLatestTag(rosversion)
+            Autoproj.message "Using tag: #{rostag} of https://github.com/ros/rosdistro to generate osdeps" 
             @osdep_file.puts "# based on https://github.com/ros/rosdistro tag #{rostag}\n#"
             @rosfile.puts "# based on https://raw.githubusercontent.com/ros/rosdistro/refs/heads/master/"+rosversion+"/distribution.yaml\n#"
             import_rosdep_osdeps("https://raw.githubusercontent.com/ros/rosdistro/refs/tags/#{rostag}/rosdep/base.yaml")

--- a/ros.osdeps
+++ b/ros.osdeps
@@ -1,0 +1,1 @@
+# dummy file for autoproj to recognize the <THIS_FILE>-<ROSNAME> osdeps files

--- a/ros.osdeps-humble
+++ b/ros.osdeps-humble
@@ -1,0 +1,3666 @@
+#
+# This file is generated, do not edit!
+# based on https://raw.githubusercontent.com/ros/rosdistro/refs/heads/master/humble/distribution.yaml
+#
+aandd_ekew_driver_py:
+    ubuntu: ros-humble-aandd-ekew-driver-py
+acado_vendor:
+    ubuntu: ros-humble-acado-vendor
+ackermann_msgs:
+    ubuntu: ros-humble-ackermann-msgs
+actuator_msgs:
+    ubuntu: ros-humble-actuator-msgs
+adaptive_component:
+    ubuntu: ros-humble-adaptive-component
+adi_3dtof_image_stitching:
+    ubuntu: ros-humble-adi-3dtof-image-stitching
+adi_tmcl:
+    ubuntu: ros-humble-adi-tmcl
+aerostack2:
+    ubuntu: ros-humble-aerostack2
+as2_alphanumeric_viewer:
+    ubuntu: ros-humble-as2-alphanumeric-viewer
+as2_behavior:
+    ubuntu: ros-humble-as2-behavior
+as2_behavior_tree:
+    ubuntu: ros-humble-as2-behavior-tree
+as2_behaviors_motion:
+    ubuntu: ros-humble-as2-behaviors-motion
+as2_behaviors_path_planning:
+    ubuntu: ros-humble-as2-behaviors-path-planning
+as2_behaviors_perception:
+    ubuntu: ros-humble-as2-behaviors-perception
+as2_behaviors_platform:
+    ubuntu: ros-humble-as2-behaviors-platform
+as2_behaviors_trajectory_generation:
+    ubuntu: ros-humble-as2-behaviors-trajectory-generation
+as2_cli:
+    ubuntu: ros-humble-as2-cli
+as2_core:
+    ubuntu: ros-humble-as2-core
+as2_external_object_to_tf:
+    ubuntu: ros-humble-as2-external-object-to-tf
+as2_gazebo_assets:
+    ubuntu: ros-humble-as2-gazebo-assets
+as2_geozones:
+    ubuntu: ros-humble-as2-geozones
+as2_keyboard_teleoperation:
+    ubuntu: ros-humble-as2-keyboard-teleoperation
+as2_map_server:
+    ubuntu: ros-humble-as2-map-server
+as2_motion_controller:
+    ubuntu: ros-humble-as2-motion-controller
+as2_motion_reference_handlers:
+    ubuntu: ros-humble-as2-motion-reference-handlers
+as2_msgs:
+    ubuntu: ros-humble-as2-msgs
+as2_platform_gazebo:
+    ubuntu: ros-humble-as2-platform-gazebo
+as2_platform_multirotor_simulator:
+    ubuntu: ros-humble-as2-platform-multirotor-simulator
+as2_python_api:
+    ubuntu: ros-humble-as2-python-api
+as2_realsense_interface:
+    ubuntu: ros-humble-as2-realsense-interface
+as2_rviz_plugins:
+    ubuntu: ros-humble-as2-rviz-plugins
+as2_state_estimator:
+    ubuntu: ros-humble-as2-state-estimator
+as2_usb_camera_interface:
+    ubuntu: ros-humble-as2-usb-camera-interface
+as2_visualization:
+    ubuntu: ros-humble-as2-visualization
+affordance_primitives:
+    ubuntu: ros-humble-affordance-primitives
+ai_prompt_msgs:
+    ubuntu: ros-humble-ai-prompt-msgs
+ament_acceleration:
+    ubuntu: ros-humble-ament-acceleration
+ament_black:
+    ubuntu: ros-humble-ament-black
+ament_cmake_black:
+    ubuntu: ros-humble-ament-cmake-black
+ament_cmake:
+    ubuntu: ros-humble-ament-cmake
+ament_cmake_auto:
+    ubuntu: ros-humble-ament-cmake-auto
+ament_cmake_core:
+    ubuntu: ros-humble-ament-cmake-core
+ament_cmake_export_definitions:
+    ubuntu: ros-humble-ament-cmake-export-definitions
+ament_cmake_export_dependencies:
+    ubuntu: ros-humble-ament-cmake-export-dependencies
+ament_cmake_export_include_directories:
+    ubuntu: ros-humble-ament-cmake-export-include-directories
+ament_cmake_export_interfaces:
+    ubuntu: ros-humble-ament-cmake-export-interfaces
+ament_cmake_export_libraries:
+    ubuntu: ros-humble-ament-cmake-export-libraries
+ament_cmake_export_link_flags:
+    ubuntu: ros-humble-ament-cmake-export-link-flags
+ament_cmake_export_targets:
+    ubuntu: ros-humble-ament-cmake-export-targets
+ament_cmake_gen_version_h:
+    ubuntu: ros-humble-ament-cmake-gen-version-h
+ament_cmake_gmock:
+    ubuntu: ros-humble-ament-cmake-gmock
+ament_cmake_google_benchmark:
+    ubuntu: ros-humble-ament-cmake-google-benchmark
+ament_cmake_gtest:
+    ubuntu: ros-humble-ament-cmake-gtest
+ament_cmake_include_directories:
+    ubuntu: ros-humble-ament-cmake-include-directories
+ament_cmake_libraries:
+    ubuntu: ros-humble-ament-cmake-libraries
+ament_cmake_nose:
+    ubuntu: ros-humble-ament-cmake-nose
+ament_cmake_pytest:
+    ubuntu: ros-humble-ament-cmake-pytest
+ament_cmake_python:
+    ubuntu: ros-humble-ament-cmake-python
+ament_cmake_target_dependencies:
+    ubuntu: ros-humble-ament-cmake-target-dependencies
+ament_cmake_test:
+    ubuntu: ros-humble-ament-cmake-test
+ament_cmake_vendor_package:
+    ubuntu: ros-humble-ament-cmake-vendor-package
+ament_cmake_version:
+    ubuntu: ros-humble-ament-cmake-version
+ament_cmake_catch2:
+    ubuntu: ros-humble-ament-cmake-catch2
+ament_cmake_ros:
+    ubuntu: ros-humble-ament-cmake-ros
+domain_coordinator:
+    ubuntu: ros-humble-domain-coordinator
+ament_download:
+    ubuntu: ros-humble-ament-download
+ament_index_cpp:
+    ubuntu: ros-humble-ament-index-cpp
+ament_index_python:
+    ubuntu: ros-humble-ament-index-python
+ament_clang_format:
+    ubuntu: ros-humble-ament-clang-format
+ament_clang_tidy:
+    ubuntu: ros-humble-ament-clang-tidy
+ament_cmake_clang_format:
+    ubuntu: ros-humble-ament-cmake-clang-format
+ament_cmake_clang_tidy:
+    ubuntu: ros-humble-ament-cmake-clang-tidy
+ament_cmake_copyright:
+    ubuntu: ros-humble-ament-cmake-copyright
+ament_cmake_cppcheck:
+    ubuntu: ros-humble-ament-cmake-cppcheck
+ament_cmake_cpplint:
+    ubuntu: ros-humble-ament-cmake-cpplint
+ament_cmake_flake8:
+    ubuntu: ros-humble-ament-cmake-flake8
+ament_cmake_lint_cmake:
+    ubuntu: ros-humble-ament-cmake-lint-cmake
+ament_cmake_mypy:
+    ubuntu: ros-humble-ament-cmake-mypy
+ament_cmake_pclint:
+    ubuntu: ros-humble-ament-cmake-pclint
+ament_cmake_pep257:
+    ubuntu: ros-humble-ament-cmake-pep257
+ament_cmake_pycodestyle:
+    ubuntu: ros-humble-ament-cmake-pycodestyle
+ament_cmake_pyflakes:
+    ubuntu: ros-humble-ament-cmake-pyflakes
+ament_cmake_uncrustify:
+    ubuntu: ros-humble-ament-cmake-uncrustify
+ament_cmake_xmllint:
+    ubuntu: ros-humble-ament-cmake-xmllint
+ament_copyright:
+    ubuntu: ros-humble-ament-copyright
+ament_cppcheck:
+    ubuntu: ros-humble-ament-cppcheck
+ament_cpplint:
+    ubuntu: ros-humble-ament-cpplint
+ament_flake8:
+    ubuntu: ros-humble-ament-flake8
+ament_lint:
+    ubuntu: ros-humble-ament-lint
+ament_lint_auto:
+    ubuntu: ros-humble-ament-lint-auto
+ament_lint_cmake:
+    ubuntu: ros-humble-ament-lint-cmake
+ament_lint_common:
+    ubuntu: ros-humble-ament-lint-common
+ament_mypy:
+    ubuntu: ros-humble-ament-mypy
+ament_pclint:
+    ubuntu: ros-humble-ament-pclint
+ament_pep257:
+    ubuntu: ros-humble-ament-pep257
+ament_pycodestyle:
+    ubuntu: ros-humble-ament-pycodestyle
+ament_pyflakes:
+    ubuntu: ros-humble-ament-pyflakes
+ament_uncrustify:
+    ubuntu: ros-humble-ament-uncrustify
+ament_xmllint:
+    ubuntu: ros-humble-ament-xmllint
+ament_nodl:
+    ubuntu: ros-humble-ament-nodl
+ament_package:
+    ubuntu: ros-humble-ament-package
+ament_vitis:
+    ubuntu: ros-humble-ament-vitis
+andino_apps:
+    ubuntu: ros-humble-andino-apps
+andino_base:
+    ubuntu: ros-humble-andino-base
+andino_bringup:
+    ubuntu: ros-humble-andino-bringup
+andino_control:
+    ubuntu: ros-humble-andino-control
+andino_description:
+    ubuntu: ros-humble-andino-description
+andino_firmware:
+    ubuntu: ros-humble-andino-firmware
+andino_gz_classic:
+    ubuntu: ros-humble-andino-gz-classic
+andino_hardware:
+    ubuntu: ros-humble-andino-hardware
+andino_navigation:
+    ubuntu: ros-humble-andino-navigation
+andino_slam:
+    ubuntu: ros-humble-andino-slam
+andino_gz:
+    ubuntu: ros-humble-andino-gz
+angles:
+    ubuntu: ros-humble-angles
+apex_containers:
+    ubuntu: ros-humble-apex-containers
+apex_test_tools:
+    ubuntu: ros-humble-apex-test-tools
+test_apex_test_tools:
+    ubuntu: ros-humble-test-apex-test-tools
+apriltag:
+    ubuntu: ros-humble-apriltag
+apriltag_detector:
+    ubuntu: ros-humble-apriltag-detector
+apriltag_detector_mit:
+    ubuntu: ros-humble-apriltag-detector-mit
+apriltag_detector_umich:
+    ubuntu: ros-humble-apriltag-detector-umich
+apriltag_draw:
+    ubuntu: ros-humble-apriltag-draw
+apriltag_mit:
+    ubuntu: ros-humble-apriltag-mit
+apriltag_msgs:
+    ubuntu: ros-humble-apriltag-msgs
+apriltag_ros:
+    ubuntu: ros-humble-apriltag-ros
+aruco_opencv:
+    ubuntu: ros-humble-aruco-opencv
+aruco_opencv_msgs:
+    ubuntu: ros-humble-aruco-opencv-msgs
+aruco:
+    ubuntu: ros-humble-aruco
+aruco_msgs:
+    ubuntu: ros-humble-aruco-msgs
+aruco_ros:
+    ubuntu: ros-humble-aruco-ros
+as2_platform_crazyflie:
+    ubuntu: ros-humble-as2-platform-crazyflie
+as2_platform_dji_osdk:
+    ubuntu: ros-humble-as2-platform-dji-osdk
+as2_platform_dji_psdk:
+    ubuntu: ros-humble-as2-platform-dji-psdk
+as2_platform_mavlink:
+    ubuntu: ros-humble-as2-platform-mavlink
+as2_platform_pixhawk:
+    ubuntu: ros-humble-as2-platform-pixhawk
+as2_platform_tello:
+    ubuntu: ros-humble-as2-platform-tello
+delphi_esr_msgs:
+    ubuntu: ros-humble-delphi-esr-msgs
+delphi_mrr_msgs:
+    ubuntu: ros-humble-delphi-mrr-msgs
+delphi_srr_msgs:
+    ubuntu: ros-humble-delphi-srr-msgs
+derived_object_msgs:
+    ubuntu: ros-humble-derived-object-msgs
+ibeo_msgs:
+    ubuntu: ros-humble-ibeo-msgs
+kartech_linear_actuator_msgs:
+    ubuntu: ros-humble-kartech-linear-actuator-msgs
+mobileye_560_660_msgs:
+    ubuntu: ros-humble-mobileye-560-660-msgs
+neobotix_usboard_msgs:
+    ubuntu: ros-humble-neobotix-usboard-msgs
+async_web_server_cpp:
+    ubuntu: ros-humble-async-web-server-cpp
+automatika_ros_sugar:
+    ubuntu: ros-humble-automatika-ros-sugar
+automotive_autonomy_msgs:
+    ubuntu: ros-humble-automotive-autonomy-msgs
+automotive_navigation_msgs:
+    ubuntu: ros-humble-automotive-navigation-msgs
+automotive_platform_msgs:
+    ubuntu: ros-humble-automotive-platform-msgs
+autoware_adapi_v1_msgs:
+    ubuntu: ros-humble-autoware-adapi-v1-msgs
+autoware_adapi_version_msgs:
+    ubuntu: ros-humble-autoware-adapi-version-msgs
+autoware_auto_msgs:
+    ubuntu: ros-humble-autoware-auto-msgs
+autoware_cmake:
+    ubuntu: ros-humble-autoware-cmake
+autoware_lint_common:
+    ubuntu: ros-humble-autoware-lint-common
+autoware_internal_debug_msgs:
+    ubuntu: ros-humble-autoware-internal-debug-msgs
+autoware_internal_msgs:
+    ubuntu: ros-humble-autoware-internal-msgs
+autoware_internal_perception_msgs:
+    ubuntu: ros-humble-autoware-internal-perception-msgs
+autoware_lanelet2_extension:
+    ubuntu: ros-humble-autoware-lanelet2-extension
+autoware_lanelet2_extension_python:
+    ubuntu: ros-humble-autoware-lanelet2-extension-python
+autoware_common_msgs:
+    ubuntu: ros-humble-autoware-common-msgs
+autoware_control_msgs:
+    ubuntu: ros-humble-autoware-control-msgs
+autoware_localization_msgs:
+    ubuntu: ros-humble-autoware-localization-msgs
+autoware_map_msgs:
+    ubuntu: ros-humble-autoware-map-msgs
+autoware_perception_msgs:
+    ubuntu: ros-humble-autoware-perception-msgs
+autoware_planning_msgs:
+    ubuntu: ros-humble-autoware-planning-msgs
+autoware_sensing_msgs:
+    ubuntu: ros-humble-autoware-sensing-msgs
+autoware_system_msgs:
+    ubuntu: ros-humble-autoware-system-msgs
+autoware_v2x_msgs:
+    ubuntu: ros-humble-autoware-v2x-msgs
+autoware_vehicle_msgs:
+    ubuntu: ros-humble-autoware-vehicle-msgs
+autoware_utils:
+    ubuntu: ros-humble-autoware-utils
+avt_vimba_camera:
+    ubuntu: ros-humble-avt-vimba-camera
+aws_robomaker_small_warehouse_world:
+    ubuntu: ros-humble-aws-robomaker-small-warehouse-world
+aws_sdk_cpp_vendor:
+    ubuntu: ros-humble-aws-sdk-cpp-vendor
+axis_camera:
+    ubuntu: ros-humble-axis-camera
+axis_description:
+    ubuntu: ros-humble-axis-description
+axis_msgs:
+    ubuntu: ros-humble-axis-msgs
+backward_ros:
+    ubuntu: ros-humble-backward-ros
+bag2_to_image:
+    ubuntu: ros-humble-bag2-to-image
+bcr_bot:
+    ubuntu: ros-humble-bcr-bot
+behaviortree_cpp_v3:
+    ubuntu: ros-humble-behaviortree-cpp-v3
+behaviortree_cpp:
+    ubuntu: ros-humble-behaviortree-cpp
+beluga:
+    ubuntu: ros-humble-beluga
+beluga_amcl:
+    ubuntu: ros-humble-beluga-amcl
+beluga_ros:
+    ubuntu: ros-humble-beluga-ros
+bno055:
+    ubuntu: ros-humble-bno055
+bond:
+    ubuntu: ros-humble-bond
+bond_core:
+    ubuntu: ros-humble-bond-core
+bondcpp:
+    ubuntu: ros-humble-bondcpp
+smclib:
+    ubuntu: ros-humble-smclib
+boost_geometry_util:
+    ubuntu: ros-humble-boost-geometry-util
+boost_plugin_loader:
+    ubuntu: ros-humble-boost-plugin-loader
+camera_aravis2:
+    ubuntu: ros-humble-camera-aravis2
+camera_aravis2_msgs:
+    ubuntu: ros-humble-camera-aravis2-msgs
+camera_ros:
+    ubuntu: ros-humble-camera-ros
+caret_analyze:
+    ubuntu: ros-humble-caret-analyze
+caret_analyze_cpp_impl:
+    ubuntu: ros-humble-caret-analyze-cpp-impl
+caret_msgs:
+    ubuntu: ros-humble-caret-msgs
+cartographer:
+    ubuntu: ros-humble-cartographer
+cartographer_ros:
+    ubuntu: ros-humble-cartographer-ros
+cartographer_ros_msgs:
+    ubuntu: ros-humble-cartographer-ros-msgs
+cartographer_rviz:
+    ubuntu: ros-humble-cartographer-rviz
+cascade_lifecycle_msgs:
+    ubuntu: ros-humble-cascade-lifecycle-msgs
+rclcpp_cascade_lifecycle:
+    ubuntu: ros-humble-rclcpp-cascade-lifecycle
+catch_ros2:
+    ubuntu: ros-humble-catch-ros2
+class_loader:
+    ubuntu: ros-humble-class-loader
+classic_bags:
+    ubuntu: ros-humble-classic-bags
+clearpath_common:
+    ubuntu: ros-humble-clearpath-common
+clearpath_control:
+    ubuntu: ros-humble-clearpath-control
+clearpath_customization:
+    ubuntu: ros-humble-clearpath-customization
+clearpath_description:
+    ubuntu: ros-humble-clearpath-description
+clearpath_generator_common:
+    ubuntu: ros-humble-clearpath-generator-common
+clearpath_manipulators:
+    ubuntu: ros-humble-clearpath-manipulators
+clearpath_manipulators_description:
+    ubuntu: ros-humble-clearpath-manipulators-description
+clearpath_mounts_description:
+    ubuntu: ros-humble-clearpath-mounts-description
+clearpath_platform_description:
+    ubuntu: ros-humble-clearpath-platform-description
+clearpath_sensors_description:
+    ubuntu: ros-humble-clearpath-sensors-description
+clearpath_config:
+    ubuntu: ros-humble-clearpath-config
+clearpath_config_live:
+    ubuntu: ros-humble-clearpath-config-live
+clearpath_desktop:
+    ubuntu: ros-humble-clearpath-desktop
+clearpath_viz:
+    ubuntu: ros-humble-clearpath-viz
+clearpath_mecanum_drive_controller:
+    ubuntu: ros-humble-clearpath-mecanum-drive-controller
+clearpath_motor_msgs:
+    ubuntu: ros-humble-clearpath-motor-msgs
+clearpath_msgs:
+    ubuntu: ros-humble-clearpath-msgs
+clearpath_platform_msgs:
+    ubuntu: ros-humble-clearpath-platform-msgs
+clearpath_nav2_demos:
+    ubuntu: ros-humble-clearpath-nav2-demos
+clearpath_ros2_socketcan_interface:
+    ubuntu: ros-humble-clearpath-ros2-socketcan-interface
+clearpath_generator_gz:
+    ubuntu: ros-humble-clearpath-generator-gz
+clearpath_gz:
+    ubuntu: ros-humble-clearpath-gz
+clearpath_simulator:
+    ubuntu: ros-humble-clearpath-simulator
+clips_vendor:
+    ubuntu: ros-humble-clips-vendor
+coal:
+    ubuntu: ros-humble-coal
+cob_actions:
+    ubuntu: ros-humble-cob-actions
+cob_msgs:
+    ubuntu: ros-humble-cob-msgs
+cob_srvs:
+    ubuntu: ros-humble-cob-srvs
+color_names:
+    ubuntu: ros-humble-color-names
+color_util:
+    ubuntu: ros-humble-color-util
+actionlib_msgs:
+    ubuntu: ros-humble-actionlib-msgs
+common_interfaces:
+    ubuntu: ros-humble-common-interfaces
+diagnostic_msgs:
+    ubuntu: ros-humble-diagnostic-msgs
+geometry_msgs:
+    ubuntu: ros-humble-geometry-msgs
+nav_msgs:
+    ubuntu: ros-humble-nav-msgs
+sensor_msgs:
+    ubuntu: ros-humble-sensor-msgs
+sensor_msgs_py:
+    ubuntu: ros-humble-sensor-msgs-py
+shape_msgs:
+    ubuntu: ros-humble-shape-msgs
+std_msgs:
+    ubuntu: ros-humble-std-msgs
+std_srvs:
+    ubuntu: ros-humble-std-srvs
+stereo_msgs:
+    ubuntu: ros-humble-stereo-msgs
+trajectory_msgs:
+    ubuntu: ros-humble-trajectory-msgs
+visualization_msgs:
+    ubuntu: ros-humble-visualization-msgs
+console_bridge_vendor:
+    ubuntu: ros-humble-console-bridge-vendor
+control_box_rst:
+    ubuntu: ros-humble-control-box-rst
+control_msgs:
+    ubuntu: ros-humble-control-msgs
+control_toolbox:
+    ubuntu: ros-humble-control-toolbox
+tcb_span:
+    ubuntu: ros-humble-tcb-span
+tl_expected:
+    ubuntu: ros-humble-tl-expected
+crane_plus:
+    ubuntu: ros-humble-crane-plus
+crane_plus_control:
+    ubuntu: ros-humble-crane-plus-control
+crane_plus_description:
+    ubuntu: ros-humble-crane-plus-description
+crane_plus_examples:
+    ubuntu: ros-humble-crane-plus-examples
+crane_plus_gazebo:
+    ubuntu: ros-humble-crane-plus-gazebo
+crane_plus_moveit_config:
+    ubuntu: ros-humble-crane-plus-moveit-config
+create3_coverage:
+    ubuntu: ros-humble-create3-coverage
+create3_examples_msgs:
+    ubuntu: ros-humble-create3-examples-msgs
+create3_examples_py:
+    ubuntu: ros-humble-create3-examples-py
+create3_lidar_slam:
+    ubuntu: ros-humble-create3-lidar-slam
+create3_republisher:
+    ubuntu: ros-humble-create3-republisher
+create3_teleop:
+    ubuntu: ros-humble-create3-teleop
+irobot_create_common_bringup:
+    ubuntu: ros-humble-irobot-create-common-bringup
+irobot_create_control:
+    ubuntu: ros-humble-irobot-create-control
+irobot_create_description:
+    ubuntu: ros-humble-irobot-create-description
+irobot_create_gazebo_bringup:
+    ubuntu: ros-humble-irobot-create-gazebo-bringup
+irobot_create_gazebo_plugins:
+    ubuntu: ros-humble-irobot-create-gazebo-plugins
+irobot_create_gazebo_sim:
+    ubuntu: ros-humble-irobot-create-gazebo-sim
+irobot_create_ignition_bringup:
+    ubuntu: ros-humble-irobot-create-ignition-bringup
+irobot_create_ignition_plugins:
+    ubuntu: ros-humble-irobot-create-ignition-plugins
+irobot_create_ignition_sim:
+    ubuntu: ros-humble-irobot-create-ignition-sim
+irobot_create_ignition_toolbox:
+    ubuntu: ros-humble-irobot-create-ignition-toolbox
+irobot_create_nodes:
+    ubuntu: ros-humble-irobot-create-nodes
+irobot_create_toolbox:
+    ubuntu: ros-humble-irobot-create-toolbox
+create_bringup:
+    ubuntu: ros-humble-create-bringup
+create_description:
+    ubuntu: ros-humble-create-description
+create_driver:
+    ubuntu: ros-humble-create-driver
+create_msgs:
+    ubuntu: ros-humble-create-msgs
+create_robot:
+    ubuntu: ros-humble-create-robot
+cudnn_cmake_module:
+    ubuntu: ros-humble-cudnn-cmake-module
+cyclonedds:
+    ubuntu: ros-humble-cyclonedds
+data_tamer_cpp:
+    ubuntu: ros-humble-data-tamer-cpp
+data_tamer_msgs:
+    ubuntu: ros-humble-data-tamer-msgs
+dataspeed_can:
+    ubuntu: ros-humble-dataspeed-can
+dataspeed_can_msg_filters:
+    ubuntu: ros-humble-dataspeed-can-msg-filters
+dataspeed_can_msgs:
+    ubuntu: ros-humble-dataspeed-can-msgs
+dataspeed_can_tools:
+    ubuntu: ros-humble-dataspeed-can-tools
+dataspeed_can_usb:
+    ubuntu: ros-humble-dataspeed-can-usb
+dataspeed_dbw_common:
+    ubuntu: ros-humble-dataspeed-dbw-common
+dataspeed_ulc:
+    ubuntu: ros-humble-dataspeed-ulc
+dataspeed_ulc_can:
+    ubuntu: ros-humble-dataspeed-ulc-can
+dataspeed_ulc_msgs:
+    ubuntu: ros-humble-dataspeed-ulc-msgs
+dbw_fca:
+    ubuntu: ros-humble-dbw-fca
+dbw_fca_can:
+    ubuntu: ros-humble-dbw-fca-can
+dbw_fca_description:
+    ubuntu: ros-humble-dbw-fca-description
+dbw_fca_joystick_demo:
+    ubuntu: ros-humble-dbw-fca-joystick-demo
+dbw_fca_msgs:
+    ubuntu: ros-humble-dbw-fca-msgs
+dbw_ford:
+    ubuntu: ros-humble-dbw-ford
+dbw_ford_can:
+    ubuntu: ros-humble-dbw-ford-can
+dbw_ford_description:
+    ubuntu: ros-humble-dbw-ford-description
+dbw_ford_joystick_demo:
+    ubuntu: ros-humble-dbw-ford-joystick-demo
+dbw_ford_msgs:
+    ubuntu: ros-humble-dbw-ford-msgs
+dbw_polaris:
+    ubuntu: ros-humble-dbw-polaris
+dbw_polaris_can:
+    ubuntu: ros-humble-dbw-polaris-can
+dbw_polaris_description:
+    ubuntu: ros-humble-dbw-polaris-description
+dbw_polaris_joystick_demo:
+    ubuntu: ros-humble-dbw-polaris-joystick-demo
+dbw_polaris_msgs:
+    ubuntu: ros-humble-dbw-polaris-msgs
+ds_dbw:
+    ubuntu: ros-humble-ds-dbw
+ds_dbw_can:
+    ubuntu: ros-humble-ds-dbw-can
+ds_dbw_joystick_demo:
+    ubuntu: ros-humble-ds-dbw-joystick-demo
+ds_dbw_msgs:
+    ubuntu: ros-humble-ds-dbw-msgs
+action_tutorials_cpp:
+    ubuntu: ros-humble-action-tutorials-cpp
+action_tutorials_interfaces:
+    ubuntu: ros-humble-action-tutorials-interfaces
+action_tutorials_py:
+    ubuntu: ros-humble-action-tutorials-py
+composition:
+    ubuntu: ros-humble-composition
+demo_nodes_cpp:
+    ubuntu: ros-humble-demo-nodes-cpp
+demo_nodes_cpp_native:
+    ubuntu: ros-humble-demo-nodes-cpp-native
+demo_nodes_py:
+    ubuntu: ros-humble-demo-nodes-py
+dummy_map_server:
+    ubuntu: ros-humble-dummy-map-server
+dummy_robot_bringup:
+    ubuntu: ros-humble-dummy-robot-bringup
+dummy_sensors:
+    ubuntu: ros-humble-dummy-sensors
+image_tools:
+    ubuntu: ros-humble-image-tools
+intra_process_demo:
+    ubuntu: ros-humble-intra-process-demo
+lifecycle:
+    ubuntu: ros-humble-lifecycle
+lifecycle_py:
+    ubuntu: ros-humble-lifecycle-py
+logging_demo:
+    ubuntu: ros-humble-logging-demo
+pendulum_control:
+    ubuntu: ros-humble-pendulum-control
+pendulum_msgs:
+    ubuntu: ros-humble-pendulum-msgs
+quality_of_service_demo_cpp:
+    ubuntu: ros-humble-quality-of-service-demo-cpp
+quality_of_service_demo_py:
+    ubuntu: ros-humble-quality-of-service-demo-py
+topic_monitor:
+    ubuntu: ros-humble-topic-monitor
+topic_statistics_demo:
+    ubuntu: ros-humble-topic-statistics-demo
+depthai:
+    ubuntu: ros-humble-depthai
+depthai-ros:
+    ubuntu: ros-humble-depthai-ros
+depthai_bridge:
+    ubuntu: ros-humble-depthai-bridge
+depthai_descriptions:
+    ubuntu: ros-humble-depthai-descriptions
+depthai_examples:
+    ubuntu: ros-humble-depthai-examples
+depthai_filters:
+    ubuntu: ros-humble-depthai-filters
+depthai_ros_driver:
+    ubuntu: ros-humble-depthai-ros-driver
+depthai_ros_msgs:
+    ubuntu: ros-humble-depthai-ros-msgs
+depthimage_to_laserscan:
+    ubuntu: ros-humble-depthimage-to-laserscan
+diagnostic_aggregator:
+    ubuntu: ros-humble-diagnostic-aggregator
+diagnostic_common_diagnostics:
+    ubuntu: ros-humble-diagnostic-common-diagnostics
+diagnostic_updater:
+    ubuntu: ros-humble-diagnostic-updater
+diagnostics:
+    ubuntu: ros-humble-diagnostics
+self_test:
+    ubuntu: ros-humble-self-test
+dolly:
+    ubuntu: ros-humble-dolly
+dolly_follow:
+    ubuntu: ros-humble-dolly-follow
+dolly_gazebo:
+    ubuntu: ros-humble-dolly-gazebo
+dolly_ignition:
+    ubuntu: ros-humble-dolly-ignition
+domain_bridge:
+    ubuntu: ros-humble-domain-bridge
+dual_laser_merger:
+    ubuntu: ros-humble-dual-laser-merger
+dynamixel_hardware:
+    ubuntu: ros-humble-dynamixel-hardware
+dynamixel_sdk:
+    ubuntu: ros-humble-dynamixel-sdk
+dynamixel_sdk_custom_interfaces:
+    ubuntu: ros-humble-dynamixel-sdk-custom-interfaces
+dynamixel_sdk_examples:
+    ubuntu: ros-humble-dynamixel-sdk-examples
+dynamixel_workbench:
+    ubuntu: ros-humble-dynamixel-workbench
+dynamixel_workbench_toolbox:
+    ubuntu: ros-humble-dynamixel-workbench-toolbox
+dynamixel_workbench_msgs:
+    ubuntu: ros-humble-dynamixel-workbench-msgs
+ecal:
+    ubuntu: ros-humble-ecal
+ecl_command_line:
+    ubuntu: ros-humble-ecl-command-line
+ecl_concepts:
+    ubuntu: ros-humble-ecl-concepts
+ecl_containers:
+    ubuntu: ros-humble-ecl-containers
+ecl_converters:
+    ubuntu: ros-humble-ecl-converters
+ecl_core:
+    ubuntu: ros-humble-ecl-core
+ecl_core_apps:
+    ubuntu: ros-humble-ecl-core-apps
+ecl_devices:
+    ubuntu: ros-humble-ecl-devices
+ecl_eigen:
+    ubuntu: ros-humble-ecl-eigen
+ecl_exceptions:
+    ubuntu: ros-humble-ecl-exceptions
+ecl_filesystem:
+    ubuntu: ros-humble-ecl-filesystem
+ecl_formatters:
+    ubuntu: ros-humble-ecl-formatters
+ecl_geometry:
+    ubuntu: ros-humble-ecl-geometry
+ecl_ipc:
+    ubuntu: ros-humble-ecl-ipc
+ecl_linear_algebra:
+    ubuntu: ros-humble-ecl-linear-algebra
+ecl_manipulators:
+    ubuntu: ros-humble-ecl-manipulators
+ecl_math:
+    ubuntu: ros-humble-ecl-math
+ecl_mobile_robot:
+    ubuntu: ros-humble-ecl-mobile-robot
+ecl_mpl:
+    ubuntu: ros-humble-ecl-mpl
+ecl_sigslots:
+    ubuntu: ros-humble-ecl-sigslots
+ecl_statistics:
+    ubuntu: ros-humble-ecl-statistics
+ecl_streams:
+    ubuntu: ros-humble-ecl-streams
+ecl_threads:
+    ubuntu: ros-humble-ecl-threads
+ecl_time:
+    ubuntu: ros-humble-ecl-time
+ecl_type_traits:
+    ubuntu: ros-humble-ecl-type-traits
+ecl_utilities:
+    ubuntu: ros-humble-ecl-utilities
+ecl_config:
+    ubuntu: ros-humble-ecl-config
+ecl_console:
+    ubuntu: ros-humble-ecl-console
+ecl_converters_lite:
+    ubuntu: ros-humble-ecl-converters-lite
+ecl_errors:
+    ubuntu: ros-humble-ecl-errors
+ecl_io:
+    ubuntu: ros-humble-ecl-io
+ecl_lite:
+    ubuntu: ros-humble-ecl-lite
+ecl_sigslots_lite:
+    ubuntu: ros-humble-ecl-sigslots-lite
+ecl_time_lite:
+    ubuntu: ros-humble-ecl-time-lite
+ecl_build:
+    ubuntu: ros-humble-ecl-build
+ecl_license:
+    ubuntu: ros-humble-ecl-license
+ecl_tools:
+    ubuntu: ros-humble-ecl-tools
+eigen3_cmake_module:
+    ubuntu: ros-humble-eigen3-cmake-module
+eigen_stl_containers:
+    ubuntu: ros-humble-eigen-stl-containers
+eigenpy:
+    ubuntu: ros-humble-eigenpy
+eiquadprog:
+    ubuntu: ros-humble-eiquadprog
+ess_imu_driver2:
+    ubuntu: ros-humble-ess-imu-driver2
+etsi_its_cam_coding:
+    ubuntu: ros-humble-etsi-its-cam-coding
+etsi_its_cam_conversion:
+    ubuntu: ros-humble-etsi-its-cam-conversion
+etsi_its_cam_msgs:
+    ubuntu: ros-humble-etsi-its-cam-msgs
+etsi_its_cam_ts_coding:
+    ubuntu: ros-humble-etsi-its-cam-ts-coding
+etsi_its_cam_ts_conversion:
+    ubuntu: ros-humble-etsi-its-cam-ts-conversion
+etsi_its_cam_ts_msgs:
+    ubuntu: ros-humble-etsi-its-cam-ts-msgs
+etsi_its_coding:
+    ubuntu: ros-humble-etsi-its-coding
+etsi_its_conversion:
+    ubuntu: ros-humble-etsi-its-conversion
+etsi_its_cpm_ts_coding:
+    ubuntu: ros-humble-etsi-its-cpm-ts-coding
+etsi_its_cpm_ts_conversion:
+    ubuntu: ros-humble-etsi-its-cpm-ts-conversion
+etsi_its_cpm_ts_msgs:
+    ubuntu: ros-humble-etsi-its-cpm-ts-msgs
+etsi_its_denm_coding:
+    ubuntu: ros-humble-etsi-its-denm-coding
+etsi_its_denm_conversion:
+    ubuntu: ros-humble-etsi-its-denm-conversion
+etsi_its_denm_msgs:
+    ubuntu: ros-humble-etsi-its-denm-msgs
+etsi_its_mapem_ts_coding:
+    ubuntu: ros-humble-etsi-its-mapem-ts-coding
+etsi_its_mapem_ts_conversion:
+    ubuntu: ros-humble-etsi-its-mapem-ts-conversion
+etsi_its_mapem_ts_msgs:
+    ubuntu: ros-humble-etsi-its-mapem-ts-msgs
+etsi_its_messages:
+    ubuntu: ros-humble-etsi-its-messages
+etsi_its_msgs:
+    ubuntu: ros-humble-etsi-its-msgs
+etsi_its_msgs_utils:
+    ubuntu: ros-humble-etsi-its-msgs-utils
+etsi_its_primitives_conversion:
+    ubuntu: ros-humble-etsi-its-primitives-conversion
+etsi_its_rviz_plugins:
+    ubuntu: ros-humble-etsi-its-rviz-plugins
+etsi_its_spatem_ts_coding:
+    ubuntu: ros-humble-etsi-its-spatem-ts-coding
+etsi_its_spatem_ts_conversion:
+    ubuntu: ros-humble-etsi-its-spatem-ts-conversion
+etsi_its_spatem_ts_msgs:
+    ubuntu: ros-humble-etsi-its-spatem-ts-msgs
+etsi_its_vam_ts_coding:
+    ubuntu: ros-humble-etsi-its-vam-ts-coding
+etsi_its_vam_ts_conversion:
+    ubuntu: ros-humble-etsi-its-vam-ts-conversion
+etsi_its_vam_ts_msgs:
+    ubuntu: ros-humble-etsi-its-vam-ts-msgs
+event_camera_codecs:
+    ubuntu: ros-humble-event-camera-codecs
+event_camera_msgs:
+    ubuntu: ros-humble-event-camera-msgs
+event_camera_py:
+    ubuntu: ros-humble-event-camera-py
+event_camera_renderer:
+    ubuntu: ros-humble-event-camera-renderer
+example_interfaces:
+    ubuntu: ros-humble-example-interfaces
+examples_rclcpp_async_client:
+    ubuntu: ros-humble-examples-rclcpp-async-client
+examples_rclcpp_cbg_executor:
+    ubuntu: ros-humble-examples-rclcpp-cbg-executor
+examples_rclcpp_minimal_action_client:
+    ubuntu: ros-humble-examples-rclcpp-minimal-action-client
+examples_rclcpp_minimal_action_server:
+    ubuntu: ros-humble-examples-rclcpp-minimal-action-server
+examples_rclcpp_minimal_client:
+    ubuntu: ros-humble-examples-rclcpp-minimal-client
+examples_rclcpp_minimal_composition:
+    ubuntu: ros-humble-examples-rclcpp-minimal-composition
+examples_rclcpp_minimal_publisher:
+    ubuntu: ros-humble-examples-rclcpp-minimal-publisher
+examples_rclcpp_minimal_service:
+    ubuntu: ros-humble-examples-rclcpp-minimal-service
+examples_rclcpp_minimal_subscriber:
+    ubuntu: ros-humble-examples-rclcpp-minimal-subscriber
+examples_rclcpp_minimal_timer:
+    ubuntu: ros-humble-examples-rclcpp-minimal-timer
+examples_rclcpp_multithreaded_executor:
+    ubuntu: ros-humble-examples-rclcpp-multithreaded-executor
+examples_rclcpp_wait_set:
+    ubuntu: ros-humble-examples-rclcpp-wait-set
+examples_rclpy_executors:
+    ubuntu: ros-humble-examples-rclpy-executors
+examples_rclpy_guard_conditions:
+    ubuntu: ros-humble-examples-rclpy-guard-conditions
+examples_rclpy_minimal_action_client:
+    ubuntu: ros-humble-examples-rclpy-minimal-action-client
+examples_rclpy_minimal_action_server:
+    ubuntu: ros-humble-examples-rclpy-minimal-action-server
+examples_rclpy_minimal_client:
+    ubuntu: ros-humble-examples-rclpy-minimal-client
+examples_rclpy_minimal_publisher:
+    ubuntu: ros-humble-examples-rclpy-minimal-publisher
+examples_rclpy_minimal_service:
+    ubuntu: ros-humble-examples-rclpy-minimal-service
+examples_rclpy_minimal_subscriber:
+    ubuntu: ros-humble-examples-rclpy-minimal-subscriber
+examples_rclpy_pointcloud_publisher:
+    ubuntu: ros-humble-examples-rclpy-pointcloud-publisher
+launch_testing_examples:
+    ubuntu: ros-humble-launch-testing-examples
+extrinsic_calibrator:
+    ubuntu: ros-humble-extrinsic-calibrator
+fadecandy_driver:
+    ubuntu: ros-humble-fadecandy-driver
+fadecandy_msgs:
+    ubuntu: ros-humble-fadecandy-msgs
+fast_gicp:
+    ubuntu: ros-humble-fast-gicp
+fastcdr:
+    ubuntu: ros-humble-fastcdr
+fastrtps:
+    ubuntu: ros-humble-fastrtps
+feetech_ros2_driver:
+    ubuntu: ros-humble-feetech-ros2-driver
+ffmpeg_encoder_decoder:
+    ubuntu: ros-humble-ffmpeg-encoder-decoder
+ffmpeg_image_transport:
+    ubuntu: ros-humble-ffmpeg-image-transport
+ffmpeg_image_transport_msgs:
+    ubuntu: ros-humble-ffmpeg-image-transport-msgs
+ffmpeg_image_transport_tools:
+    ubuntu: ros-humble-ffmpeg-image-transport-tools
+fields2cover:
+    ubuntu: ros-humble-fields2cover
+filters:
+    ubuntu: ros-humble-filters
+find_object_2d:
+    ubuntu: ros-humble-find-object-2d
+flex_sync:
+    ubuntu: ros-humble-flex-sync
+flexbe_app:
+    ubuntu: ros-humble-flexbe-app
+flexbe_behavior_engine:
+    ubuntu: ros-humble-flexbe-behavior-engine
+flexbe_core:
+    ubuntu: ros-humble-flexbe-core
+flexbe_input:
+    ubuntu: ros-humble-flexbe-input
+flexbe_mirror:
+    ubuntu: ros-humble-flexbe-mirror
+flexbe_msgs:
+    ubuntu: ros-humble-flexbe-msgs
+flexbe_onboard:
+    ubuntu: ros-humble-flexbe-onboard
+flexbe_states:
+    ubuntu: ros-humble-flexbe-states
+flexbe_testing:
+    ubuntu: ros-humble-flexbe-testing
+flexbe_widget:
+    ubuntu: ros-humble-flexbe-widget
+flir_camera_description:
+    ubuntu: ros-humble-flir-camera-description
+flir_camera_msgs:
+    ubuntu: ros-humble-flir-camera-msgs
+spinnaker_camera_driver:
+    ubuntu: ros-humble-spinnaker-camera-driver
+spinnaker_synchronized_camera_driver:
+    ubuntu: ros-humble-spinnaker-synchronized-camera-driver
+fluent_bit_vendor:
+    ubuntu: ros-humble-fluent-bit-vendor
+fluent_rviz:
+    ubuntu: ros-humble-fluent-rviz
+fmi_adapter:
+    ubuntu: ros-humble-fmi-adapter
+fmi_adapter_examples:
+    ubuntu: ros-humble-fmi-adapter-examples
+fmilibrary_vendor:
+    ubuntu: ros-humble-fmilibrary-vendor
+fogros2:
+    ubuntu: ros-humble-fogros2
+fogros2_examples:
+    ubuntu: ros-humble-fogros2-examples
+foonathan_memory_vendor:
+    ubuntu: ros-humble-foonathan-memory-vendor
+foros:
+    ubuntu: ros-humble-foros
+foros_examples:
+    ubuntu: ros-humble-foros-examples
+foros_inspector:
+    ubuntu: ros-humble-foros-inspector
+foros_msgs:
+    ubuntu: ros-humble-foros-msgs
+four_wheel_steering_msgs:
+    ubuntu: ros-humble-four-wheel-steering-msgs
+foxglove_bridge:
+    ubuntu: ros-humble-foxglove-bridge
+foxglove_compressed_video_transport:
+    ubuntu: ros-humble-foxglove-compressed-video-transport
+foxglove_msgs:
+    ubuntu: ros-humble-foxglove-msgs
+franka_description:
+    ubuntu: ros-humble-franka-description
+franka_ros2:
+    ubuntu: ros-humble-franka-ros2
+game_controller_spl:
+    ubuntu: ros-humble-game-controller-spl
+game_controller_spl_interfaces:
+    ubuntu: ros-humble-game-controller-spl-interfaces
+gc_spl:
+    ubuntu: ros-humble-gc-spl
+gc_spl_2022:
+    ubuntu: ros-humble-gc-spl-2022
+gc_spl_interfaces:
+    ubuntu: ros-humble-gc-spl-interfaces
+rcgcd_spl_14:
+    ubuntu: ros-humble-rcgcd-spl-14
+rcgcd_spl_14_conversion:
+    ubuntu: ros-humble-rcgcd-spl-14-conversion
+rcgcrd_spl_4:
+    ubuntu: ros-humble-rcgcrd-spl-4
+rcgcrd_spl_4_conversion:
+    ubuntu: ros-humble-rcgcrd-spl-4-conversion
+gazebo_model_attachment_plugin:
+    ubuntu: ros-humble-gazebo-model-attachment-plugin
+gazebo_model_attachment_plugin_msgs:
+    ubuntu: ros-humble-gazebo-model-attachment-plugin-msgs
+gazebo_no_physics_plugin:
+    ubuntu: ros-humble-gazebo-no-physics-plugin
+gazebo_planar_move_plugin:
+    ubuntu: ros-humble-gazebo-planar-move-plugin
+gazebo_ros2_control:
+    ubuntu: ros-humble-gazebo-ros2-control
+gazebo_ros2_control_demos:
+    ubuntu: ros-humble-gazebo-ros2-control-demos
+gazebo_dev:
+    ubuntu: ros-humble-gazebo-dev
+gazebo_msgs:
+    ubuntu: ros-humble-gazebo-msgs
+gazebo_plugins:
+    ubuntu: ros-humble-gazebo-plugins
+gazebo_ros:
+    ubuntu: ros-humble-gazebo-ros
+gazebo_ros_pkgs:
+    ubuntu: ros-humble-gazebo-ros-pkgs
+gazebo_set_joint_positions_plugin:
+    ubuntu: ros-humble-gazebo-set-joint-positions-plugin
+gazebo_video_monitor_interfaces:
+    ubuntu: ros-humble-gazebo-video-monitor-interfaces
+gazebo_video_monitor_plugins:
+    ubuntu: ros-humble-gazebo-video-monitor-plugins
+gazebo_video_monitor_utils:
+    ubuntu: ros-humble-gazebo-video-monitor-utils
+gazebo_video_monitors:
+    ubuntu: ros-humble-gazebo-video-monitors
+cmake_generate_parameter_module_example:
+    ubuntu: ros-humble-cmake-generate-parameter-module-example
+generate_parameter_library:
+    ubuntu: ros-humble-generate-parameter-library
+generate_parameter_library_example:
+    ubuntu: ros-humble-generate-parameter-library-example
+generate_parameter_library_py:
+    ubuntu: ros-humble-generate-parameter-library-py
+generate_parameter_module_example:
+    ubuntu: ros-humble-generate-parameter-module-example
+parameter_traits:
+    ubuntu: ros-humble-parameter-traits
+geodesy:
+    ubuntu: ros-humble-geodesy
+geographic_info:
+    ubuntu: ros-humble-geographic-info
+geographic_msgs:
+    ubuntu: ros-humble-geographic-msgs
+geometric_shapes:
+    ubuntu: ros-humble-geometric-shapes
+examples_tf2_py:
+    ubuntu: ros-humble-examples-tf2-py
+geometry2:
+    ubuntu: ros-humble-geometry2
+tf2:
+    ubuntu: ros-humble-tf2
+tf2_bullet:
+    ubuntu: ros-humble-tf2-bullet
+tf2_eigen:
+    ubuntu: ros-humble-tf2-eigen
+tf2_eigen_kdl:
+    ubuntu: ros-humble-tf2-eigen-kdl
+tf2_geometry_msgs:
+    ubuntu: ros-humble-tf2-geometry-msgs
+tf2_kdl:
+    ubuntu: ros-humble-tf2-kdl
+tf2_msgs:
+    ubuntu: ros-humble-tf2-msgs
+tf2_py:
+    ubuntu: ros-humble-tf2-py
+tf2_ros:
+    ubuntu: ros-humble-tf2-ros
+tf2_ros_py:
+    ubuntu: ros-humble-tf2-ros-py
+tf2_sensor_msgs:
+    ubuntu: ros-humble-tf2-sensor-msgs
+tf2_tools:
+    ubuntu: ros-humble-tf2-tools
+geometry_tutorials:
+    ubuntu: ros-humble-geometry-tutorials
+turtle_tf2_cpp:
+    ubuntu: ros-humble-turtle-tf2-cpp
+turtle_tf2_py:
+    ubuntu: ros-humble-turtle-tf2-py
+google_benchmark_vendor:
+    ubuntu: ros-humble-google-benchmark-vendor
+gmock_vendor:
+    ubuntu: ros-humble-gmock-vendor
+gtest_vendor:
+    ubuntu: ros-humble-gtest-vendor
+gps_msgs:
+    ubuntu: ros-humble-gps-msgs
+gps_tools:
+    ubuntu: ros-humble-gps-tools
+gps_umd:
+    ubuntu: ros-humble-gps-umd
+gpsd_client:
+    ubuntu: ros-humble-gpsd-client
+graph_msgs:
+    ubuntu: ros-humble-graph-msgs
+grasping_msgs:
+    ubuntu: ros-humble-grasping-msgs
+grbl_msgs:
+    ubuntu: ros-humble-grbl-msgs
+grbl_ros:
+    ubuntu: ros-humble-grbl-ros
+grid_map:
+    ubuntu: ros-humble-grid-map
+grid_map_cmake_helpers:
+    ubuntu: ros-humble-grid-map-cmake-helpers
+grid_map_core:
+    ubuntu: ros-humble-grid-map-core
+grid_map_costmap_2d:
+    ubuntu: ros-humble-grid-map-costmap-2d
+grid_map_cv:
+    ubuntu: ros-humble-grid-map-cv
+grid_map_demos:
+    ubuntu: ros-humble-grid-map-demos
+grid_map_filters:
+    ubuntu: ros-humble-grid-map-filters
+grid_map_loader:
+    ubuntu: ros-humble-grid-map-loader
+grid_map_msgs:
+    ubuntu: ros-humble-grid-map-msgs
+grid_map_octomap:
+    ubuntu: ros-humble-grid-map-octomap
+grid_map_pcl:
+    ubuntu: ros-humble-grid-map-pcl
+grid_map_ros:
+    ubuntu: ros-humble-grid-map-ros
+grid_map_rviz_plugin:
+    ubuntu: ros-humble-grid-map-rviz-plugin
+grid_map_sdf:
+    ubuntu: ros-humble-grid-map-sdf
+grid_map_visualization:
+    ubuntu: ros-humble-grid-map-visualization
+grid_map_geo:
+    ubuntu: ros-humble-grid-map-geo
+gscam:
+    ubuntu: ros-humble-gscam
+gtsam:
+    ubuntu: ros-humble-gtsam
+hash_library_vendor:
+    ubuntu: ros-humble-hash-library-vendor
+hatchbed_common:
+    ubuntu: ros-humble-hatchbed-common
+heaphook:
+    ubuntu: ros-humble-heaphook
+hebi_cpp_api:
+    ubuntu: ros-humble-hebi-cpp-api
+hey5_description:
+    ubuntu: ros-humble-hey5-description
+hls_lfcd_lds_driver:
+    ubuntu: ros-humble-hls-lfcd-lds-driver
+homing_local_planner:
+    ubuntu: ros-humble-homing-local-planner
+hpp-fcl:
+    ubuntu: ros-humble-hpp-fcl
+hri:
+    ubuntu: ros-humble-hri
+pyhri:
+    ubuntu: ros-humble-pyhri
+hri_actions_msgs:
+    ubuntu: ros-humble-hri-actions-msgs
+hri_face_body_matcher:
+    ubuntu: ros-humble-hri-face-body-matcher
+hri_face_detect:
+    ubuntu: ros-humble-hri-face-detect
+hri_msgs:
+    ubuntu: ros-humble-hri-msgs
+hri_privacy_msgs:
+    ubuntu: ros-humble-hri-privacy-msgs
+hri_rviz:
+    ubuntu: ros-humble-hri-rviz
+human_description:
+    ubuntu: ros-humble-human-description
+iceoryx_binding_c:
+    ubuntu: ros-humble-iceoryx-binding-c
+iceoryx_hoofs:
+    ubuntu: ros-humble-iceoryx-hoofs
+iceoryx_introspection:
+    ubuntu: ros-humble-iceoryx-introspection
+iceoryx_posh:
+    ubuntu: ros-humble-iceoryx-posh
+ifm3d_core:
+    ubuntu: ros-humble-ifm3d-core
+gz_ros2_control_tests:
+    ubuntu: ros-humble-gz-ros2-control-tests
+ign_ros2_control:
+    ubuntu: ros-humble-ign-ros2-control
+ign_ros2_control_demos:
+    ubuntu: ros-humble-ign-ros2-control-demos
+ign_rviz:
+    ubuntu: ros-humble-ign-rviz
+ign_rviz_common:
+    ubuntu: ros-humble-ign-rviz-common
+ign_rviz_plugins:
+    ubuntu: ros-humble-ign-rviz-plugins
+ignition_cmake2_vendor:
+    ubuntu: ros-humble-ignition-cmake2-vendor
+ignition_math6_vendor:
+    ubuntu: ros-humble-ignition-math6-vendor
+camera_calibration_parsers:
+    ubuntu: ros-humble-camera-calibration-parsers
+camera_info_manager:
+    ubuntu: ros-humble-camera-info-manager
+camera_info_manager_py:
+    ubuntu: ros-humble-camera-info-manager-py
+image_common:
+    ubuntu: ros-humble-image-common
+image_transport:
+    ubuntu: ros-humble-image-transport
+camera_calibration:
+    ubuntu: ros-humble-camera-calibration
+depth_image_proc:
+    ubuntu: ros-humble-depth-image-proc
+image_pipeline:
+    ubuntu: ros-humble-image-pipeline
+image_proc:
+    ubuntu: ros-humble-image-proc
+image_publisher:
+    ubuntu: ros-humble-image-publisher
+image_rotate:
+    ubuntu: ros-humble-image-rotate
+image_view:
+    ubuntu: ros-humble-image-view
+stereo_image_proc:
+    ubuntu: ros-humble-stereo-image-proc
+tracetools_image_pipeline:
+    ubuntu: ros-humble-tracetools-image-pipeline
+compressed_depth_image_transport:
+    ubuntu: ros-humble-compressed-depth-image-transport
+compressed_image_transport:
+    ubuntu: ros-humble-compressed-image-transport
+image_transport_plugins:
+    ubuntu: ros-humble-image-transport-plugins
+theora_image_transport:
+    ubuntu: ros-humble-theora-image-transport
+imu_pipeline:
+    ubuntu: ros-humble-imu-pipeline
+imu_processors:
+    ubuntu: ros-humble-imu-processors
+imu_transformer:
+    ubuntu: ros-humble-imu-transformer
+imu_complementary_filter:
+    ubuntu: ros-humble-imu-complementary-filter
+imu_filter_madgwick:
+    ubuntu: ros-humble-imu-filter-madgwick
+imu_tools:
+    ubuntu: ros-humble-imu-tools
+rviz_imu_plugin:
+    ubuntu: ros-humble-rviz-imu-plugin
+interactive_marker_twist_server:
+    ubuntu: ros-humble-interactive-marker-twist-server
+interactive_markers:
+    ubuntu: ros-humble-interactive-markers
+irobot_create_msgs:
+    ubuntu: ros-humble-irobot-create-msgs
+jacro:
+    ubuntu: ros-humble-jacro
+joint_state_publisher:
+    ubuntu: ros-humble-joint-state-publisher
+joint_state_publisher_gui:
+    ubuntu: ros-humble-joint-state-publisher-gui
+joy_tester:
+    ubuntu: ros-humble-joy-tester
+joy:
+    ubuntu: ros-humble-joy
+joy_linux:
+    ubuntu: ros-humble-joy-linux
+sdl2_vendor:
+    ubuntu: ros-humble-sdl2-vendor
+spacenav:
+    ubuntu: ros-humble-spacenav
+wiimote:
+    ubuntu: ros-humble-wiimote
+wiimote_msgs:
+    ubuntu: ros-humble-wiimote-msgs
+kdl_parser:
+    ubuntu: ros-humble-kdl-parser
+keyboard_handler:
+    ubuntu: ros-humble-keyboard-handler
+kinematics_interface:
+    ubuntu: ros-humble-kinematics-interface
+kinematics_interface_kdl:
+    ubuntu: ros-humble-kinematics-interface-kdl
+kinematics_interface_pinocchio:
+    ubuntu: ros-humble-kinematics-interface-pinocchio
+kobuki_core:
+    ubuntu: ros-humble-kobuki-core
+kobuki_ros_interfaces:
+    ubuntu: ros-humble-kobuki-ros-interfaces
+kobuki_velocity_smoother:
+    ubuntu: ros-humble-kobuki-velocity-smoother
+kompass:
+    ubuntu: ros-humble-kompass
+fri_configuration_controller:
+    ubuntu: ros-humble-fri-configuration-controller
+fri_state_broadcaster:
+    ubuntu: ros-humble-fri-state-broadcaster
+iiqka_moveit_example:
+    ubuntu: ros-humble-iiqka-moveit-example
+joint_group_impedance_controller:
+    ubuntu: ros-humble-joint-group-impedance-controller
+kuka_control_mode_handler:
+    ubuntu: ros-humble-kuka-control-mode-handler
+kuka_controllers:
+    ubuntu: ros-humble-kuka-controllers
+kuka_driver_interfaces:
+    ubuntu: ros-humble-kuka-driver-interfaces
+kuka_drivers:
+    ubuntu: ros-humble-kuka-drivers
+kuka_drivers_core:
+    ubuntu: ros-humble-kuka-drivers-core
+kuka_event_broadcaster:
+    ubuntu: ros-humble-kuka-event-broadcaster
+kuka_iiqka_eac_driver:
+    ubuntu: ros-humble-kuka-iiqka-eac-driver
+kuka_kss_rsi_driver:
+    ubuntu: ros-humble-kuka-kss-rsi-driver
+kuka_rsi_simulator:
+    ubuntu: ros-humble-kuka-rsi-simulator
+kuka_sunrise_fri_driver:
+    ubuntu: ros-humble-kuka-sunrise-fri-driver
+kuka_external_control_sdk:
+    ubuntu: ros-humble-kuka-external-control-sdk
+kuka_external_control_sdk_examples:
+    ubuntu: ros-humble-kuka-external-control-sdk-examples
+kuka_agilus_support:
+    ubuntu: ros-humble-kuka-agilus-support
+kuka_cybertech_support:
+    ubuntu: ros-humble-kuka-cybertech-support
+kuka_fortec_support:
+    ubuntu: ros-humble-kuka-fortec-support
+kuka_iontec_support:
+    ubuntu: ros-humble-kuka-iontec-support
+kuka_kr_moveit_config:
+    ubuntu: ros-humble-kuka-kr-moveit-config
+kuka_lbr_iisy_moveit_config:
+    ubuntu: ros-humble-kuka-lbr-iisy-moveit-config
+kuka_lbr_iisy_support:
+    ubuntu: ros-humble-kuka-lbr-iisy-support
+kuka_lbr_iiwa_moveit_config:
+    ubuntu: ros-humble-kuka-lbr-iiwa-moveit-config
+kuka_lbr_iiwa_support:
+    ubuntu: ros-humble-kuka-lbr-iiwa-support
+kuka_mock_hardware_interface:
+    ubuntu: ros-humble-kuka-mock-hardware-interface
+kuka_quantec_support:
+    ubuntu: ros-humble-kuka-quantec-support
+kuka_resources:
+    ubuntu: ros-humble-kuka-resources
+kuka_robot_descriptions:
+    ubuntu: ros-humble-kuka-robot-descriptions
+lanelet2:
+    ubuntu: ros-humble-lanelet2
+lanelet2_core:
+    ubuntu: ros-humble-lanelet2-core
+lanelet2_examples:
+    ubuntu: ros-humble-lanelet2-examples
+lanelet2_io:
+    ubuntu: ros-humble-lanelet2-io
+lanelet2_maps:
+    ubuntu: ros-humble-lanelet2-maps
+lanelet2_matching:
+    ubuntu: ros-humble-lanelet2-matching
+lanelet2_projection:
+    ubuntu: ros-humble-lanelet2-projection
+lanelet2_python:
+    ubuntu: ros-humble-lanelet2-python
+lanelet2_routing:
+    ubuntu: ros-humble-lanelet2-routing
+lanelet2_traffic_rules:
+    ubuntu: ros-humble-lanelet2-traffic-rules
+lanelet2_validation:
+    ubuntu: ros-humble-lanelet2-validation
+laser_filters:
+    ubuntu: ros-humble-laser-filters
+laser_geometry:
+    ubuntu: ros-humble-laser-geometry
+laser_proc:
+    ubuntu: ros-humble-laser-proc
+laser_segmentation:
+    ubuntu: ros-humble-laser-segmentation
+launch:
+    ubuntu: ros-humble-launch
+launch_pytest:
+    ubuntu: ros-humble-launch-pytest
+launch_testing:
+    ubuntu: ros-humble-launch-testing
+launch_testing_ament_cmake:
+    ubuntu: ros-humble-launch-testing-ament-cmake
+launch_xml:
+    ubuntu: ros-humble-launch-xml
+launch_yaml:
+    ubuntu: ros-humble-launch-yaml
+launch_pal:
+    ubuntu: ros-humble-launch-pal
+launch_param_builder:
+    ubuntu: ros-humble-launch-param-builder
+launch_ros:
+    ubuntu: ros-humble-launch-ros
+launch_testing_ros:
+    ubuntu: ros-humble-launch-testing-ros
+ros2launch:
+    ubuntu: ros-humble-ros2launch
+leo:
+    ubuntu: ros-humble-leo
+leo_description:
+    ubuntu: ros-humble-leo-description
+leo_msgs:
+    ubuntu: ros-humble-leo-msgs
+leo_teleop:
+    ubuntu: ros-humble-leo-teleop
+leo_desktop:
+    ubuntu: ros-humble-leo-desktop
+leo_viz:
+    ubuntu: ros-humble-leo-viz
+leo_bringup:
+    ubuntu: ros-humble-leo-bringup
+leo_fw:
+    ubuntu: ros-humble-leo-fw
+leo_robot:
+    ubuntu: ros-humble-leo-robot
+leo_gz_bringup:
+    ubuntu: ros-humble-leo-gz-bringup
+leo_gz_plugins:
+    ubuntu: ros-humble-leo-gz-plugins
+leo_gz_worlds:
+    ubuntu: ros-humble-leo-gz-worlds
+leo_simulator:
+    ubuntu: ros-humble-leo-simulator
+lgsvl_msgs:
+    ubuntu: ros-humble-lgsvl-msgs
+libcaer:
+    ubuntu: ros-humble-libcaer
+libcaer_driver:
+    ubuntu: ros-humble-libcaer-driver
+libcaer_vendor:
+    ubuntu: ros-humble-libcaer-vendor
+libcamera:
+    ubuntu: ros-humble-libcamera
+libcreate:
+    ubuntu: ros-humble-libcreate
+libfranka:
+    ubuntu: ros-humble-libfranka
+libg2o:
+    ubuntu: ros-humble-libg2o
+libnabo:
+    ubuntu: ros-humble-libnabo
+libpointmatcher:
+    ubuntu: ros-humble-libpointmatcher
+librealsense2:
+    ubuntu: ros-humble-librealsense2
+libstatistics_collector:
+    ubuntu: ros-humble-libstatistics-collector
+libyaml_vendor:
+    ubuntu: ros-humble-libyaml-vendor
+lidar_situational_graphs:
+    ubuntu: ros-humble-lidar-situational-graphs
+lms1xx:
+    ubuntu: ros-humble-lms1xx
+bosch_locator_bridge:
+    ubuntu: ros-humble-bosch-locator-bridge
+bosch_locator_bridge_utils:
+    ubuntu: ros-humble-bosch-locator-bridge-utils
+log_view:
+    ubuntu: ros-humble-log-view
+lsc_ros2_driver:
+    ubuntu: ros-humble-lsc-ros2-driver
+lusb:
+    ubuntu: ros-humble-lusb
+magic_enum:
+    ubuntu: ros-humble-magic-enum
+mapviz:
+    ubuntu: ros-humble-mapviz
+mapviz_interfaces:
+    ubuntu: ros-humble-mapviz-interfaces
+mapviz_plugins:
+    ubuntu: ros-humble-mapviz-plugins
+multires_image:
+    ubuntu: ros-humble-multires-image
+tile_map:
+    ubuntu: ros-humble-tile-map
+marine_acoustic_msgs:
+    ubuntu: ros-humble-marine-acoustic-msgs
+marine_sensor_msgs:
+    ubuntu: ros-humble-marine-sensor-msgs
+marker_msgs:
+    ubuntu: ros-humble-marker-msgs
+swri_cli_tools:
+    ubuntu: ros-humble-swri-cli-tools
+swri_console_util:
+    ubuntu: ros-humble-swri-console-util
+swri_dbw_interface:
+    ubuntu: ros-humble-swri-dbw-interface
+swri_geometry_util:
+    ubuntu: ros-humble-swri-geometry-util
+swri_image_util:
+    ubuntu: ros-humble-swri-image-util
+swri_math_util:
+    ubuntu: ros-humble-swri-math-util
+swri_opencv_util:
+    ubuntu: ros-humble-swri-opencv-util
+swri_roscpp:
+    ubuntu: ros-humble-swri-roscpp
+swri_route_util:
+    ubuntu: ros-humble-swri-route-util
+swri_serial_util:
+    ubuntu: ros-humble-swri-serial-util
+swri_system_util:
+    ubuntu: ros-humble-swri-system-util
+swri_transform_util:
+    ubuntu: ros-humble-swri-transform-util
+marti_can_msgs:
+    ubuntu: ros-humble-marti-can-msgs
+marti_common_msgs:
+    ubuntu: ros-humble-marti-common-msgs
+marti_dbw_msgs:
+    ubuntu: ros-humble-marti-dbw-msgs
+marti_introspection_msgs:
+    ubuntu: ros-humble-marti-introspection-msgs
+marti_nav_msgs:
+    ubuntu: ros-humble-marti-nav-msgs
+marti_perception_msgs:
+    ubuntu: ros-humble-marti-perception-msgs
+marti_sensor_msgs:
+    ubuntu: ros-humble-marti-sensor-msgs
+marti_status_msgs:
+    ubuntu: ros-humble-marti-status-msgs
+marti_visualization_msgs:
+    ubuntu: ros-humble-marti-visualization-msgs
+marvelmind_ros2_msgs:
+    ubuntu: ros-humble-marvelmind-ros2-msgs
+marvelmind_ros2:
+    ubuntu: ros-humble-marvelmind-ros2
+mavlink:
+    ubuntu: ros-humble-mavlink
+libmavconn:
+    ubuntu: ros-humble-libmavconn
+mavros:
+    ubuntu: ros-humble-mavros
+mavros_extras:
+    ubuntu: ros-humble-mavros-extras
+mavros_msgs:
+    ubuntu: ros-humble-mavros-msgs
+menge_vendor:
+    ubuntu: ros-humble-menge-vendor
+message_filters:
+    ubuntu: ros-humble-message-filters
+message_tf_frame_transformer:
+    ubuntu: ros-humble-message-tf-frame-transformer
+metavision_driver:
+    ubuntu: ros-humble-metavision-driver
+collision_log_msgs:
+    ubuntu: ros-humble-collision-log-msgs
+metro_benchmark_msgs:
+    ubuntu: ros-humble-metro-benchmark-msgs
+metro_benchmark_pub:
+    ubuntu: ros-humble-metro-benchmark-pub
+metro_gazebo_plugins:
+    ubuntu: ros-humble-metro-gazebo-plugins
+base2d_kinematics:
+    ubuntu: ros-humble-base2d-kinematics
+base2d_kinematics_msgs:
+    ubuntu: ros-humble-base2d-kinematics-msgs
+micro_ros_diagnostic_bridge:
+    ubuntu: ros-humble-micro-ros-diagnostic-bridge
+micro_ros_diagnostic_msgs:
+    ubuntu: ros-humble-micro-ros-diagnostic-msgs
+micro_ros_msgs:
+    ubuntu: ros-humble-micro-ros-msgs
+microstrain_inertial_description:
+    ubuntu: ros-humble-microstrain-inertial-description
+microstrain_inertial_driver:
+    ubuntu: ros-humble-microstrain-inertial-driver
+microstrain_inertial_examples:
+    ubuntu: ros-humble-microstrain-inertial-examples
+microstrain_inertial_msgs:
+    ubuntu: ros-humble-microstrain-inertial-msgs
+microstrain_inertial_rqt:
+    ubuntu: ros-humble-microstrain-inertial-rqt
+mimick_vendor:
+    ubuntu: ros-humble-mimick-vendor
+mir_robot:
+    ubuntu: ros-humble-mir-robot
+mocap4r2_control:
+    ubuntu: ros-humble-mocap4r2-control
+mocap4r2_control_msgs:
+    ubuntu: ros-humble-mocap4r2-control-msgs
+mocap4r2_dummy_driver:
+    ubuntu: ros-humble-mocap4r2-dummy-driver
+mocap4r2_marker_publisher:
+    ubuntu: ros-humble-mocap4r2-marker-publisher
+mocap4r2_marker_viz:
+    ubuntu: ros-humble-mocap4r2-marker-viz
+mocap4r2_marker_viz_srvs:
+    ubuntu: ros-humble-mocap4r2-marker-viz-srvs
+mocap4r2_robot_gt:
+    ubuntu: ros-humble-mocap4r2-robot-gt
+mocap4r2_robot_gt_msgs:
+    ubuntu: ros-humble-mocap4r2-robot-gt-msgs
+rqt_mocap4r2_control:
+    ubuntu: ros-humble-rqt-mocap4r2-control
+mocap4r2_msgs:
+    ubuntu: ros-humble-mocap4r2-msgs
+mocap_optitrack:
+    ubuntu: ros-humble-mocap-optitrack
+mod:
+    ubuntu: ros-humble-mod
+kitti_metrics_eval:
+    ubuntu: ros-humble-kitti-metrics-eval
+mola:
+    ubuntu: ros-humble-mola
+mola_bridge_ros2:
+    ubuntu: ros-humble-mola-bridge-ros2
+mola_demos:
+    ubuntu: ros-humble-mola-demos
+mola_input_euroc_dataset:
+    ubuntu: ros-humble-mola-input-euroc-dataset
+mola_input_kitti360_dataset:
+    ubuntu: ros-humble-mola-input-kitti360-dataset
+mola_input_kitti_dataset:
+    ubuntu: ros-humble-mola-input-kitti-dataset
+mola_input_mulran_dataset:
+    ubuntu: ros-humble-mola-input-mulran-dataset
+mola_input_paris_luco_dataset:
+    ubuntu: ros-humble-mola-input-paris-luco-dataset
+mola_input_rawlog:
+    ubuntu: ros-humble-mola-input-rawlog
+mola_input_rosbag2:
+    ubuntu: ros-humble-mola-input-rosbag2
+mola_kernel:
+    ubuntu: ros-humble-mola-kernel
+mola_launcher:
+    ubuntu: ros-humble-mola-launcher
+mola_metric_maps:
+    ubuntu: ros-humble-mola-metric-maps
+mola_msgs:
+    ubuntu: ros-humble-mola-msgs
+mola_pose_list:
+    ubuntu: ros-humble-mola-pose-list
+mola_relocalization:
+    ubuntu: ros-humble-mola-relocalization
+mola_traj_tools:
+    ubuntu: ros-humble-mola-traj-tools
+mola_viz:
+    ubuntu: ros-humble-mola-viz
+mola_yaml:
+    ubuntu: ros-humble-mola-yaml
+mola_common:
+    ubuntu: ros-humble-mola-common
+mola_lidar_odometry:
+    ubuntu: ros-humble-mola-lidar-odometry
+mola_imu_preintegration:
+    ubuntu: ros-humble-mola-imu-preintegration
+mola_state_estimation:
+    ubuntu: ros-humble-mola-state-estimation
+mola_state_estimation_simple:
+    ubuntu: ros-humble-mola-state-estimation-simple
+mola_state_estimation_smoother:
+    ubuntu: ros-humble-mola-state-estimation-smoother
+mola_test_datasets:
+    ubuntu: ros-humble-mola-test-datasets
+motion_capture_tracking:
+    ubuntu: ros-humble-motion-capture-tracking
+motion_capture_tracking_interfaces:
+    ubuntu: ros-humble-motion-capture-tracking-interfaces
+chomp_motion_planner:
+    ubuntu: ros-humble-chomp-motion-planner
+moveit:
+    ubuntu: ros-humble-moveit
+moveit_chomp_optimizer_adapter:
+    ubuntu: ros-humble-moveit-chomp-optimizer-adapter
+moveit_common:
+    ubuntu: ros-humble-moveit-common
+moveit_configs_utils:
+    ubuntu: ros-humble-moveit-configs-utils
+moveit_core:
+    ubuntu: ros-humble-moveit-core
+moveit_hybrid_planning:
+    ubuntu: ros-humble-moveit-hybrid-planning
+moveit_kinematics:
+    ubuntu: ros-humble-moveit-kinematics
+moveit_planners:
+    ubuntu: ros-humble-moveit-planners
+moveit_planners_chomp:
+    ubuntu: ros-humble-moveit-planners-chomp
+moveit_planners_ompl:
+    ubuntu: ros-humble-moveit-planners-ompl
+moveit_plugins:
+    ubuntu: ros-humble-moveit-plugins
+moveit_resources_prbt_ikfast_manipulator_plugin:
+    ubuntu: ros-humble-moveit-resources-prbt-ikfast-manipulator-plugin
+moveit_resources_prbt_moveit_config:
+    ubuntu: ros-humble-moveit-resources-prbt-moveit-config
+moveit_resources_prbt_pg70_support:
+    ubuntu: ros-humble-moveit-resources-prbt-pg70-support
+moveit_resources_prbt_support:
+    ubuntu: ros-humble-moveit-resources-prbt-support
+moveit_ros:
+    ubuntu: ros-humble-moveit-ros
+moveit_ros_benchmarks:
+    ubuntu: ros-humble-moveit-ros-benchmarks
+moveit_ros_control_interface:
+    ubuntu: ros-humble-moveit-ros-control-interface
+moveit_ros_move_group:
+    ubuntu: ros-humble-moveit-ros-move-group
+moveit_ros_occupancy_map_monitor:
+    ubuntu: ros-humble-moveit-ros-occupancy-map-monitor
+moveit_ros_perception:
+    ubuntu: ros-humble-moveit-ros-perception
+moveit_ros_planning:
+    ubuntu: ros-humble-moveit-ros-planning
+moveit_ros_planning_interface:
+    ubuntu: ros-humble-moveit-ros-planning-interface
+moveit_ros_robot_interaction:
+    ubuntu: ros-humble-moveit-ros-robot-interaction
+moveit_ros_visualization:
+    ubuntu: ros-humble-moveit-ros-visualization
+moveit_ros_warehouse:
+    ubuntu: ros-humble-moveit-ros-warehouse
+moveit_runtime:
+    ubuntu: ros-humble-moveit-runtime
+moveit_servo:
+    ubuntu: ros-humble-moveit-servo
+moveit_setup_app_plugins:
+    ubuntu: ros-humble-moveit-setup-app-plugins
+moveit_setup_assistant:
+    ubuntu: ros-humble-moveit-setup-assistant
+moveit_setup_controllers:
+    ubuntu: ros-humble-moveit-setup-controllers
+moveit_setup_core_plugins:
+    ubuntu: ros-humble-moveit-setup-core-plugins
+moveit_setup_framework:
+    ubuntu: ros-humble-moveit-setup-framework
+moveit_setup_srdf_plugins:
+    ubuntu: ros-humble-moveit-setup-srdf-plugins
+moveit_simple_controller_manager:
+    ubuntu: ros-humble-moveit-simple-controller-manager
+pilz_industrial_motion_planner:
+    ubuntu: ros-humble-pilz-industrial-motion-planner
+pilz_industrial_motion_planner_testutils:
+    ubuntu: ros-humble-pilz-industrial-motion-planner-testutils
+moveit_msgs:
+    ubuntu: ros-humble-moveit-msgs
+moveit_resources:
+    ubuntu: ros-humble-moveit-resources
+moveit_resources_fanuc_description:
+    ubuntu: ros-humble-moveit-resources-fanuc-description
+moveit_resources_fanuc_moveit_config:
+    ubuntu: ros-humble-moveit-resources-fanuc-moveit-config
+moveit_resources_panda_description:
+    ubuntu: ros-humble-moveit-resources-panda-description
+moveit_resources_panda_moveit_config:
+    ubuntu: ros-humble-moveit-resources-panda-moveit-config
+moveit_resources_pr2_description:
+    ubuntu: ros-humble-moveit-resources-pr2-description
+moveit_visual_tools:
+    ubuntu: ros-humble-moveit-visual-tools
+mp2p_icp:
+    ubuntu: ros-humble-mp2p-icp
+mqtt_client:
+    ubuntu: ros-humble-mqtt-client
+mqtt_client_interfaces:
+    ubuntu: ros-humble-mqtt-client-interfaces
+mrpt_msgs:
+    ubuntu: ros-humble-mrpt-msgs
+mrpt_map_server:
+    ubuntu: ros-humble-mrpt-map-server
+mrpt_msgs_bridge:
+    ubuntu: ros-humble-mrpt-msgs-bridge
+mrpt_nav_interfaces:
+    ubuntu: ros-humble-mrpt-nav-interfaces
+mrpt_navigation:
+    ubuntu: ros-humble-mrpt-navigation
+mrpt_pf_localization:
+    ubuntu: ros-humble-mrpt-pf-localization
+mrpt_pointcloud_pipeline:
+    ubuntu: ros-humble-mrpt-pointcloud-pipeline
+mrpt_rawlog:
+    ubuntu: ros-humble-mrpt-rawlog
+mrpt_reactivenav2d:
+    ubuntu: ros-humble-mrpt-reactivenav2d
+mrpt_tps_astar_planner:
+    ubuntu: ros-humble-mrpt-tps-astar-planner
+mrpt_tutorials:
+    ubuntu: ros-humble-mrpt-tutorials
+mrpt_path_planning:
+    ubuntu: ros-humble-mrpt-path-planning
+mrpt_apps:
+    ubuntu: ros-humble-mrpt-apps
+mrpt_libapps:
+    ubuntu: ros-humble-mrpt-libapps
+mrpt_libbase:
+    ubuntu: ros-humble-mrpt-libbase
+mrpt_libgui:
+    ubuntu: ros-humble-mrpt-libgui
+mrpt_libhwdrivers:
+    ubuntu: ros-humble-mrpt-libhwdrivers
+mrpt_libmaps:
+    ubuntu: ros-humble-mrpt-libmaps
+mrpt_libmath:
+    ubuntu: ros-humble-mrpt-libmath
+mrpt_libnav:
+    ubuntu: ros-humble-mrpt-libnav
+mrpt_libobs:
+    ubuntu: ros-humble-mrpt-libobs
+mrpt_libopengl:
+    ubuntu: ros-humble-mrpt-libopengl
+mrpt_libposes:
+    ubuntu: ros-humble-mrpt-libposes
+mrpt_libros_bridge:
+    ubuntu: ros-humble-mrpt-libros-bridge
+mrpt_libslam:
+    ubuntu: ros-humble-mrpt-libslam
+mrpt_libtclap:
+    ubuntu: ros-humble-mrpt-libtclap
+mrpt_generic_sensor:
+    ubuntu: ros-humble-mrpt-generic-sensor
+mrpt_sensor_bumblebee_stereo:
+    ubuntu: ros-humble-mrpt-sensor-bumblebee-stereo
+mrpt_sensor_gnss_nmea:
+    ubuntu: ros-humble-mrpt-sensor-gnss-nmea
+mrpt_sensor_gnss_novatel:
+    ubuntu: ros-humble-mrpt-sensor-gnss-novatel
+mrpt_sensor_imu_taobotics:
+    ubuntu: ros-humble-mrpt-sensor-imu-taobotics
+mrpt_sensorlib:
+    ubuntu: ros-humble-mrpt-sensorlib
+mrpt_sensors:
+    ubuntu: ros-humble-mrpt-sensors
+mrt_cmake_modules:
+    ubuntu: ros-humble-mrt-cmake-modules
+multiple_topic_monitor:
+    ubuntu: ros-humble-multiple-topic-monitor
+mvsim:
+    ubuntu: ros-humble-mvsim
+myactuator_rmd:
+    ubuntu: ros-humble-myactuator-rmd
+nao_button_sim:
+    ubuntu: ros-humble-nao-button-sim
+nao_command_msgs:
+    ubuntu: ros-humble-nao-command-msgs
+nao_sensor_msgs:
+    ubuntu: ros-humble-nao-sensor-msgs
+nao_lola:
+    ubuntu: ros-humble-nao-lola
+nao_meshes:
+    ubuntu: ros-humble-nao-meshes
+naoqi_bridge_msgs:
+    ubuntu: ros-humble-naoqi-bridge-msgs
+naoqi_driver:
+    ubuntu: ros-humble-naoqi-driver
+naoqi_libqi:
+    ubuntu: ros-humble-naoqi-libqi
+naoqi_libqicore:
+    ubuntu: ros-humble-naoqi-libqicore
+costmap_queue:
+    ubuntu: ros-humble-costmap-queue
+dwb_core:
+    ubuntu: ros-humble-dwb-core
+dwb_critics:
+    ubuntu: ros-humble-dwb-critics
+dwb_msgs:
+    ubuntu: ros-humble-dwb-msgs
+dwb_plugins:
+    ubuntu: ros-humble-dwb-plugins
+nav2_amcl:
+    ubuntu: ros-humble-nav2-amcl
+nav2_behavior_tree:
+    ubuntu: ros-humble-nav2-behavior-tree
+nav2_behaviors:
+    ubuntu: ros-humble-nav2-behaviors
+nav2_bringup:
+    ubuntu: ros-humble-nav2-bringup
+nav2_bt_navigator:
+    ubuntu: ros-humble-nav2-bt-navigator
+nav2_collision_monitor:
+    ubuntu: ros-humble-nav2-collision-monitor
+nav2_common:
+    ubuntu: ros-humble-nav2-common
+nav2_constrained_smoother:
+    ubuntu: ros-humble-nav2-constrained-smoother
+nav2_controller:
+    ubuntu: ros-humble-nav2-controller
+nav2_core:
+    ubuntu: ros-humble-nav2-core
+nav2_costmap_2d:
+    ubuntu: ros-humble-nav2-costmap-2d
+nav2_dwb_controller:
+    ubuntu: ros-humble-nav2-dwb-controller
+nav2_graceful_controller:
+    ubuntu: ros-humble-nav2-graceful-controller
+nav2_lifecycle_manager:
+    ubuntu: ros-humble-nav2-lifecycle-manager
+nav2_map_server:
+    ubuntu: ros-humble-nav2-map-server
+nav2_mppi_controller:
+    ubuntu: ros-humble-nav2-mppi-controller
+nav2_msgs:
+    ubuntu: ros-humble-nav2-msgs
+nav2_navfn_planner:
+    ubuntu: ros-humble-nav2-navfn-planner
+nav2_planner:
+    ubuntu: ros-humble-nav2-planner
+nav2_regulated_pure_pursuit_controller:
+    ubuntu: ros-humble-nav2-regulated-pure-pursuit-controller
+nav2_rotation_shim_controller:
+    ubuntu: ros-humble-nav2-rotation-shim-controller
+nav2_rviz_plugins:
+    ubuntu: ros-humble-nav2-rviz-plugins
+nav2_simple_commander:
+    ubuntu: ros-humble-nav2-simple-commander
+nav2_smac_planner:
+    ubuntu: ros-humble-nav2-smac-planner
+nav2_smoother:
+    ubuntu: ros-humble-nav2-smoother
+nav2_system_tests:
+    ubuntu: ros-humble-nav2-system-tests
+nav2_theta_star_planner:
+    ubuntu: ros-humble-nav2-theta-star-planner
+nav2_util:
+    ubuntu: ros-humble-nav2-util
+nav2_velocity_smoother:
+    ubuntu: ros-humble-nav2-velocity-smoother
+nav2_voxel_grid:
+    ubuntu: ros-humble-nav2-voxel-grid
+nav2_waypoint_follower:
+    ubuntu: ros-humble-nav2-waypoint-follower
+nav_2d_msgs:
+    ubuntu: ros-humble-nav-2d-msgs
+nav_2d_utils:
+    ubuntu: ros-humble-nav-2d-utils
+navigation2:
+    ubuntu: ros-humble-navigation2
+map_msgs:
+    ubuntu: ros-humble-map-msgs
+ndt_omp:
+    ubuntu: ros-humble-ndt-omp
+neo_nav2_bringup:
+    ubuntu: ros-humble-neo-nav2-bringup
+neo_simulation2:
+    ubuntu: ros-humble-neo-simulation2
+nerian_stereo:
+    ubuntu: ros-humble-nerian-stereo
+network_interface:
+    ubuntu: ros-humble-network-interface
+nicla_vision_ros2:
+    ubuntu: ros-humble-nicla-vision-ros2
+nlohmann_json_schema_validator_vendor:
+    ubuntu: ros-humble-nlohmann-json-schema-validator-vendor
+nmea_hardware_interface:
+    ubuntu: ros-humble-nmea-hardware-interface
+nmea_msgs:
+    ubuntu: ros-humble-nmea-msgs
+nmea_navsat_driver:
+    ubuntu: ros-humble-nmea-navsat-driver
+nodl_python:
+    ubuntu: ros-humble-nodl-python
+ros2nodl:
+    ubuntu: ros-humble-ros2nodl
+nodl_to_policy:
+    ubuntu: ros-humble-nodl-to-policy
+novatel_gps_driver:
+    ubuntu: ros-humble-novatel-gps-driver
+novatel_gps_msgs:
+    ubuntu: ros-humble-novatel-gps-msgs
+novatel_oem7_driver:
+    ubuntu: ros-humble-novatel-oem7-driver
+novatel_oem7_msgs:
+    ubuntu: ros-humble-novatel-oem7-msgs
+ntpd_driver:
+    ubuntu: ros-humble-ntpd-driver
+ntrip_client:
+    ubuntu: ros-humble-ntrip-client
+object_recognition_msgs:
+    ubuntu: ros-humble-object-recognition-msgs
+dynamic_edt_3d:
+    ubuntu: ros-humble-dynamic-edt-3d
+octomap:
+    ubuntu: ros-humble-octomap
+octovis:
+    ubuntu: ros-humble-octovis
+octomap_mapping:
+    ubuntu: ros-humble-octomap-mapping
+octomap_server:
+    ubuntu: ros-humble-octomap-server
+octomap_msgs:
+    ubuntu: ros-humble-octomap-msgs
+octomap_ros:
+    ubuntu: ros-humble-octomap-ros
+octomap_rviz_plugins:
+    ubuntu: ros-humble-octomap-rviz-plugins
+odom_to_tf_ros2:
+    ubuntu: ros-humble-odom-to-tf-ros2
+off_highway_can:
+    ubuntu: ros-humble-off-highway-can
+off_highway_general_purpose_radar:
+    ubuntu: ros-humble-off-highway-general-purpose-radar
+off_highway_general_purpose_radar_msgs:
+    ubuntu: ros-humble-off-highway-general-purpose-radar-msgs
+off_highway_premium_radar_sample:
+    ubuntu: ros-humble-off-highway-premium-radar-sample
+off_highway_premium_radar_sample_msgs:
+    ubuntu: ros-humble-off-highway-premium-radar-sample-msgs
+off_highway_radar:
+    ubuntu: ros-humble-off-highway-radar
+off_highway_radar_msgs:
+    ubuntu: ros-humble-off-highway-radar-msgs
+off_highway_sensor_drivers:
+    ubuntu: ros-humble-off-highway-sensor-drivers
+off_highway_sensor_drivers_examples:
+    ubuntu: ros-humble-off-highway-sensor-drivers-examples
+off_highway_uss:
+    ubuntu: ros-humble-off-highway-uss
+off_highway_uss_msgs:
+    ubuntu: ros-humble-off-highway-uss-msgs
+omni_base_2dnav:
+    ubuntu: ros-humble-omni-base-2dnav
+omni_base_laser_sensors:
+    ubuntu: ros-humble-omni-base-laser-sensors
+omni_base_navigation:
+    ubuntu: ros-humble-omni-base-navigation
+omni_base_rgbd_sensors:
+    ubuntu: ros-humble-omni-base-rgbd-sensors
+omni_base_bringup:
+    ubuntu: ros-humble-omni-base-bringup
+omni_base_controller_configuration:
+    ubuntu: ros-humble-omni-base-controller-configuration
+omni_base_description:
+    ubuntu: ros-humble-omni-base-description
+omni_base_robot:
+    ubuntu: ros-humble-omni-base-robot
+omni_base_gazebo:
+    ubuntu: ros-humble-omni-base-gazebo
+omni_base_simulation:
+    ubuntu: ros-humble-omni-base-simulation
+ompl:
+    ubuntu: ros-humble-ompl
+openeb_vendor:
+    ubuntu: ros-humble-openeb-vendor
+opennav_docking:
+    ubuntu: ros-humble-opennav-docking
+opennav_docking_bt:
+    ubuntu: ros-humble-opennav-docking-bt
+opennav_docking_core:
+    ubuntu: ros-humble-opennav-docking-core
+opennav_docking_msgs:
+    ubuntu: ros-humble-opennav-docking-msgs
+openni2_camera:
+    ubuntu: ros-humble-openni2-camera
+orocos_kdl_vendor:
+    ubuntu: ros-humble-orocos-kdl-vendor
+python_orocos_kdl_vendor:
+    ubuntu: ros-humble-python-orocos-kdl-vendor
+ortools_vendor:
+    ubuntu: ros-humble-ortools-vendor
+osqp_vendor:
+    ubuntu: ros-humble-osqp-vendor
+osrf_pycommon:
+    ubuntu: ros-humble-osrf-pycommon
+osrf_testing_tools_cpp:
+    ubuntu: ros-humble-osrf-testing-tools-cpp
+ouxt_common:
+    ubuntu: ros-humble-ouxt-common
+ouxt_lint_common:
+    ubuntu: ros-humble-ouxt-lint-common
+pal_gazebo_plugins:
+    ubuntu: ros-humble-pal-gazebo-plugins
+pal_gazebo_worlds:
+    ubuntu: ros-humble-pal-gazebo-worlds
+pal_gripper:
+    ubuntu: ros-humble-pal-gripper
+pal_gripper_controller_configuration:
+    ubuntu: ros-humble-pal-gripper-controller-configuration
+pal_gripper_description:
+    ubuntu: ros-humble-pal-gripper-description
+pal_gripper_simulation:
+    ubuntu: ros-humble-pal-gripper-simulation
+pal_hey5:
+    ubuntu: ros-humble-pal-hey5
+pal_hey5_controller_configuration:
+    ubuntu: ros-humble-pal-hey5-controller-configuration
+pal_hey5_description:
+    ubuntu: ros-humble-pal-hey5-description
+pal_maps:
+    ubuntu: ros-humble-pal-maps
+pal_navigation_cfg:
+    ubuntu: ros-humble-pal-navigation-cfg
+pal_navigation_cfg_bringup:
+    ubuntu: ros-humble-pal-navigation-cfg-bringup
+pal_navigation_cfg_params:
+    ubuntu: ros-humble-pal-navigation-cfg-params
+pal_robotiq_controller_configuration:
+    ubuntu: ros-humble-pal-robotiq-controller-configuration
+pal_robotiq_description:
+    ubuntu: ros-humble-pal-robotiq-description
+pal_robotiq_gripper:
+    ubuntu: ros-humble-pal-robotiq-gripper
+pal_statistics:
+    ubuntu: ros-humble-pal-statistics
+pal_statistics_msgs:
+    ubuntu: ros-humble-pal-statistics-msgs
+pal_urdf_utils:
+    ubuntu: ros-humble-pal-urdf-utils
+pangolin:
+    ubuntu: ros-humble-pangolin
+pcl_msgs:
+    ubuntu: ros-humble-pcl-msgs
+pepper_meshes:
+    ubuntu: ros-humble-pepper-meshes
+open3d_conversions:
+    ubuntu: ros-humble-open3d-conversions
+pcl_conversions:
+    ubuntu: ros-humble-pcl-conversions
+pcl_ros:
+    ubuntu: ros-humble-pcl-ros
+perception_pcl:
+    ubuntu: ros-humble-perception-pcl
+performance_test:
+    ubuntu: ros-humble-performance-test
+performance_test_fixture:
+    ubuntu: ros-humble-performance-test-fixture
+libphidget22:
+    ubuntu: ros-humble-libphidget22
+phidgets_accelerometer:
+    ubuntu: ros-humble-phidgets-accelerometer
+phidgets_analog_inputs:
+    ubuntu: ros-humble-phidgets-analog-inputs
+phidgets_analog_outputs:
+    ubuntu: ros-humble-phidgets-analog-outputs
+phidgets_api:
+    ubuntu: ros-humble-phidgets-api
+phidgets_digital_inputs:
+    ubuntu: ros-humble-phidgets-digital-inputs
+phidgets_digital_outputs:
+    ubuntu: ros-humble-phidgets-digital-outputs
+phidgets_drivers:
+    ubuntu: ros-humble-phidgets-drivers
+phidgets_gyroscope:
+    ubuntu: ros-humble-phidgets-gyroscope
+phidgets_high_speed_encoder:
+    ubuntu: ros-humble-phidgets-high-speed-encoder
+phidgets_ik:
+    ubuntu: ros-humble-phidgets-ik
+phidgets_magnetometer:
+    ubuntu: ros-humble-phidgets-magnetometer
+phidgets_motors:
+    ubuntu: ros-humble-phidgets-motors
+phidgets_msgs:
+    ubuntu: ros-humble-phidgets-msgs
+phidgets_spatial:
+    ubuntu: ros-humble-phidgets-spatial
+phidgets_temperature:
+    ubuntu: ros-humble-phidgets-temperature
+pick_ik:
+    ubuntu: ros-humble-pick-ik
+picknik_ament_copyright:
+    ubuntu: ros-humble-picknik-ament-copyright
+picknik_reset_fault_controller:
+    ubuntu: ros-humble-picknik-reset-fault-controller
+picknik_twist_controller:
+    ubuntu: ros-humble-picknik-twist-controller
+pinocchio:
+    ubuntu: ros-humble-pinocchio
+play_motion2:
+    ubuntu: ros-humble-play-motion2
+play_motion2_msgs:
+    ubuntu: ros-humble-play-motion2-msgs
+plotjuggler:
+    ubuntu: ros-humble-plotjuggler
+plotjuggler_msgs:
+    ubuntu: ros-humble-plotjuggler-msgs
+plotjuggler_ros:
+    ubuntu: ros-humble-plotjuggler-ros
+pluginlib:
+    ubuntu: ros-humble-pluginlib
+pmb2_2dnav:
+    ubuntu: ros-humble-pmb2-2dnav
+pmb2_laser_sensors:
+    ubuntu: ros-humble-pmb2-laser-sensors
+pmb2_navigation:
+    ubuntu: ros-humble-pmb2-navigation
+pmb2_bringup:
+    ubuntu: ros-humble-pmb2-bringup
+pmb2_controller_configuration:
+    ubuntu: ros-humble-pmb2-controller-configuration
+pmb2_description:
+    ubuntu: ros-humble-pmb2-description
+pmb2_robot:
+    ubuntu: ros-humble-pmb2-robot
+pmb2_gazebo:
+    ubuntu: ros-humble-pmb2-gazebo
+pmb2_simulation:
+    ubuntu: ros-humble-pmb2-simulation
+point_cloud_msg_wrapper:
+    ubuntu: ros-humble-point-cloud-msg-wrapper
+point_cloud_transport:
+    ubuntu: ros-humble-point-cloud-transport
+point_cloud_transport_py:
+    ubuntu: ros-humble-point-cloud-transport-py
+draco_point_cloud_transport:
+    ubuntu: ros-humble-draco-point-cloud-transport
+point_cloud_interfaces:
+    ubuntu: ros-humble-point-cloud-interfaces
+point_cloud_transport_plugins:
+    ubuntu: ros-humble-point-cloud-transport-plugins
+zlib_point_cloud_transport:
+    ubuntu: ros-humble-zlib-point-cloud-transport
+zstd_point_cloud_transport:
+    ubuntu: ros-humble-zstd-point-cloud-transport
+pointcloud_to_laserscan:
+    ubuntu: ros-humble-pointcloud-to-laserscan
+polygon_demos:
+    ubuntu: ros-humble-polygon-demos
+polygon_msgs:
+    ubuntu: ros-humble-polygon-msgs
+polygon_rviz_plugins:
+    ubuntu: ros-humble-polygon-rviz-plugins
+polygon_utils:
+    ubuntu: ros-humble-polygon-utils
+popf:
+    ubuntu: ros-humble-popf
+pose_cov_ops:
+    ubuntu: ros-humble-pose-cov-ops
+proto2ros:
+    ubuntu: ros-humble-proto2ros
+proxsuite:
+    ubuntu: ros-humble-proxsuite
+psdk_interfaces:
+    ubuntu: ros-humble-psdk-interfaces
+psdk_wrapper:
+    ubuntu: ros-humble-psdk-wrapper
+ptz_action_server_msgs:
+    ubuntu: ros-humble-ptz-action-server-msgs
+clearpath_socketcan_interface:
+    ubuntu: ros-humble-clearpath-socketcan-interface
+puma_motor_driver:
+    ubuntu: ros-humble-puma-motor-driver
+puma_motor_msgs:
+    ubuntu: ros-humble-puma-motor-msgs
+py_binding_tools:
+    ubuntu: ros-humble-py-binding-tools
+py_trees:
+    ubuntu: ros-humble-py-trees
+py_trees_js:
+    ubuntu: ros-humble-py-trees-js
+py_trees_ros:
+    ubuntu: ros-humble-py-trees-ros
+py_trees_ros_interfaces:
+    ubuntu: ros-humble-py-trees-ros-interfaces
+pybind11_json_vendor:
+    ubuntu: ros-humble-pybind11-json-vendor
+pybind11_vendor:
+    ubuntu: ros-humble-pybind11-vendor
+python_cmake_module:
+    ubuntu: ros-humble-python-cmake-module
+python_mrpt:
+    ubuntu: ros-humble-python-mrpt
+python_qt_binding:
+    ubuntu: ros-humble-python-qt-binding
+qb_device:
+    ubuntu: ros-humble-qb-device
+qb_device_bringup:
+    ubuntu: ros-humble-qb-device-bringup
+qb_device_driver:
+    ubuntu: ros-humble-qb-device-driver
+qb_device_msgs:
+    ubuntu: ros-humble-qb-device-msgs
+qb_device_ros2_control:
+    ubuntu: ros-humble-qb-device-ros2-control
+qb_device_test_controllers:
+    ubuntu: ros-humble-qb-device-test-controllers
+qb_softhand_industry:
+    ubuntu: ros-humble-qb-softhand-industry
+qb_softhand_industry_description:
+    ubuntu: ros-humble-qb-softhand-industry-description
+qb_softhand_industry_driver:
+    ubuntu: ros-humble-qb-softhand-industry-driver
+qb_softhand_industry_msgs:
+    ubuntu: ros-humble-qb-softhand-industry-msgs
+qb_softhand_industry_ros2_control:
+    ubuntu: ros-humble-qb-softhand-industry-ros2-control
+qb_softhand_industry_srvs:
+    ubuntu: ros-humble-qb-softhand-industry-srvs
+qml_ros2_plugin:
+    ubuntu: ros-humble-qml-ros2-plugin
+qpoases_vendor:
+    ubuntu: ros-humble-qpoases-vendor
+qt_dotgraph:
+    ubuntu: ros-humble-qt-dotgraph
+qt_gui:
+    ubuntu: ros-humble-qt-gui
+qt_gui_app:
+    ubuntu: ros-humble-qt-gui-app
+qt_gui_core:
+    ubuntu: ros-humble-qt-gui-core
+qt_gui_cpp:
+    ubuntu: ros-humble-qt-gui-cpp
+qt_gui_py_common:
+    ubuntu: ros-humble-qt-gui-py-common
+quaternion_operation:
+    ubuntu: ros-humble-quaternion-operation
+r2r_spl:
+    ubuntu: ros-humble-r2r-spl
+r2r_spl_7:
+    ubuntu: ros-humble-r2r-spl-7
+r2r_spl_8:
+    ubuntu: ros-humble-r2r-spl-8
+r2r_spl_test_interfaces:
+    ubuntu: ros-humble-r2r-spl-test-interfaces
+splsm_7:
+    ubuntu: ros-humble-splsm-7
+splsm_7_conversion:
+    ubuntu: ros-humble-splsm-7-conversion
+splsm_8:
+    ubuntu: ros-humble-splsm-8
+splsm_8_conversion:
+    ubuntu: ros-humble-splsm-8-conversion
+radar_msgs:
+    ubuntu: ros-humble-radar-msgs
+random_numbers:
+    ubuntu: ros-humble-random-numbers
+raspimouse:
+    ubuntu: ros-humble-raspimouse
+raspimouse_msgs:
+    ubuntu: ros-humble-raspimouse-msgs
+raspimouse_description:
+    ubuntu: ros-humble-raspimouse-description
+raspimouse_ros2_examples:
+    ubuntu: ros-humble-raspimouse-ros2-examples
+raspimouse_fake:
+    ubuntu: ros-humble-raspimouse-fake
+raspimouse_gazebo:
+    ubuntu: ros-humble-raspimouse-gazebo
+raspimouse_sim:
+    ubuntu: ros-humble-raspimouse-sim
+raspimouse_navigation:
+    ubuntu: ros-humble-raspimouse-navigation
+raspimouse_slam:
+    ubuntu: ros-humble-raspimouse-slam
+raspimouse_slam_navigation:
+    ubuntu: ros-humble-raspimouse-slam-navigation
+rc_common_msgs:
+    ubuntu: ros-humble-rc-common-msgs
+rc_dynamics_api:
+    ubuntu: ros-humble-rc-dynamics-api
+rc_genicam_api:
+    ubuntu: ros-humble-rc-genicam-api
+rc_genicam_driver:
+    ubuntu: ros-humble-rc-genicam-driver
+rc_reason_clients:
+    ubuntu: ros-humble-rc-reason-clients
+rc_reason_msgs:
+    ubuntu: ros-humble-rc-reason-msgs
+rcdiscover:
+    ubuntu: ros-humble-rcdiscover
+rcl:
+    ubuntu: ros-humble-rcl
+rcl_action:
+    ubuntu: ros-humble-rcl-action
+rcl_lifecycle:
+    ubuntu: ros-humble-rcl-lifecycle
+rcl_yaml_param_parser:
+    ubuntu: ros-humble-rcl-yaml-param-parser
+action_msgs:
+    ubuntu: ros-humble-action-msgs
+builtin_interfaces:
+    ubuntu: ros-humble-builtin-interfaces
+composition_interfaces:
+    ubuntu: ros-humble-composition-interfaces
+lifecycle_msgs:
+    ubuntu: ros-humble-lifecycle-msgs
+rcl_interfaces:
+    ubuntu: ros-humble-rcl-interfaces
+rosgraph_msgs:
+    ubuntu: ros-humble-rosgraph-msgs
+statistics_msgs:
+    ubuntu: ros-humble-statistics-msgs
+test_msgs:
+    ubuntu: ros-humble-test-msgs
+rcl_logging_interface:
+    ubuntu: ros-humble-rcl-logging-interface
+rcl_logging_noop:
+    ubuntu: ros-humble-rcl-logging-noop
+rcl_logging_spdlog:
+    ubuntu: ros-humble-rcl-logging-spdlog
+rclc:
+    ubuntu: ros-humble-rclc
+rclc_examples:
+    ubuntu: ros-humble-rclc-examples
+rclc_lifecycle:
+    ubuntu: ros-humble-rclc-lifecycle
+rclc_parameter:
+    ubuntu: ros-humble-rclc-parameter
+rclcpp:
+    ubuntu: ros-humble-rclcpp
+rclcpp_action:
+    ubuntu: ros-humble-rclcpp-action
+rclcpp_components:
+    ubuntu: ros-humble-rclcpp-components
+rclcpp_lifecycle:
+    ubuntu: ros-humble-rclcpp-lifecycle
+rclpy:
+    ubuntu: ros-humble-rclpy
+rcpputils:
+    ubuntu: ros-humble-rcpputils
+rcss3d_agent:
+    ubuntu: ros-humble-rcss3d-agent
+rcss3d_agent_basic:
+    ubuntu: ros-humble-rcss3d-agent-basic
+rcss3d_agent_msgs:
+    ubuntu: ros-humble-rcss3d-agent-msgs
+rcutils:
+    ubuntu: ros-humble-rcutils
+reach:
+    ubuntu: ros-humble-reach
+reach_ros:
+    ubuntu: ros-humble-reach-ros
+realsense2_camera:
+    ubuntu: ros-humble-realsense2-camera
+realsense2_camera_msgs:
+    ubuntu: ros-humble-realsense2-camera-msgs
+realsense2_description:
+    ubuntu: ros-humble-realsense2-description
+rttest:
+    ubuntu: ros-humble-rttest
+tlsf_cpp:
+    ubuntu: ros-humble-tlsf-cpp
+realtime_tools:
+    ubuntu: ros-humble-realtime-tools
+libcurl_vendor:
+    ubuntu: ros-humble-libcurl-vendor
+resource_retriever:
+    ubuntu: ros-humble-resource-retriever
+rig_reconfigure:
+    ubuntu: ros-humble-rig-reconfigure
+rmf_api_msgs:
+    ubuntu: ros-humble-rmf-api-msgs
+rmf_battery:
+    ubuntu: ros-humble-rmf-battery
+rmf_building_map_msgs:
+    ubuntu: ros-humble-rmf-building-map-msgs
+rmf_cmake_uncrustify:
+    ubuntu: ros-humble-rmf-cmake-uncrustify
+rmf_demos:
+    ubuntu: ros-humble-rmf-demos
+rmf_charger_msgs:
+    ubuntu: ros-humble-rmf-charger-msgs
+rmf_dispenser_msgs:
+    ubuntu: ros-humble-rmf-dispenser-msgs
+rmf_door_msgs:
+    ubuntu: ros-humble-rmf-door-msgs
+rmf_fleet_msgs:
+    ubuntu: ros-humble-rmf-fleet-msgs
+rmf_ingestor_msgs:
+    ubuntu: ros-humble-rmf-ingestor-msgs
+rmf_lift_msgs:
+    ubuntu: ros-humble-rmf-lift-msgs
+rmf_obstacle_msgs:
+    ubuntu: ros-humble-rmf-obstacle-msgs
+rmf_scheduler_msgs:
+    ubuntu: ros-humble-rmf-scheduler-msgs
+rmf_site_map_msgs:
+    ubuntu: ros-humble-rmf-site-map-msgs
+rmf_task_msgs:
+    ubuntu: ros-humble-rmf-task-msgs
+rmf_traffic_msgs:
+    ubuntu: ros-humble-rmf-traffic-msgs
+rmf_workcell_msgs:
+    ubuntu: ros-humble-rmf-workcell-msgs
+rmf_fleet_adapter:
+    ubuntu: ros-humble-rmf-fleet-adapter
+rmf_fleet_adapter_python:
+    ubuntu: ros-humble-rmf-fleet-adapter-python
+rmf_task_ros2:
+    ubuntu: ros-humble-rmf-task-ros2
+rmf_traffic_ros2:
+    ubuntu: ros-humble-rmf-traffic-ros2
+rmf_websocket:
+    ubuntu: ros-humble-rmf-websocket
+rmf_building_sim_common:
+    ubuntu: ros-humble-rmf-building-sim-common
+rmf_building_sim_gz_classic_plugins:
+    ubuntu: ros-humble-rmf-building-sim-gz-classic-plugins
+rmf_building_sim_gz_plugins:
+    ubuntu: ros-humble-rmf-building-sim-gz-plugins
+rmf_robot_sim_common:
+    ubuntu: ros-humble-rmf-robot-sim-common
+rmf_robot_sim_gz_classic_plugins:
+    ubuntu: ros-humble-rmf-robot-sim-gz-classic-plugins
+rmf_robot_sim_gz_plugins:
+    ubuntu: ros-humble-rmf-robot-sim-gz-plugins
+rmf_task:
+    ubuntu: ros-humble-rmf-task
+rmf_task_sequence:
+    ubuntu: ros-humble-rmf-task-sequence
+rmf_traffic:
+    ubuntu: ros-humble-rmf-traffic
+rmf_traffic_examples:
+    ubuntu: ros-humble-rmf-traffic-examples
+rmf_building_map_tools:
+    ubuntu: ros-humble-rmf-building-map-tools
+rmf_traffic_editor:
+    ubuntu: ros-humble-rmf-traffic-editor
+rmf_traffic_editor_assets:
+    ubuntu: ros-humble-rmf-traffic-editor-assets
+rmf_traffic_editor_test_maps:
+    ubuntu: ros-humble-rmf-traffic-editor-test-maps
+rmf_utils:
+    ubuntu: ros-humble-rmf-utils
+rmf_dev:
+    ubuntu: ros-humble-rmf-dev
+rmf_visualization:
+    ubuntu: ros-humble-rmf-visualization
+rmf_visualization_building_systems:
+    ubuntu: ros-humble-rmf-visualization-building-systems
+rmf_visualization_fleet_states:
+    ubuntu: ros-humble-rmf-visualization-fleet-states
+rmf_visualization_floorplans:
+    ubuntu: ros-humble-rmf-visualization-floorplans
+rmf_visualization_navgraphs:
+    ubuntu: ros-humble-rmf-visualization-navgraphs
+rmf_visualization_obstacles:
+    ubuntu: ros-humble-rmf-visualization-obstacles
+rmf_visualization_rviz2_plugins:
+    ubuntu: ros-humble-rmf-visualization-rviz2-plugins
+rmf_visualization_schedule:
+    ubuntu: ros-humble-rmf-visualization-schedule
+rmf_visualization_msgs:
+    ubuntu: ros-humble-rmf-visualization-msgs
+rmw:
+    ubuntu: ros-humble-rmw
+rmw_implementation_cmake:
+    ubuntu: ros-humble-rmw-implementation-cmake
+rmw_connextdds:
+    ubuntu: ros-humble-rmw-connextdds
+rmw_connextdds_common:
+    ubuntu: ros-humble-rmw-connextdds-common
+rti_connext_dds_cmake_module:
+    ubuntu: ros-humble-rti-connext-dds-cmake-module
+rmw_cyclonedds_cpp:
+    ubuntu: ros-humble-rmw-cyclonedds-cpp
+rmw_dds_common:
+    ubuntu: ros-humble-rmw-dds-common
+rmw_fastrtps_cpp:
+    ubuntu: ros-humble-rmw-fastrtps-cpp
+rmw_fastrtps_dynamic_cpp:
+    ubuntu: ros-humble-rmw-fastrtps-dynamic-cpp
+rmw_fastrtps_shared_cpp:
+    ubuntu: ros-humble-rmw-fastrtps-shared-cpp
+gurumdds_cmake_module:
+    ubuntu: ros-humble-gurumdds-cmake-module
+rmw_gurumdds_cpp:
+    ubuntu: ros-humble-rmw-gurumdds-cpp
+rmw_implementation:
+    ubuntu: ros-humble-rmw-implementation
+rmw_zenoh_cpp:
+    ubuntu: ros-humble-rmw-zenoh-cpp
+zenoh_cpp_vendor:
+    ubuntu: ros-humble-zenoh-cpp-vendor
+robosoft_openai:
+    ubuntu: ros-humble-robosoft-openai
+robot_calibration:
+    ubuntu: ros-humble-robot-calibration
+robot_calibration_msgs:
+    ubuntu: ros-humble-robot-calibration-msgs
+robot_controllers:
+    ubuntu: ros-humble-robot-controllers
+robot_controllers_interface:
+    ubuntu: ros-humble-robot-controllers-interface
+robot_controllers_msgs:
+    ubuntu: ros-humble-robot-controllers-msgs
+robot_localization:
+    ubuntu: ros-humble-robot-localization
+robot_state_publisher:
+    ubuntu: ros-humble-robot-state-publisher
+robot_upstart:
+    ubuntu: ros-humble-robot-upstart
+robotont_driver:
+    ubuntu: ros-humble-robotont-driver
+robotraconteur:
+    ubuntu: ros-humble-robotraconteur
+ros1_bridge:
+    ubuntu: ros-humble-ros1-bridge
+canopen:
+    ubuntu: ros-humble-canopen
+canopen_402_driver:
+    ubuntu: ros-humble-canopen-402-driver
+canopen_base_driver:
+    ubuntu: ros-humble-canopen-base-driver
+canopen_core:
+    ubuntu: ros-humble-canopen-core
+canopen_fake_slaves:
+    ubuntu: ros-humble-canopen-fake-slaves
+canopen_interfaces:
+    ubuntu: ros-humble-canopen-interfaces
+canopen_master_driver:
+    ubuntu: ros-humble-canopen-master-driver
+canopen_proxy_driver:
+    ubuntu: ros-humble-canopen-proxy-driver
+canopen_ros2_control:
+    ubuntu: ros-humble-canopen-ros2-control
+canopen_ros2_controllers:
+    ubuntu: ros-humble-canopen-ros2-controllers
+canopen_tests:
+    ubuntu: ros-humble-canopen-tests
+canopen_utils:
+    ubuntu: ros-humble-canopen-utils
+lely_core_libraries:
+    ubuntu: ros-humble-lely-core-libraries
+controller_interface:
+    ubuntu: ros-humble-controller-interface
+controller_manager:
+    ubuntu: ros-humble-controller-manager
+controller_manager_msgs:
+    ubuntu: ros-humble-controller-manager-msgs
+hardware_interface:
+    ubuntu: ros-humble-hardware-interface
+hardware_interface_testing:
+    ubuntu: ros-humble-hardware-interface-testing
+joint_limits:
+    ubuntu: ros-humble-joint-limits
+ros2_control:
+    ubuntu: ros-humble-ros2-control
+ros2_control_test_assets:
+    ubuntu: ros-humble-ros2-control-test-assets
+ros2controlcli:
+    ubuntu: ros-humble-ros2controlcli
+rqt_controller_manager:
+    ubuntu: ros-humble-rqt-controller-manager
+transmission_interface:
+    ubuntu: ros-humble-transmission-interface
+ackermann_steering_controller:
+    ubuntu: ros-humble-ackermann-steering-controller
+admittance_controller:
+    ubuntu: ros-humble-admittance-controller
+bicycle_steering_controller:
+    ubuntu: ros-humble-bicycle-steering-controller
+diff_drive_controller:
+    ubuntu: ros-humble-diff-drive-controller
+effort_controllers:
+    ubuntu: ros-humble-effort-controllers
+force_torque_sensor_broadcaster:
+    ubuntu: ros-humble-force-torque-sensor-broadcaster
+forward_command_controller:
+    ubuntu: ros-humble-forward-command-controller
+gpio_controllers:
+    ubuntu: ros-humble-gpio-controllers
+gripper_controllers:
+    ubuntu: ros-humble-gripper-controllers
+imu_sensor_broadcaster:
+    ubuntu: ros-humble-imu-sensor-broadcaster
+joint_state_broadcaster:
+    ubuntu: ros-humble-joint-state-broadcaster
+joint_trajectory_controller:
+    ubuntu: ros-humble-joint-trajectory-controller
+pid_controller:
+    ubuntu: ros-humble-pid-controller
+pose_broadcaster:
+    ubuntu: ros-humble-pose-broadcaster
+position_controllers:
+    ubuntu: ros-humble-position-controllers
+range_sensor_broadcaster:
+    ubuntu: ros-humble-range-sensor-broadcaster
+ros2_controllers:
+    ubuntu: ros-humble-ros2-controllers
+ros2_controllers_test_nodes:
+    ubuntu: ros-humble-ros2-controllers-test-nodes
+rqt_joint_trajectory_controller:
+    ubuntu: ros-humble-rqt-joint-trajectory-controller
+steering_controllers_library:
+    ubuntu: ros-humble-steering-controllers-library
+tricycle_controller:
+    ubuntu: ros-humble-tricycle-controller
+tricycle_steering_controller:
+    ubuntu: ros-humble-tricycle-steering-controller
+velocity_controllers:
+    ubuntu: ros-humble-velocity-controllers
+kinova_gen3_6dof_robotiq_2f_85_moveit_config:
+    ubuntu: ros-humble-kinova-gen3-6dof-robotiq-2f-85-moveit-config
+kinova_gen3_7dof_robotiq_2f_85_moveit_config:
+    ubuntu: ros-humble-kinova-gen3-7dof-robotiq-2f-85-moveit-config
+kortex_api:
+    ubuntu: ros-humble-kortex-api
+kortex_bringup:
+    ubuntu: ros-humble-kortex-bringup
+kortex_description:
+    ubuntu: ros-humble-kortex-description
+kortex_driver:
+    ubuntu: ros-humble-kortex-driver
+ouster_msgs:
+    ubuntu: ros-humble-ouster-msgs
+ros2_ouster:
+    ubuntu: ros-humble-ros2-ouster
+plansys2_bringup:
+    ubuntu: ros-humble-plansys2-bringup
+plansys2_bt_actions:
+    ubuntu: ros-humble-plansys2-bt-actions
+plansys2_core:
+    ubuntu: ros-humble-plansys2-core
+plansys2_domain_expert:
+    ubuntu: ros-humble-plansys2-domain-expert
+plansys2_executor:
+    ubuntu: ros-humble-plansys2-executor
+plansys2_lifecycle_manager:
+    ubuntu: ros-humble-plansys2-lifecycle-manager
+plansys2_msgs:
+    ubuntu: ros-humble-plansys2-msgs
+plansys2_pddl_parser:
+    ubuntu: ros-humble-plansys2-pddl-parser
+plansys2_planner:
+    ubuntu: ros-humble-plansys2-planner
+plansys2_popf_plan_solver:
+    ubuntu: ros-humble-plansys2-popf-plan-solver
+plansys2_problem_expert:
+    ubuntu: ros-humble-plansys2-problem-expert
+plansys2_terminal:
+    ubuntu: ros-humble-plansys2-terminal
+plansys2_tools:
+    ubuntu: ros-humble-plansys2-tools
+robotiq_controllers:
+    ubuntu: ros-humble-robotiq-controllers
+robotiq_description:
+    ubuntu: ros-humble-robotiq-description
+ros2_socketcan:
+    ubuntu: ros-humble-ros2-socketcan
+ros2_socketcan_msgs:
+    ubuntu: ros-humble-ros2-socketcan-msgs
+ros2trace:
+    ubuntu: ros-humble-ros2trace
+tracetools:
+    ubuntu: ros-humble-tracetools
+tracetools_launch:
+    ubuntu: ros-humble-tracetools-launch
+tracetools_read:
+    ubuntu: ros-humble-tracetools-read
+tracetools_test:
+    ubuntu: ros-humble-tracetools-test
+tracetools_trace:
+    ubuntu: ros-humble-tracetools-trace
+ros2acceleration:
+    ubuntu: ros-humble-ros2acceleration
+ros2caret:
+    ubuntu: ros-humble-ros2caret
+ros2action:
+    ubuntu: ros-humble-ros2action
+ros2cli:
+    ubuntu: ros-humble-ros2cli
+ros2cli_test_interfaces:
+    ubuntu: ros-humble-ros2cli-test-interfaces
+ros2component:
+    ubuntu: ros-humble-ros2component
+ros2doctor:
+    ubuntu: ros-humble-ros2doctor
+ros2interface:
+    ubuntu: ros-humble-ros2interface
+ros2lifecycle:
+    ubuntu: ros-humble-ros2lifecycle
+ros2lifecycle_test_fixtures:
+    ubuntu: ros-humble-ros2lifecycle-test-fixtures
+ros2multicast:
+    ubuntu: ros-humble-ros2multicast
+ros2node:
+    ubuntu: ros-humble-ros2node
+ros2param:
+    ubuntu: ros-humble-ros2param
+ros2pkg:
+    ubuntu: ros-humble-ros2pkg
+ros2run:
+    ubuntu: ros-humble-ros2run
+ros2service:
+    ubuntu: ros-humble-ros2service
+ros2topic:
+    ubuntu: ros-humble-ros2topic
+ros2cli_common_extensions:
+    ubuntu: ros-humble-ros2cli-common-extensions
+ros2launch_security:
+    ubuntu: ros-humble-ros2launch-security
+ros2launch_security_examples:
+    ubuntu: ros-humble-ros2launch-security-examples
+ros_babel_fish:
+    ubuntu: ros-humble-ros-babel-fish
+ros_babel_fish_test_msgs:
+    ubuntu: ros-humble-ros-babel-fish-test-msgs
+can_msgs:
+    ubuntu: ros-humble-can-msgs
+ros_environment:
+    ubuntu: ros-humble-ros-environment
+ros_gz:
+    ubuntu: ros-humble-ros-gz
+ros_gz_bridge:
+    ubuntu: ros-humble-ros-gz-bridge
+ros_gz_image:
+    ubuntu: ros-humble-ros-gz-image
+ros_gz_interfaces:
+    ubuntu: ros-humble-ros-gz-interfaces
+ros_gz_sim:
+    ubuntu: ros-humble-ros-gz-sim
+ros_gz_sim_demos:
+    ubuntu: ros-humble-ros-gz-sim-demos
+ros_ign:
+    ubuntu: ros-humble-ros-ign
+ros_ign_bridge:
+    ubuntu: ros-humble-ros-ign-bridge
+ros_ign_gazebo:
+    ubuntu: ros-humble-ros-ign-gazebo
+ros_ign_gazebo_demos:
+    ubuntu: ros-humble-ros-ign-gazebo-demos
+ros_ign_image:
+    ubuntu: ros-humble-ros-ign-image
+ros_ign_interfaces:
+    ubuntu: ros-humble-ros-ign-interfaces
+test_ros_gz_bridge:
+    ubuntu: ros-humble-test-ros-gz-bridge
+ros_image_to_qimage:
+    ubuntu: ros-humble-ros-image-to-qimage
+ros_industrial_cmake_boilerplate:
+    ubuntu: ros-humble-ros-industrial-cmake-boilerplate
+ros2test:
+    ubuntu: ros-humble-ros2test
+ros_testing:
+    ubuntu: ros-humble-ros-testing
+turtlesim:
+    ubuntu: ros-humble-turtlesim
+ros_workspace:
+    ubuntu: ros-humble-ros-workspace
+mcap_vendor:
+    ubuntu: ros-humble-mcap-vendor
+ros2bag:
+    ubuntu: ros-humble-ros2bag
+rosbag2:
+    ubuntu: ros-humble-rosbag2
+rosbag2_compression:
+    ubuntu: ros-humble-rosbag2-compression
+rosbag2_compression_zstd:
+    ubuntu: ros-humble-rosbag2-compression-zstd
+rosbag2_cpp:
+    ubuntu: ros-humble-rosbag2-cpp
+rosbag2_interfaces:
+    ubuntu: ros-humble-rosbag2-interfaces
+rosbag2_performance_benchmarking:
+    ubuntu: ros-humble-rosbag2-performance-benchmarking
+rosbag2_py:
+    ubuntu: ros-humble-rosbag2-py
+rosbag2_storage:
+    ubuntu: ros-humble-rosbag2-storage
+rosbag2_storage_default_plugins:
+    ubuntu: ros-humble-rosbag2-storage-default-plugins
+rosbag2_storage_mcap:
+    ubuntu: ros-humble-rosbag2-storage-mcap
+rosbag2_storage_mcap_testdata:
+    ubuntu: ros-humble-rosbag2-storage-mcap-testdata
+rosbag2_test_common:
+    ubuntu: ros-humble-rosbag2-test-common
+rosbag2_tests:
+    ubuntu: ros-humble-rosbag2-tests
+rosbag2_transport:
+    ubuntu: ros-humble-rosbag2-transport
+shared_queues_vendor:
+    ubuntu: ros-humble-shared-queues-vendor
+sqlite3_vendor:
+    ubuntu: ros-humble-sqlite3-vendor
+zstd_vendor:
+    ubuntu: ros-humble-zstd-vendor
+ros1_rosbag_storage_vendor:
+    ubuntu: ros-humble-ros1-rosbag-storage-vendor
+rosbag2_bag_v2_plugins:
+    ubuntu: ros-humble-rosbag2-bag-v2-plugins
+rosbag2_to_video:
+    ubuntu: ros-humble-rosbag2-to-video
+rosapi:
+    ubuntu: ros-humble-rosapi
+rosapi_msgs:
+    ubuntu: ros-humble-rosapi-msgs
+rosbridge_library:
+    ubuntu: ros-humble-rosbridge-library
+rosbridge_msgs:
+    ubuntu: ros-humble-rosbridge-msgs
+rosbridge_server:
+    ubuntu: ros-humble-rosbridge-server
+rosbridge_suite:
+    ubuntu: ros-humble-rosbridge-suite
+rosbridge_test_msgs:
+    ubuntu: ros-humble-rosbridge-test-msgs
+rosidl_adapter:
+    ubuntu: ros-humble-rosidl-adapter
+rosidl_cli:
+    ubuntu: ros-humble-rosidl-cli
+rosidl_cmake:
+    ubuntu: ros-humble-rosidl-cmake
+rosidl_generator_c:
+    ubuntu: ros-humble-rosidl-generator-c
+rosidl_generator_cpp:
+    ubuntu: ros-humble-rosidl-generator-cpp
+rosidl_parser:
+    ubuntu: ros-humble-rosidl-parser
+rosidl_runtime_c:
+    ubuntu: ros-humble-rosidl-runtime-c
+rosidl_runtime_cpp:
+    ubuntu: ros-humble-rosidl-runtime-cpp
+rosidl_typesupport_interface:
+    ubuntu: ros-humble-rosidl-typesupport-interface
+rosidl_typesupport_introspection_c:
+    ubuntu: ros-humble-rosidl-typesupport-introspection-c
+rosidl_typesupport_introspection_cpp:
+    ubuntu: ros-humble-rosidl-typesupport-introspection-cpp
+rosidl_generator_dds_idl:
+    ubuntu: ros-humble-rosidl-generator-dds-idl
+rosidl_default_generators:
+    ubuntu: ros-humble-rosidl-default-generators
+rosidl_default_runtime:
+    ubuntu: ros-humble-rosidl-default-runtime
+rosidl_generator_py:
+    ubuntu: ros-humble-rosidl-generator-py
+rosidl_runtime_py:
+    ubuntu: ros-humble-rosidl-runtime-py
+rosidl_typesupport_c:
+    ubuntu: ros-humble-rosidl-typesupport-c
+rosidl_typesupport_cpp:
+    ubuntu: ros-humble-rosidl-typesupport-cpp
+fastrtps_cmake_module:
+    ubuntu: ros-humble-fastrtps-cmake-module
+rosidl_typesupport_fastrtps_c:
+    ubuntu: ros-humble-rosidl-typesupport-fastrtps-c
+rosidl_typesupport_fastrtps_cpp:
+    ubuntu: ros-humble-rosidl-typesupport-fastrtps-cpp
+rclpy_message_converter:
+    ubuntu: ros-humble-rclpy-message-converter
+rclpy_message_converter_msgs:
+    ubuntu: ros-humble-rclpy-message-converter-msgs
+rosx_introspection:
+    ubuntu: ros-humble-rosx-introspection
+rot_conv:
+    ubuntu: ros-humble-rot-conv
+rplidar_ros:
+    ubuntu: ros-humble-rplidar-ros
+rpyutils:
+    ubuntu: ros-humble-rpyutils
+rqt:
+    ubuntu: ros-humble-rqt
+rqt_gui:
+    ubuntu: ros-humble-rqt-gui
+rqt_gui_cpp:
+    ubuntu: ros-humble-rqt-gui-cpp
+rqt_gui_py:
+    ubuntu: ros-humble-rqt-gui-py
+rqt_py_common:
+    ubuntu: ros-humble-rqt-py-common
+rqt_action:
+    ubuntu: ros-humble-rqt-action
+rqt_bag:
+    ubuntu: ros-humble-rqt-bag
+rqt_bag_plugins:
+    ubuntu: ros-humble-rqt-bag-plugins
+rqt_common_plugins:
+    ubuntu: ros-humble-rqt-common-plugins
+rqt_console:
+    ubuntu: ros-humble-rqt-console
+rqt_dotgraph:
+    ubuntu: ros-humble-rqt-dotgraph
+rqt_gauges:
+    ubuntu: ros-humble-rqt-gauges
+rqt_graph:
+    ubuntu: ros-humble-rqt-graph
+rqt_image_overlay:
+    ubuntu: ros-humble-rqt-image-overlay
+rqt_image_overlay_layer:
+    ubuntu: ros-humble-rqt-image-overlay-layer
+rqt_image_view:
+    ubuntu: ros-humble-rqt-image-view
+rqt_moveit:
+    ubuntu: ros-humble-rqt-moveit
+rqt_msg:
+    ubuntu: ros-humble-rqt-msg
+rqt_plot:
+    ubuntu: ros-humble-rqt-plot
+rqt_publisher:
+    ubuntu: ros-humble-rqt-publisher
+rqt_py_console:
+    ubuntu: ros-humble-rqt-py-console
+rqt_reconfigure:
+    ubuntu: ros-humble-rqt-reconfigure
+rqt_robot_dashboard:
+    ubuntu: ros-humble-rqt-robot-dashboard
+rqt_robot_monitor:
+    ubuntu: ros-humble-rqt-robot-monitor
+rqt_robot_steering:
+    ubuntu: ros-humble-rqt-robot-steering
+rqt_runtime_monitor:
+    ubuntu: ros-humble-rqt-runtime-monitor
+rqt_service_caller:
+    ubuntu: ros-humble-rqt-service-caller
+rqt_shell:
+    ubuntu: ros-humble-rqt-shell
+rqt_srv:
+    ubuntu: ros-humble-rqt-srv
+rqt_tf_tree:
+    ubuntu: ros-humble-rqt-tf-tree
+rqt_topic:
+    ubuntu: ros-humble-rqt-topic
+rsl:
+    ubuntu: ros-humble-rsl
+rt_manipulators_cpp:
+    ubuntu: ros-humble-rt-manipulators-cpp
+rt_manipulators_examples:
+    ubuntu: ros-humble-rt-manipulators-examples
+rt_usb_9axisimu_driver:
+    ubuntu: ros-humble-rt-usb-9axisimu-driver
+rtabmap:
+    ubuntu: ros-humble-rtabmap
+rtabmap_conversions:
+    ubuntu: ros-humble-rtabmap-conversions
+rtabmap_demos:
+    ubuntu: ros-humble-rtabmap-demos
+rtabmap_examples:
+    ubuntu: ros-humble-rtabmap-examples
+rtabmap_launch:
+    ubuntu: ros-humble-rtabmap-launch
+rtabmap_msgs:
+    ubuntu: ros-humble-rtabmap-msgs
+rtabmap_odom:
+    ubuntu: ros-humble-rtabmap-odom
+rtabmap_python:
+    ubuntu: ros-humble-rtabmap-python
+rtabmap_ros:
+    ubuntu: ros-humble-rtabmap-ros
+rtabmap_rviz_plugins:
+    ubuntu: ros-humble-rtabmap-rviz-plugins
+rtabmap_slam:
+    ubuntu: ros-humble-rtabmap-slam
+rtabmap_sync:
+    ubuntu: ros-humble-rtabmap-sync
+rtabmap_util:
+    ubuntu: ros-humble-rtabmap-util
+rtabmap_viz:
+    ubuntu: ros-humble-rtabmap-viz
+rtcm_msgs:
+    ubuntu: ros-humble-rtcm-msgs
+ruckig:
+    ubuntu: ros-humble-ruckig
+rviz2:
+    ubuntu: ros-humble-rviz2
+rviz_assimp_vendor:
+    ubuntu: ros-humble-rviz-assimp-vendor
+rviz_common:
+    ubuntu: ros-humble-rviz-common
+rviz_default_plugins:
+    ubuntu: ros-humble-rviz-default-plugins
+rviz_ogre_vendor:
+    ubuntu: ros-humble-rviz-ogre-vendor
+rviz_rendering:
+    ubuntu: ros-humble-rviz-rendering
+rviz_rendering_tests:
+    ubuntu: ros-humble-rviz-rendering-tests
+rviz_visual_testing_framework:
+    ubuntu: ros-humble-rviz-visual-testing-framework
+rviz_2d_overlay_msgs:
+    ubuntu: ros-humble-rviz-2d-overlay-msgs
+rviz_2d_overlay_plugins:
+    ubuntu: ros-humble-rviz-2d-overlay-plugins
+rviz_satellite:
+    ubuntu: ros-humble-rviz-satellite
+rviz_visual_tools:
+    ubuntu: ros-humble-rviz-visual-tools
+sbg_driver:
+    ubuntu: ros-humble-sbg-driver
+scenario_execution:
+    ubuntu: ros-humble-scenario-execution
+scenario_execution_control:
+    ubuntu: ros-humble-scenario-execution-control
+scenario_execution_coverage:
+    ubuntu: ros-humble-scenario-execution-coverage
+scenario_execution_gazebo:
+    ubuntu: ros-humble-scenario-execution-gazebo
+scenario_execution_interfaces:
+    ubuntu: ros-humble-scenario-execution-interfaces
+scenario_execution_nav2:
+    ubuntu: ros-humble-scenario-execution-nav2
+scenario_execution_os:
+    ubuntu: ros-humble-scenario-execution-os
+scenario_execution_py_trees_ros:
+    ubuntu: ros-humble-scenario-execution-py-trees-ros
+scenario_execution_ros:
+    ubuntu: ros-humble-scenario-execution-ros
+scenario_execution_rviz:
+    ubuntu: ros-humble-scenario-execution-rviz
+scenario_execution_x11:
+    ubuntu: ros-humble-scenario-execution-x11
+schunk_svh_library:
+    ubuntu: ros-humble-schunk-svh-library
+schunk_svh_description:
+    ubuntu: ros-humble-schunk-svh-description
+schunk_svh_driver:
+    ubuntu: ros-humble-schunk-svh-driver
+schunk_svh_tests:
+    ubuntu: ros-humble-schunk-svh-tests
+sdformat_test_files:
+    ubuntu: ros-humble-sdformat-test-files
+sdformat_urdf:
+    ubuntu: ros-humble-sdformat-urdf
+septentrio_gnss_driver:
+    ubuntu: ros-humble-septentrio-gnss-driver
+sick_safetyscanners2:
+    ubuntu: ros-humble-sick-safetyscanners2
+sick_safetyscanners2_interfaces:
+    ubuntu: ros-humble-sick-safetyscanners2-interfaces
+sick_safetyscanners_base:
+    ubuntu: ros-humble-sick-safetyscanners-base
+sick_safevisionary_base:
+    ubuntu: ros-humble-sick-safevisionary-base
+sick_safevisionary_driver:
+    ubuntu: ros-humble-sick-safevisionary-driver
+sick_safevisionary_interfaces:
+    ubuntu: ros-humble-sick-safevisionary-interfaces
+sick_safevisionary_tests:
+    ubuntu: ros-humble-sick-safevisionary-tests
+sick_scan_xd:
+    ubuntu: ros-humble-sick-scan-xd
+sicks300_2:
+    ubuntu: ros-humble-sicks300-2
+simple_actions:
+    ubuntu: ros-humble-simple-actions
+simple_grasping:
+    ubuntu: ros-humble-simple-grasping
+simple_launch:
+    ubuntu: ros-humble-simple-launch
+simple_term_menu_vendor:
+    ubuntu: ros-humble-simple-term-menu-vendor
+situational_graphs_datasets:
+    ubuntu: ros-humble-situational-graphs-datasets
+situational_graphs_msgs:
+    ubuntu: ros-humble-situational-graphs-msgs
+situational_graphs_reasoning:
+    ubuntu: ros-humble-situational-graphs-reasoning
+situational_graphs_reasoning_msgs:
+    ubuntu: ros-humble-situational-graphs-reasoning-msgs
+situational_graphs_wrapper:
+    ubuntu: ros-humble-situational-graphs-wrapper
+slam_toolbox:
+    ubuntu: ros-humble-slam-toolbox
+slg_msgs:
+    ubuntu: ros-humble-slg-msgs
+slider_publisher:
+    ubuntu: ros-humble-slider-publisher
+smacc2:
+    ubuntu: ros-humble-smacc2
+smacc2_msgs:
+    ubuntu: ros-humble-smacc2-msgs
+executive_smach:
+    ubuntu: ros-humble-executive-smach
+smach:
+    ubuntu: ros-humble-smach
+smach_msgs:
+    ubuntu: ros-humble-smach-msgs
+smach_ros:
+    ubuntu: ros-humble-smach-ros
+snowbot_operating_system:
+    ubuntu: ros-humble-snowbot-operating-system
+soar_ros:
+    ubuntu: ros-humble-soar-ros
+soccer_interfaces:
+    ubuntu: ros-humble-soccer-interfaces
+soccer_vision_2d_msgs:
+    ubuntu: ros-humble-soccer-vision-2d-msgs
+soccer_vision_3d_msgs:
+    ubuntu: ros-humble-soccer-vision-3d-msgs
+soccer_vision_attribute_msgs:
+    ubuntu: ros-humble-soccer-vision-attribute-msgs
+soccer_object_msgs:
+    ubuntu: ros-humble-soccer-object-msgs
+soccer_marker_generation:
+    ubuntu: ros-humble-soccer-marker-generation
+social_nav_msgs:
+    ubuntu: ros-humble-social-nav-msgs
+social_nav_util:
+    ubuntu: ros-humble-social-nav-util
+sol_vendor:
+    ubuntu: ros-humble-sol-vendor
+sophus:
+    ubuntu: ros-humble-sophus
+openvdb_vendor:
+    ubuntu: ros-humble-openvdb-vendor
+spatio_temporal_voxel_layer:
+    ubuntu: ros-humble-spatio-temporal-voxel-layer
+spdlog_vendor:
+    ubuntu: ros-humble-spdlog-vendor
+srdfdom:
+    ubuntu: ros-humble-srdfdom
+sros2:
+    ubuntu: ros-humble-sros2
+sros2_cmake:
+    ubuntu: ros-humble-sros2-cmake
+stcamera_ros2:
+    ubuntu: ros-humble-stcamera-ros2
+stomp:
+    ubuntu: ros-humble-stomp
+stubborn_buddies:
+    ubuntu: ros-humble-stubborn-buddies
+stubborn_buddies_msgs:
+    ubuntu: ros-humble-stubborn-buddies-msgs
+swri_console:
+    ubuntu: ros-humble-swri-console
+sync_parameter_server:
+    ubuntu: ros-humble-sync-parameter-server
+system_fingerprint:
+    ubuntu: ros-humble-system-fingerprint
+launch_system_modes:
+    ubuntu: ros-humble-launch-system-modes
+system_modes:
+    ubuntu: ros-humble-system-modes
+system_modes_examples:
+    ubuntu: ros-humble-system-modes-examples
+system_modes_msgs:
+    ubuntu: ros-humble-system-modes-msgs
+system_tests:
+    ubuntu: ros-humble-system-tests
+talos_moveit_config:
+    ubuntu: ros-humble-talos-moveit-config
+talos_bringup:
+    ubuntu: ros-humble-talos-bringup
+talos_controller_configuration:
+    ubuntu: ros-humble-talos-controller-configuration
+talos_description:
+    ubuntu: ros-humble-talos-description
+talos_description_calibration:
+    ubuntu: ros-humble-talos-description-calibration
+talos_description_inertial:
+    ubuntu: ros-humble-talos-description-inertial
+talos_robot:
+    ubuntu: ros-humble-talos-robot
+talos_gazebo:
+    ubuntu: ros-humble-talos-gazebo
+tango_icons_vendor:
+    ubuntu: ros-humble-tango-icons-vendor
+joy_teleop:
+    ubuntu: ros-humble-joy-teleop
+key_teleop:
+    ubuntu: ros-humble-key-teleop
+mouse_teleop:
+    ubuntu: ros-humble-mouse-teleop
+teleop_tools:
+    ubuntu: ros-humble-teleop-tools
+teleop_tools_msgs:
+    ubuntu: ros-humble-teleop-tools-msgs
+teleop_twist_joy:
+    ubuntu: ros-humble-teleop-twist-joy
+teleop_twist_keyboard:
+    ubuntu: ros-humble-teleop-twist-keyboard
+tensorrt_cmake_module:
+    ubuntu: ros-humble-tensorrt-cmake-module
+test_interface_files:
+    ubuntu: ros-humble-test-interface-files
+tf_transformations:
+    ubuntu: ros-humble-tf-transformations
+the_navigation_gauntlet:
+    ubuntu: ros-humble-the-navigation-gauntlet
+tiago_moveit_config:
+    ubuntu: ros-humble-tiago-moveit-config
+tiago_2dnav:
+    ubuntu: ros-humble-tiago-2dnav
+tiago_laser_sensors:
+    ubuntu: ros-humble-tiago-laser-sensors
+tiago_navigation:
+    ubuntu: ros-humble-tiago-navigation
+tiago_bringup:
+    ubuntu: ros-humble-tiago-bringup
+tiago_controller_configuration:
+    ubuntu: ros-humble-tiago-controller-configuration
+tiago_description:
+    ubuntu: ros-humble-tiago-description
+tiago_robot:
+    ubuntu: ros-humble-tiago-robot
+tiago_gazebo:
+    ubuntu: ros-humble-tiago-gazebo
+tiago_simulation:
+    ubuntu: ros-humble-tiago-simulation
+tinyspline_vendor:
+    ubuntu: ros-humble-tinyspline-vendor
+tinyxml2_vendor:
+    ubuntu: ros-humble-tinyxml2-vendor
+tinyxml_vendor:
+    ubuntu: ros-humble-tinyxml-vendor
+tlsf:
+    ubuntu: ros-humble-tlsf
+topic_based_ros2_control:
+    ubuntu: ros-humble-topic-based-ros2-control
+topic_tools:
+    ubuntu: ros-humble-topic-tools
+topic_tools_interfaces:
+    ubuntu: ros-humble-topic-tools-interfaces
+tracetools_acceleration:
+    ubuntu: ros-humble-tracetools-acceleration
+ros2trace_analysis:
+    ubuntu: ros-humble-ros2trace-analysis
+tracetools_analysis:
+    ubuntu: ros-humble-tracetools-analysis
+asio_cmake_module:
+    ubuntu: ros-humble-asio-cmake-module
+io_context:
+    ubuntu: ros-humble-io-context
+serial_driver:
+    ubuntu: ros-humble-serial-driver
+udp_driver:
+    ubuntu: ros-humble-udp-driver
+turbojpeg_compressed_image_transport:
+    ubuntu: ros-humble-turbojpeg-compressed-image-transport
+turtle_nest:
+    ubuntu: ros-humble-turtle-nest
+turtlebot3:
+    ubuntu: ros-humble-turtlebot3
+turtlebot3_bringup:
+    ubuntu: ros-humble-turtlebot3-bringup
+turtlebot3_cartographer:
+    ubuntu: ros-humble-turtlebot3-cartographer
+turtlebot3_description:
+    ubuntu: ros-humble-turtlebot3-description
+turtlebot3_example:
+    ubuntu: ros-humble-turtlebot3-example
+turtlebot3_navigation2:
+    ubuntu: ros-humble-turtlebot3-navigation2
+turtlebot3_node:
+    ubuntu: ros-humble-turtlebot3-node
+turtlebot3_teleop:
+    ubuntu: ros-humble-turtlebot3-teleop
+turtlebot3_manipulation:
+    ubuntu: ros-humble-turtlebot3-manipulation
+turtlebot3_manipulation_bringup:
+    ubuntu: ros-humble-turtlebot3-manipulation-bringup
+turtlebot3_manipulation_cartographer:
+    ubuntu: ros-humble-turtlebot3-manipulation-cartographer
+turtlebot3_manipulation_description:
+    ubuntu: ros-humble-turtlebot3-manipulation-description
+turtlebot3_manipulation_hardware:
+    ubuntu: ros-humble-turtlebot3-manipulation-hardware
+turtlebot3_manipulation_moveit_config:
+    ubuntu: ros-humble-turtlebot3-manipulation-moveit-config
+turtlebot3_manipulation_navigation2:
+    ubuntu: ros-humble-turtlebot3-manipulation-navigation2
+turtlebot3_manipulation_teleop:
+    ubuntu: ros-humble-turtlebot3-manipulation-teleop
+turtlebot3_msgs:
+    ubuntu: ros-humble-turtlebot3-msgs
+turtlebot3_fake_node:
+    ubuntu: ros-humble-turtlebot3-fake-node
+turtlebot3_gazebo:
+    ubuntu: ros-humble-turtlebot3-gazebo
+turtlebot3_simulations:
+    ubuntu: ros-humble-turtlebot3-simulations
+turtlebot4_description:
+    ubuntu: ros-humble-turtlebot4-description
+turtlebot4_msgs:
+    ubuntu: ros-humble-turtlebot4-msgs
+turtlebot4_navigation:
+    ubuntu: ros-humble-turtlebot4-navigation
+turtlebot4_node:
+    ubuntu: ros-humble-turtlebot4-node
+turtlebot4_desktop:
+    ubuntu: ros-humble-turtlebot4-desktop
+turtlebot4_viz:
+    ubuntu: ros-humble-turtlebot4-viz
+turtlebot4_base:
+    ubuntu: ros-humble-turtlebot4-base
+turtlebot4_bringup:
+    ubuntu: ros-humble-turtlebot4-bringup
+turtlebot4_diagnostics:
+    ubuntu: ros-humble-turtlebot4-diagnostics
+turtlebot4_robot:
+    ubuntu: ros-humble-turtlebot4-robot
+turtlebot4_tests:
+    ubuntu: ros-humble-turtlebot4-tests
+turtlebot4_setup:
+    ubuntu: ros-humble-turtlebot4-setup
+turtlebot4_ignition_bringup:
+    ubuntu: ros-humble-turtlebot4-ignition-bringup
+turtlebot4_ignition_gui_plugins:
+    ubuntu: ros-humble-turtlebot4-ignition-gui-plugins
+turtlebot4_ignition_toolbox:
+    ubuntu: ros-humble-turtlebot4-ignition-toolbox
+turtlebot4_simulator:
+    ubuntu: ros-humble-turtlebot4-simulator
+turtlebot4_cpp_tutorials:
+    ubuntu: ros-humble-turtlebot4-cpp-tutorials
+turtlebot4_python_tutorials:
+    ubuntu: ros-humble-turtlebot4-python-tutorials
+turtlebot4_tutorials:
+    ubuntu: ros-humble-turtlebot4-tutorials
+tuw_geometry:
+    ubuntu: ros-humble-tuw-geometry
+tuw_airskin_msgs:
+    ubuntu: ros-humble-tuw-airskin-msgs
+tuw_geo_msgs:
+    ubuntu: ros-humble-tuw-geo-msgs
+tuw_geometry_msgs:
+    ubuntu: ros-humble-tuw-geometry-msgs
+tuw_graph_msgs:
+    ubuntu: ros-humble-tuw-graph-msgs
+tuw_msgs:
+    ubuntu: ros-humble-tuw-msgs
+tuw_multi_robot_msgs:
+    ubuntu: ros-humble-tuw-multi-robot-msgs
+tuw_nav_msgs:
+    ubuntu: ros-humble-tuw-nav-msgs
+tuw_object_map_msgs:
+    ubuntu: ros-humble-tuw-object-map-msgs
+tuw_object_msgs:
+    ubuntu: ros-humble-tuw-object-msgs
+tuw_std_msgs:
+    ubuntu: ros-humble-tuw-std-msgs
+tvm_vendor:
+    ubuntu: ros-humble-tvm-vendor
+twist_mux:
+    ubuntu: ros-humble-twist-mux
+twist_mux_msgs:
+    ubuntu: ros-humble-twist-mux-msgs
+twist_stamper:
+    ubuntu: ros-humble-twist-stamper
+ublox:
+    ubuntu: ros-humble-ublox
+ublox_gps:
+    ubuntu: ros-humble-ublox-gps
+ublox_msgs:
+    ubuntu: ros-humble-ublox-msgs
+ublox_serialization:
+    ubuntu: ros-humble-ublox-serialization
+ntrip_client_node:
+    ubuntu: ros-humble-ntrip-client-node
+ublox_dgnss:
+    ubuntu: ros-humble-ublox-dgnss
+ublox_dgnss_node:
+    ubuntu: ros-humble-ublox-dgnss-node
+ublox_nav_sat_fix_hp_node:
+    ubuntu: ros-humble-ublox-nav-sat-fix-hp-node
+ublox_ubx_interfaces:
+    ubuntu: ros-humble-ublox-ubx-interfaces
+ublox_ubx_msgs:
+    ubuntu: ros-humble-ublox-ubx-msgs
+udp_msgs:
+    ubuntu: ros-humble-udp-msgs
+uncrustify_vendor:
+    ubuntu: ros-humble-uncrustify-vendor
+unique_identifier_msgs:
+    ubuntu: ros-humble-unique-identifier-msgs
+unitree_ros:
+    ubuntu: ros-humble-unitree-ros
+ur_client_library:
+    ubuntu: ros-humble-ur-client-library
+ur_description:
+    ubuntu: ros-humble-ur-description
+ur_msgs:
+    ubuntu: ros-humble-ur-msgs
+ur:
+    ubuntu: ros-humble-ur
+ur_bringup:
+    ubuntu: ros-humble-ur-bringup
+ur_calibration:
+    ubuntu: ros-humble-ur-calibration
+ur_controllers:
+    ubuntu: ros-humble-ur-controllers
+ur_dashboard_msgs:
+    ubuntu: ros-humble-ur-dashboard-msgs
+ur_moveit_config:
+    ubuntu: ros-humble-ur-moveit-config
+ur_robot_driver:
+    ubuntu: ros-humble-ur-robot-driver
+ur_simulation_gz:
+    ubuntu: ros-humble-ur-simulation-gz
+urdf:
+    ubuntu: ros-humble-urdf
+urdf_parser_plugin:
+    ubuntu: ros-humble-urdf-parser-plugin
+urdf_launch:
+    ubuntu: ros-humble-urdf-launch
+urdfdom_py:
+    ubuntu: ros-humble-urdfdom-py
+urdf_sim_tutorial:
+    ubuntu: ros-humble-urdf-sim-tutorial
+urdf_test:
+    ubuntu: ros-humble-urdf-test
+urdf_tutorial:
+    ubuntu: ros-humble-urdf-tutorial
+urdfdom:
+    ubuntu: ros-humble-urdfdom
+urdfdom_headers:
+    ubuntu: ros-humble-urdfdom-headers
+urg_c:
+    ubuntu: ros-humble-urg-c
+urg_node:
+    ubuntu: ros-humble-urg-node
+urg_node_msgs:
+    ubuntu: ros-humble-urg-node-msgs
+usb_cam:
+    ubuntu: ros-humble-usb-cam
+v4l2_camera:
+    ubuntu: ros-humble-v4l2-camera
+desktop:
+    ubuntu: ros-humble-desktop
+desktop_full:
+    ubuntu: ros-humble-desktop-full
+perception:
+    ubuntu: ros-humble-perception
+ros_base:
+    ubuntu: ros-humble-ros-base
+ros_core:
+    ubuntu: ros-humble-ros-core
+simulation:
+    ubuntu: ros-humble-simulation
+vector_pursuit_controller:
+    ubuntu: ros-humble-vector-pursuit-controller
+velodyne:
+    ubuntu: ros-humble-velodyne
+velodyne_driver:
+    ubuntu: ros-humble-velodyne-driver
+velodyne_laserscan:
+    ubuntu: ros-humble-velodyne-laserscan
+velodyne_msgs:
+    ubuntu: ros-humble-velodyne-msgs
+velodyne_pointcloud:
+    ubuntu: ros-humble-velodyne-pointcloud
+velodyne_description:
+    ubuntu: ros-humble-velodyne-description
+velodyne_gazebo_plugins:
+    ubuntu: ros-humble-velodyne-gazebo-plugins
+velodyne_simulator:
+    ubuntu: ros-humble-velodyne-simulator
+vimbax_camera:
+    ubuntu: ros-humble-vimbax-camera
+vimbax_camera_events:
+    ubuntu: ros-humble-vimbax-camera-events
+vimbax_camera_examples:
+    ubuntu: ros-humble-vimbax-camera-examples
+vimbax_camera_msgs:
+    ubuntu: ros-humble-vimbax-camera-msgs
+vmbc_interface:
+    ubuntu: ros-humble-vmbc-interface
+vision_msgs:
+    ubuntu: ros-humble-vision-msgs
+vision_msgs_rviz_plugins:
+    ubuntu: ros-humble-vision-msgs-rviz-plugins
+vision_msgs_layers:
+    ubuntu: ros-humble-vision-msgs-layers
+cv_bridge:
+    ubuntu: ros-humble-cv-bridge
+image_geometry:
+    ubuntu: ros-humble-image-geometry
+vision_opencv:
+    ubuntu: ros-humble-vision-opencv
+visp:
+    ubuntu: ros-humble-visp
+vitis_common:
+    ubuntu: ros-humble-vitis-common
+vizanti:
+    ubuntu: ros-humble-vizanti
+vrpn:
+    ubuntu: ros-humble-vrpn
+vrpn_mocap:
+    ubuntu: ros-humble-vrpn-mocap
+wall_follower_ros2:
+    ubuntu: ros-humble-wall-follower-ros2
+warehouse_ros:
+    ubuntu: ros-humble-warehouse-ros
+warehouse_ros_mongo:
+    ubuntu: ros-humble-warehouse-ros-mongo
+warehouse_ros_sqlite:
+    ubuntu: ros-humble-warehouse-ros-sqlite
+web_video_server:
+    ubuntu: ros-humble-web-video-server
+webots_ros2:
+    ubuntu: ros-humble-webots-ros2
+webots_ros2_control:
+    ubuntu: ros-humble-webots-ros2-control
+webots_ros2_driver:
+    ubuntu: ros-humble-webots-ros2-driver
+webots_ros2_epuck:
+    ubuntu: ros-humble-webots-ros2-epuck
+webots_ros2_importer:
+    ubuntu: ros-humble-webots-ros2-importer
+webots_ros2_mavic:
+    ubuntu: ros-humble-webots-ros2-mavic
+webots_ros2_msgs:
+    ubuntu: ros-humble-webots-ros2-msgs
+webots_ros2_tesla:
+    ubuntu: ros-humble-webots-ros2-tesla
+webots_ros2_tests:
+    ubuntu: ros-humble-webots-ros2-tests
+webots_ros2_tiago:
+    ubuntu: ros-humble-webots-ros2-tiago
+webots_ros2_turtlebot:
+    ubuntu: ros-humble-webots-ros2-turtlebot
+webots_ros2_universal_robot:
+    ubuntu: ros-humble-webots-ros2-universal-robot
+weight_scale_interfaces:
+    ubuntu: ros-humble-weight-scale-interfaces
+whill:
+    ubuntu: ros-humble-whill
+whill_msgs:
+    ubuntu: ros-humble-whill-msgs
+wireless_msgs:
+    ubuntu: ros-humble-wireless-msgs
+wireless_watcher:
+    ubuntu: ros-humble-wireless-watcher
+wrapyfi_ros2_interfaces:
+    ubuntu: ros-humble-wrapyfi-ros2-interfaces
+xacro:
+    ubuntu: ros-humble-xacro
+yaml_cpp_vendor:
+    ubuntu: ros-humble-yaml-cpp-vendor
+yasmin:
+    ubuntu: ros-humble-yasmin
+yasmin_demos:
+    ubuntu: ros-humble-yasmin-demos
+yasmin_msgs:
+    ubuntu: ros-humble-yasmin-msgs
+yasmin_ros:
+    ubuntu: ros-humble-yasmin-ros
+yasmin_viewer:
+    ubuntu: ros-humble-yasmin-viewer
+zbar_ros:
+    ubuntu: ros-humble-zbar-ros
+zed_msgs:
+    ubuntu: ros-humble-zed-msgs
+zenoh_bridge_dds:
+    ubuntu: ros-humble-zenoh-bridge-dds
+zmqpp_vendor:
+    ubuntu: ros-humble-zmqpp-vendor

--- a/ros.osdeps-humble
+++ b/ros.osdeps-humble
@@ -2,6 +2,8 @@
 # This file is generated, do not edit!
 # based on https://raw.githubusercontent.com/ros/rosdistro/refs/heads/master/humble/distribution.yaml
 #
+# If you need a refresh, call autoproj reconfigure or delete just this file and run autoproj update --config
+#
 aandd_ekew_driver_py:
     ubuntu: ros-humble-aandd-ekew-driver-py
 acado_vendor:

--- a/ros.osdeps-jazzy
+++ b/ros.osdeps-jazzy
@@ -2,6 +2,8 @@
 # This file is generated, do not edit!
 # based on https://raw.githubusercontent.com/ros/rosdistro/refs/heads/master/jazzy/distribution.yaml
 #
+# If you need a refresh, call autoproj reconfigure or delete just this file and run autoproj update --config
+#
 smacc2:
     ubuntu: ros-jazzy-smacc2
 smacc2_msgs:

--- a/ros.osdeps-jazzy
+++ b/ros.osdeps-jazzy
@@ -1,0 +1,3072 @@
+#
+# This file is generated, do not edit!
+# based on https://raw.githubusercontent.com/ros/rosdistro/refs/heads/master/jazzy/distribution.yaml
+#
+smacc2:
+    ubuntu: ros-jazzy-smacc2
+smacc2_msgs:
+    ubuntu: ros-jazzy-smacc2-msgs
+acado_vendor:
+    ubuntu: ros-jazzy-acado-vendor
+ackermann_msgs:
+    ubuntu: ros-jazzy-ackermann-msgs
+actuator_msgs:
+    ubuntu: ros-jazzy-actuator-msgs
+adaptive_component:
+    ubuntu: ros-jazzy-adaptive-component
+ai_prompt_msgs:
+    ubuntu: ros-jazzy-ai-prompt-msgs
+ament_acceleration:
+    ubuntu: ros-jazzy-ament-acceleration
+ament_black:
+    ubuntu: ros-jazzy-ament-black
+ament_cmake_black:
+    ubuntu: ros-jazzy-ament-cmake-black
+ament_cmake:
+    ubuntu: ros-jazzy-ament-cmake
+ament_cmake_auto:
+    ubuntu: ros-jazzy-ament-cmake-auto
+ament_cmake_core:
+    ubuntu: ros-jazzy-ament-cmake-core
+ament_cmake_export_definitions:
+    ubuntu: ros-jazzy-ament-cmake-export-definitions
+ament_cmake_export_dependencies:
+    ubuntu: ros-jazzy-ament-cmake-export-dependencies
+ament_cmake_export_include_directories:
+    ubuntu: ros-jazzy-ament-cmake-export-include-directories
+ament_cmake_export_interfaces:
+    ubuntu: ros-jazzy-ament-cmake-export-interfaces
+ament_cmake_export_libraries:
+    ubuntu: ros-jazzy-ament-cmake-export-libraries
+ament_cmake_export_link_flags:
+    ubuntu: ros-jazzy-ament-cmake-export-link-flags
+ament_cmake_export_targets:
+    ubuntu: ros-jazzy-ament-cmake-export-targets
+ament_cmake_gen_version_h:
+    ubuntu: ros-jazzy-ament-cmake-gen-version-h
+ament_cmake_gmock:
+    ubuntu: ros-jazzy-ament-cmake-gmock
+ament_cmake_google_benchmark:
+    ubuntu: ros-jazzy-ament-cmake-google-benchmark
+ament_cmake_gtest:
+    ubuntu: ros-jazzy-ament-cmake-gtest
+ament_cmake_include_directories:
+    ubuntu: ros-jazzy-ament-cmake-include-directories
+ament_cmake_libraries:
+    ubuntu: ros-jazzy-ament-cmake-libraries
+ament_cmake_pytest:
+    ubuntu: ros-jazzy-ament-cmake-pytest
+ament_cmake_python:
+    ubuntu: ros-jazzy-ament-cmake-python
+ament_cmake_target_dependencies:
+    ubuntu: ros-jazzy-ament-cmake-target-dependencies
+ament_cmake_test:
+    ubuntu: ros-jazzy-ament-cmake-test
+ament_cmake_vendor_package:
+    ubuntu: ros-jazzy-ament-cmake-vendor-package
+ament_cmake_version:
+    ubuntu: ros-jazzy-ament-cmake-version
+ament_cmake_catch2:
+    ubuntu: ros-jazzy-ament-cmake-catch2
+ament_cmake_ros:
+    ubuntu: ros-jazzy-ament-cmake-ros
+domain_coordinator:
+    ubuntu: ros-jazzy-domain-coordinator
+ament_download:
+    ubuntu: ros-jazzy-ament-download
+ament_index_cpp:
+    ubuntu: ros-jazzy-ament-index-cpp
+ament_index_python:
+    ubuntu: ros-jazzy-ament-index-python
+ament_clang_format:
+    ubuntu: ros-jazzy-ament-clang-format
+ament_clang_tidy:
+    ubuntu: ros-jazzy-ament-clang-tidy
+ament_cmake_clang_format:
+    ubuntu: ros-jazzy-ament-cmake-clang-format
+ament_cmake_clang_tidy:
+    ubuntu: ros-jazzy-ament-cmake-clang-tidy
+ament_cmake_copyright:
+    ubuntu: ros-jazzy-ament-cmake-copyright
+ament_cmake_cppcheck:
+    ubuntu: ros-jazzy-ament-cmake-cppcheck
+ament_cmake_cpplint:
+    ubuntu: ros-jazzy-ament-cmake-cpplint
+ament_cmake_flake8:
+    ubuntu: ros-jazzy-ament-cmake-flake8
+ament_cmake_lint_cmake:
+    ubuntu: ros-jazzy-ament-cmake-lint-cmake
+ament_cmake_mypy:
+    ubuntu: ros-jazzy-ament-cmake-mypy
+ament_cmake_pclint:
+    ubuntu: ros-jazzy-ament-cmake-pclint
+ament_cmake_pep257:
+    ubuntu: ros-jazzy-ament-cmake-pep257
+ament_cmake_pycodestyle:
+    ubuntu: ros-jazzy-ament-cmake-pycodestyle
+ament_cmake_pyflakes:
+    ubuntu: ros-jazzy-ament-cmake-pyflakes
+ament_cmake_uncrustify:
+    ubuntu: ros-jazzy-ament-cmake-uncrustify
+ament_cmake_xmllint:
+    ubuntu: ros-jazzy-ament-cmake-xmllint
+ament_copyright:
+    ubuntu: ros-jazzy-ament-copyright
+ament_cppcheck:
+    ubuntu: ros-jazzy-ament-cppcheck
+ament_cpplint:
+    ubuntu: ros-jazzy-ament-cpplint
+ament_flake8:
+    ubuntu: ros-jazzy-ament-flake8
+ament_lint:
+    ubuntu: ros-jazzy-ament-lint
+ament_lint_auto:
+    ubuntu: ros-jazzy-ament-lint-auto
+ament_lint_cmake:
+    ubuntu: ros-jazzy-ament-lint-cmake
+ament_lint_common:
+    ubuntu: ros-jazzy-ament-lint-common
+ament_mypy:
+    ubuntu: ros-jazzy-ament-mypy
+ament_pclint:
+    ubuntu: ros-jazzy-ament-pclint
+ament_pep257:
+    ubuntu: ros-jazzy-ament-pep257
+ament_pycodestyle:
+    ubuntu: ros-jazzy-ament-pycodestyle
+ament_pyflakes:
+    ubuntu: ros-jazzy-ament-pyflakes
+ament_uncrustify:
+    ubuntu: ros-jazzy-ament-uncrustify
+ament_xmllint:
+    ubuntu: ros-jazzy-ament-xmllint
+ament_nodl:
+    ubuntu: ros-jazzy-ament-nodl
+ament_package:
+    ubuntu: ros-jazzy-ament-package
+ament_vitis:
+    ubuntu: ros-jazzy-ament-vitis
+angles:
+    ubuntu: ros-jazzy-angles
+apex_test_tools:
+    ubuntu: ros-jazzy-apex-test-tools
+test_apex_test_tools:
+    ubuntu: ros-jazzy-test-apex-test-tools
+apriltag:
+    ubuntu: ros-jazzy-apriltag
+apriltag_detector:
+    ubuntu: ros-jazzy-apriltag-detector
+apriltag_mit:
+    ubuntu: ros-jazzy-apriltag-mit
+apriltag_msgs:
+    ubuntu: ros-jazzy-apriltag-msgs
+apriltag_ros:
+    ubuntu: ros-jazzy-apriltag-ros
+ar4_ros_driver:
+    ubuntu: ros-jazzy-ar4-ros-driver
+aruco_opencv:
+    ubuntu: ros-jazzy-aruco-opencv
+aruco_opencv_msgs:
+    ubuntu: ros-jazzy-aruco-opencv-msgs
+aruco:
+    ubuntu: ros-jazzy-aruco
+aruco_msgs:
+    ubuntu: ros-jazzy-aruco-msgs
+aruco_ros:
+    ubuntu: ros-jazzy-aruco-ros
+delphi_esr_msgs:
+    ubuntu: ros-jazzy-delphi-esr-msgs
+delphi_mrr_msgs:
+    ubuntu: ros-jazzy-delphi-mrr-msgs
+delphi_srr_msgs:
+    ubuntu: ros-jazzy-delphi-srr-msgs
+derived_object_msgs:
+    ubuntu: ros-jazzy-derived-object-msgs
+ibeo_msgs:
+    ubuntu: ros-jazzy-ibeo-msgs
+kartech_linear_actuator_msgs:
+    ubuntu: ros-jazzy-kartech-linear-actuator-msgs
+mobileye_560_660_msgs:
+    ubuntu: ros-jazzy-mobileye-560-660-msgs
+neobotix_usboard_msgs:
+    ubuntu: ros-jazzy-neobotix-usboard-msgs
+async_web_server_cpp:
+    ubuntu: ros-jazzy-async-web-server-cpp
+asyncapi_gencpp:
+    ubuntu: ros-jazzy-asyncapi-gencpp
+automatika_ros_sugar:
+    ubuntu: ros-jazzy-automatika-ros-sugar
+automotive_autonomy_msgs:
+    ubuntu: ros-jazzy-automotive-autonomy-msgs
+automotive_navigation_msgs:
+    ubuntu: ros-jazzy-automotive-navigation-msgs
+automotive_platform_msgs:
+    ubuntu: ros-jazzy-automotive-platform-msgs
+autoware_adapi_v1_msgs:
+    ubuntu: ros-jazzy-autoware-adapi-v1-msgs
+autoware_adapi_version_msgs:
+    ubuntu: ros-jazzy-autoware-adapi-version-msgs
+autoware_auto_msgs:
+    ubuntu: ros-jazzy-autoware-auto-msgs
+autoware_cmake:
+    ubuntu: ros-jazzy-autoware-cmake
+autoware_lint_common:
+    ubuntu: ros-jazzy-autoware-lint-common
+autoware_internal_debug_msgs:
+    ubuntu: ros-jazzy-autoware-internal-debug-msgs
+autoware_internal_msgs:
+    ubuntu: ros-jazzy-autoware-internal-msgs
+autoware_internal_perception_msgs:
+    ubuntu: ros-jazzy-autoware-internal-perception-msgs
+autoware_lanelet2_extension:
+    ubuntu: ros-jazzy-autoware-lanelet2-extension
+autoware_lanelet2_extension_python:
+    ubuntu: ros-jazzy-autoware-lanelet2-extension-python
+autoware_common_msgs:
+    ubuntu: ros-jazzy-autoware-common-msgs
+autoware_control_msgs:
+    ubuntu: ros-jazzy-autoware-control-msgs
+autoware_localization_msgs:
+    ubuntu: ros-jazzy-autoware-localization-msgs
+autoware_map_msgs:
+    ubuntu: ros-jazzy-autoware-map-msgs
+autoware_perception_msgs:
+    ubuntu: ros-jazzy-autoware-perception-msgs
+autoware_planning_msgs:
+    ubuntu: ros-jazzy-autoware-planning-msgs
+autoware_sensing_msgs:
+    ubuntu: ros-jazzy-autoware-sensing-msgs
+autoware_system_msgs:
+    ubuntu: ros-jazzy-autoware-system-msgs
+autoware_v2x_msgs:
+    ubuntu: ros-jazzy-autoware-v2x-msgs
+autoware_vehicle_msgs:
+    ubuntu: ros-jazzy-autoware-vehicle-msgs
+autoware_utils:
+    ubuntu: ros-jazzy-autoware-utils
+avt_vimba_camera:
+    ubuntu: ros-jazzy-avt-vimba-camera
+aws_robomaker_small_warehouse_world:
+    ubuntu: ros-jazzy-aws-robomaker-small-warehouse-world
+aws_sdk_cpp_vendor:
+    ubuntu: ros-jazzy-aws-sdk-cpp-vendor
+axis_camera:
+    ubuntu: ros-jazzy-axis-camera
+axis_description:
+    ubuntu: ros-jazzy-axis-description
+axis_msgs:
+    ubuntu: ros-jazzy-axis-msgs
+azure_iot_sdk_c:
+    ubuntu: ros-jazzy-azure-iot-sdk-c
+backward_ros:
+    ubuntu: ros-jazzy-backward-ros
+bag2_to_image:
+    ubuntu: ros-jazzy-bag2-to-image
+behaviortree_cpp_v3:
+    ubuntu: ros-jazzy-behaviortree-cpp-v3
+behaviortree_cpp:
+    ubuntu: ros-jazzy-behaviortree-cpp
+beluga:
+    ubuntu: ros-jazzy-beluga
+beluga_amcl:
+    ubuntu: ros-jazzy-beluga-amcl
+beluga_ros:
+    ubuntu: ros-jazzy-beluga-ros
+bno055:
+    ubuntu: ros-jazzy-bno055
+bond:
+    ubuntu: ros-jazzy-bond
+bond_core:
+    ubuntu: ros-jazzy-bond-core
+bondcpp:
+    ubuntu: ros-jazzy-bondcpp
+bondpy:
+    ubuntu: ros-jazzy-bondpy
+smclib:
+    ubuntu: ros-jazzy-smclib
+boost_geometry_util:
+    ubuntu: ros-jazzy-boost-geometry-util
+boost_plugin_loader:
+    ubuntu: ros-jazzy-boost-plugin-loader
+boost_sml_vendor:
+    ubuntu: ros-jazzy-boost-sml-vendor
+camera_aravis2:
+    ubuntu: ros-jazzy-camera-aravis2
+camera_aravis2_msgs:
+    ubuntu: ros-jazzy-camera-aravis2-msgs
+camera_ros:
+    ubuntu: ros-jazzy-camera-ros
+cartographer:
+    ubuntu: ros-jazzy-cartographer
+cartographer_ros:
+    ubuntu: ros-jazzy-cartographer-ros
+cartographer_ros_msgs:
+    ubuntu: ros-jazzy-cartographer-ros-msgs
+cartographer_rviz:
+    ubuntu: ros-jazzy-cartographer-rviz
+cascade_lifecycle_msgs:
+    ubuntu: ros-jazzy-cascade-lifecycle-msgs
+rclcpp_cascade_lifecycle:
+    ubuntu: ros-jazzy-rclcpp-cascade-lifecycle
+catch_ros2:
+    ubuntu: ros-jazzy-catch-ros2
+class_loader:
+    ubuntu: ros-jazzy-class-loader
+classic_bags:
+    ubuntu: ros-jazzy-classic-bags
+clearpath_motor_msgs:
+    ubuntu: ros-jazzy-clearpath-motor-msgs
+clearpath_msgs:
+    ubuntu: ros-jazzy-clearpath-msgs
+clearpath_platform_msgs:
+    ubuntu: ros-jazzy-clearpath-platform-msgs
+clearpath_ros2_socketcan_interface:
+    ubuntu: ros-jazzy-clearpath-ros2-socketcan-interface
+clips_vendor:
+    ubuntu: ros-jazzy-clips-vendor
+coal:
+    ubuntu: ros-jazzy-coal
+color_names:
+    ubuntu: ros-jazzy-color-names
+color_util:
+    ubuntu: ros-jazzy-color-util
+actionlib_msgs:
+    ubuntu: ros-jazzy-actionlib-msgs
+common_interfaces:
+    ubuntu: ros-jazzy-common-interfaces
+diagnostic_msgs:
+    ubuntu: ros-jazzy-diagnostic-msgs
+geometry_msgs:
+    ubuntu: ros-jazzy-geometry-msgs
+nav_msgs:
+    ubuntu: ros-jazzy-nav-msgs
+sensor_msgs:
+    ubuntu: ros-jazzy-sensor-msgs
+sensor_msgs_py:
+    ubuntu: ros-jazzy-sensor-msgs-py
+shape_msgs:
+    ubuntu: ros-jazzy-shape-msgs
+std_msgs:
+    ubuntu: ros-jazzy-std-msgs
+std_srvs:
+    ubuntu: ros-jazzy-std-srvs
+stereo_msgs:
+    ubuntu: ros-jazzy-stereo-msgs
+trajectory_msgs:
+    ubuntu: ros-jazzy-trajectory-msgs
+visualization_msgs:
+    ubuntu: ros-jazzy-visualization-msgs
+console_bridge_vendor:
+    ubuntu: ros-jazzy-console-bridge-vendor
+control_box_rst:
+    ubuntu: ros-jazzy-control-box-rst
+control_msgs:
+    ubuntu: ros-jazzy-control-msgs
+control_toolbox:
+    ubuntu: ros-jazzy-control-toolbox
+tcb_span:
+    ubuntu: ros-jazzy-tcb-span
+tl_expected:
+    ubuntu: ros-jazzy-tl-expected
+create3_coverage:
+    ubuntu: ros-jazzy-create3-coverage
+create3_examples_msgs:
+    ubuntu: ros-jazzy-create3-examples-msgs
+create3_examples_py:
+    ubuntu: ros-jazzy-create3-examples-py
+create3_lidar_slam:
+    ubuntu: ros-jazzy-create3-lidar-slam
+create3_republisher:
+    ubuntu: ros-jazzy-create3-republisher
+create3_teleop:
+    ubuntu: ros-jazzy-create3-teleop
+irobot_create_common_bringup:
+    ubuntu: ros-jazzy-irobot-create-common-bringup
+irobot_create_control:
+    ubuntu: ros-jazzy-irobot-create-control
+irobot_create_description:
+    ubuntu: ros-jazzy-irobot-create-description
+irobot_create_gz_bringup:
+    ubuntu: ros-jazzy-irobot-create-gz-bringup
+irobot_create_gz_plugins:
+    ubuntu: ros-jazzy-irobot-create-gz-plugins
+irobot_create_gz_sim:
+    ubuntu: ros-jazzy-irobot-create-gz-sim
+irobot_create_gz_toolbox:
+    ubuntu: ros-jazzy-irobot-create-gz-toolbox
+irobot_create_nodes:
+    ubuntu: ros-jazzy-irobot-create-nodes
+irobot_create_toolbox:
+    ubuntu: ros-jazzy-irobot-create-toolbox
+cudnn_cmake_module:
+    ubuntu: ros-jazzy-cudnn-cmake-module
+cyclonedds:
+    ubuntu: ros-jazzy-cyclonedds
+data_tamer_cpp:
+    ubuntu: ros-jazzy-data-tamer-cpp
+data_tamer_msgs:
+    ubuntu: ros-jazzy-data-tamer-msgs
+dataspeed_can:
+    ubuntu: ros-jazzy-dataspeed-can
+dataspeed_can_msg_filters:
+    ubuntu: ros-jazzy-dataspeed-can-msg-filters
+dataspeed_can_msgs:
+    ubuntu: ros-jazzy-dataspeed-can-msgs
+dataspeed_can_tools:
+    ubuntu: ros-jazzy-dataspeed-can-tools
+dataspeed_can_usb:
+    ubuntu: ros-jazzy-dataspeed-can-usb
+ds_dbw:
+    ubuntu: ros-jazzy-ds-dbw
+ds_dbw_can:
+    ubuntu: ros-jazzy-ds-dbw-can
+ds_dbw_joystick_demo:
+    ubuntu: ros-jazzy-ds-dbw-joystick-demo
+ds_dbw_msgs:
+    ubuntu: ros-jazzy-ds-dbw-msgs
+action_tutorials_cpp:
+    ubuntu: ros-jazzy-action-tutorials-cpp
+action_tutorials_interfaces:
+    ubuntu: ros-jazzy-action-tutorials-interfaces
+action_tutorials_py:
+    ubuntu: ros-jazzy-action-tutorials-py
+composition:
+    ubuntu: ros-jazzy-composition
+demo_nodes_cpp:
+    ubuntu: ros-jazzy-demo-nodes-cpp
+demo_nodes_cpp_native:
+    ubuntu: ros-jazzy-demo-nodes-cpp-native
+demo_nodes_py:
+    ubuntu: ros-jazzy-demo-nodes-py
+dummy_map_server:
+    ubuntu: ros-jazzy-dummy-map-server
+dummy_robot_bringup:
+    ubuntu: ros-jazzy-dummy-robot-bringup
+dummy_sensors:
+    ubuntu: ros-jazzy-dummy-sensors
+image_tools:
+    ubuntu: ros-jazzy-image-tools
+intra_process_demo:
+    ubuntu: ros-jazzy-intra-process-demo
+lifecycle:
+    ubuntu: ros-jazzy-lifecycle
+lifecycle_py:
+    ubuntu: ros-jazzy-lifecycle-py
+logging_demo:
+    ubuntu: ros-jazzy-logging-demo
+pendulum_control:
+    ubuntu: ros-jazzy-pendulum-control
+pendulum_msgs:
+    ubuntu: ros-jazzy-pendulum-msgs
+quality_of_service_demo_cpp:
+    ubuntu: ros-jazzy-quality-of-service-demo-cpp
+quality_of_service_demo_py:
+    ubuntu: ros-jazzy-quality-of-service-demo-py
+topic_monitor:
+    ubuntu: ros-jazzy-topic-monitor
+topic_statistics_demo:
+    ubuntu: ros-jazzy-topic-statistics-demo
+depthai:
+    ubuntu: ros-jazzy-depthai
+depthai-ros:
+    ubuntu: ros-jazzy-depthai-ros
+depthai_bridge:
+    ubuntu: ros-jazzy-depthai-bridge
+depthai_descriptions:
+    ubuntu: ros-jazzy-depthai-descriptions
+depthai_examples:
+    ubuntu: ros-jazzy-depthai-examples
+depthai_filters:
+    ubuntu: ros-jazzy-depthai-filters
+depthai_ros_driver:
+    ubuntu: ros-jazzy-depthai-ros-driver
+depthai_ros_msgs:
+    ubuntu: ros-jazzy-depthai-ros-msgs
+depthimage_to_laserscan:
+    ubuntu: ros-jazzy-depthimage-to-laserscan
+diagnostic_aggregator:
+    ubuntu: ros-jazzy-diagnostic-aggregator
+diagnostic_common_diagnostics:
+    ubuntu: ros-jazzy-diagnostic-common-diagnostics
+diagnostic_updater:
+    ubuntu: ros-jazzy-diagnostic-updater
+diagnostics:
+    ubuntu: ros-jazzy-diagnostics
+self_test:
+    ubuntu: ros-jazzy-self-test
+dolly:
+    ubuntu: ros-jazzy-dolly
+dolly_follow:
+    ubuntu: ros-jazzy-dolly-follow
+dolly_gazebo:
+    ubuntu: ros-jazzy-dolly-gazebo
+dolly_ignition:
+    ubuntu: ros-jazzy-dolly-ignition
+domain_bridge:
+    ubuntu: ros-jazzy-domain-bridge
+dual_laser_merger:
+    ubuntu: ros-jazzy-dual-laser-merger
+dynamixel_hardware:
+    ubuntu: ros-jazzy-dynamixel-hardware
+dynamixel_sdk:
+    ubuntu: ros-jazzy-dynamixel-sdk
+dynamixel_sdk_custom_interfaces:
+    ubuntu: ros-jazzy-dynamixel-sdk-custom-interfaces
+dynamixel_sdk_examples:
+    ubuntu: ros-jazzy-dynamixel-sdk-examples
+dynamixel_workbench:
+    ubuntu: ros-jazzy-dynamixel-workbench
+dynamixel_workbench_toolbox:
+    ubuntu: ros-jazzy-dynamixel-workbench-toolbox
+dynamixel_workbench_msgs:
+    ubuntu: ros-jazzy-dynamixel-workbench-msgs
+ecal:
+    ubuntu: ros-jazzy-ecal
+ecl_command_line:
+    ubuntu: ros-jazzy-ecl-command-line
+ecl_concepts:
+    ubuntu: ros-jazzy-ecl-concepts
+ecl_containers:
+    ubuntu: ros-jazzy-ecl-containers
+ecl_converters:
+    ubuntu: ros-jazzy-ecl-converters
+ecl_core:
+    ubuntu: ros-jazzy-ecl-core
+ecl_core_apps:
+    ubuntu: ros-jazzy-ecl-core-apps
+ecl_devices:
+    ubuntu: ros-jazzy-ecl-devices
+ecl_eigen:
+    ubuntu: ros-jazzy-ecl-eigen
+ecl_exceptions:
+    ubuntu: ros-jazzy-ecl-exceptions
+ecl_filesystem:
+    ubuntu: ros-jazzy-ecl-filesystem
+ecl_formatters:
+    ubuntu: ros-jazzy-ecl-formatters
+ecl_geometry:
+    ubuntu: ros-jazzy-ecl-geometry
+ecl_ipc:
+    ubuntu: ros-jazzy-ecl-ipc
+ecl_linear_algebra:
+    ubuntu: ros-jazzy-ecl-linear-algebra
+ecl_manipulators:
+    ubuntu: ros-jazzy-ecl-manipulators
+ecl_math:
+    ubuntu: ros-jazzy-ecl-math
+ecl_mobile_robot:
+    ubuntu: ros-jazzy-ecl-mobile-robot
+ecl_mpl:
+    ubuntu: ros-jazzy-ecl-mpl
+ecl_sigslots:
+    ubuntu: ros-jazzy-ecl-sigslots
+ecl_statistics:
+    ubuntu: ros-jazzy-ecl-statistics
+ecl_streams:
+    ubuntu: ros-jazzy-ecl-streams
+ecl_threads:
+    ubuntu: ros-jazzy-ecl-threads
+ecl_time:
+    ubuntu: ros-jazzy-ecl-time
+ecl_type_traits:
+    ubuntu: ros-jazzy-ecl-type-traits
+ecl_utilities:
+    ubuntu: ros-jazzy-ecl-utilities
+ecl_config:
+    ubuntu: ros-jazzy-ecl-config
+ecl_console:
+    ubuntu: ros-jazzy-ecl-console
+ecl_converters_lite:
+    ubuntu: ros-jazzy-ecl-converters-lite
+ecl_errors:
+    ubuntu: ros-jazzy-ecl-errors
+ecl_io:
+    ubuntu: ros-jazzy-ecl-io
+ecl_lite:
+    ubuntu: ros-jazzy-ecl-lite
+ecl_sigslots_lite:
+    ubuntu: ros-jazzy-ecl-sigslots-lite
+ecl_time_lite:
+    ubuntu: ros-jazzy-ecl-time-lite
+ecl_build:
+    ubuntu: ros-jazzy-ecl-build
+ecl_license:
+    ubuntu: ros-jazzy-ecl-license
+ecl_tools:
+    ubuntu: ros-jazzy-ecl-tools
+eigen3_cmake_module:
+    ubuntu: ros-jazzy-eigen3-cmake-module
+eigen_stl_containers:
+    ubuntu: ros-jazzy-eigen-stl-containers
+eigenpy:
+    ubuntu: ros-jazzy-eigenpy
+eiquadprog:
+    ubuntu: ros-jazzy-eiquadprog
+ess_imu_driver2:
+    ubuntu: ros-jazzy-ess-imu-driver2
+etsi_its_cam_coding:
+    ubuntu: ros-jazzy-etsi-its-cam-coding
+etsi_its_cam_conversion:
+    ubuntu: ros-jazzy-etsi-its-cam-conversion
+etsi_its_cam_msgs:
+    ubuntu: ros-jazzy-etsi-its-cam-msgs
+etsi_its_cam_ts_coding:
+    ubuntu: ros-jazzy-etsi-its-cam-ts-coding
+etsi_its_cam_ts_conversion:
+    ubuntu: ros-jazzy-etsi-its-cam-ts-conversion
+etsi_its_cam_ts_msgs:
+    ubuntu: ros-jazzy-etsi-its-cam-ts-msgs
+etsi_its_coding:
+    ubuntu: ros-jazzy-etsi-its-coding
+etsi_its_conversion:
+    ubuntu: ros-jazzy-etsi-its-conversion
+etsi_its_cpm_ts_coding:
+    ubuntu: ros-jazzy-etsi-its-cpm-ts-coding
+etsi_its_cpm_ts_conversion:
+    ubuntu: ros-jazzy-etsi-its-cpm-ts-conversion
+etsi_its_cpm_ts_msgs:
+    ubuntu: ros-jazzy-etsi-its-cpm-ts-msgs
+etsi_its_denm_coding:
+    ubuntu: ros-jazzy-etsi-its-denm-coding
+etsi_its_denm_conversion:
+    ubuntu: ros-jazzy-etsi-its-denm-conversion
+etsi_its_denm_msgs:
+    ubuntu: ros-jazzy-etsi-its-denm-msgs
+etsi_its_mapem_ts_coding:
+    ubuntu: ros-jazzy-etsi-its-mapem-ts-coding
+etsi_its_mapem_ts_conversion:
+    ubuntu: ros-jazzy-etsi-its-mapem-ts-conversion
+etsi_its_mapem_ts_msgs:
+    ubuntu: ros-jazzy-etsi-its-mapem-ts-msgs
+etsi_its_messages:
+    ubuntu: ros-jazzy-etsi-its-messages
+etsi_its_msgs:
+    ubuntu: ros-jazzy-etsi-its-msgs
+etsi_its_msgs_utils:
+    ubuntu: ros-jazzy-etsi-its-msgs-utils
+etsi_its_primitives_conversion:
+    ubuntu: ros-jazzy-etsi-its-primitives-conversion
+etsi_its_rviz_plugins:
+    ubuntu: ros-jazzy-etsi-its-rviz-plugins
+etsi_its_spatem_ts_coding:
+    ubuntu: ros-jazzy-etsi-its-spatem-ts-coding
+etsi_its_spatem_ts_conversion:
+    ubuntu: ros-jazzy-etsi-its-spatem-ts-conversion
+etsi_its_spatem_ts_msgs:
+    ubuntu: ros-jazzy-etsi-its-spatem-ts-msgs
+etsi_its_vam_ts_coding:
+    ubuntu: ros-jazzy-etsi-its-vam-ts-coding
+etsi_its_vam_ts_conversion:
+    ubuntu: ros-jazzy-etsi-its-vam-ts-conversion
+etsi_its_vam_ts_msgs:
+    ubuntu: ros-jazzy-etsi-its-vam-ts-msgs
+event_camera_codecs:
+    ubuntu: ros-jazzy-event-camera-codecs
+event_camera_msgs:
+    ubuntu: ros-jazzy-event-camera-msgs
+event_camera_py:
+    ubuntu: ros-jazzy-event-camera-py
+event_camera_renderer:
+    ubuntu: ros-jazzy-event-camera-renderer
+example_interfaces:
+    ubuntu: ros-jazzy-example-interfaces
+examples_rclcpp_async_client:
+    ubuntu: ros-jazzy-examples-rclcpp-async-client
+examples_rclcpp_cbg_executor:
+    ubuntu: ros-jazzy-examples-rclcpp-cbg-executor
+examples_rclcpp_minimal_action_client:
+    ubuntu: ros-jazzy-examples-rclcpp-minimal-action-client
+examples_rclcpp_minimal_action_server:
+    ubuntu: ros-jazzy-examples-rclcpp-minimal-action-server
+examples_rclcpp_minimal_client:
+    ubuntu: ros-jazzy-examples-rclcpp-minimal-client
+examples_rclcpp_minimal_composition:
+    ubuntu: ros-jazzy-examples-rclcpp-minimal-composition
+examples_rclcpp_minimal_publisher:
+    ubuntu: ros-jazzy-examples-rclcpp-minimal-publisher
+examples_rclcpp_minimal_service:
+    ubuntu: ros-jazzy-examples-rclcpp-minimal-service
+examples_rclcpp_minimal_subscriber:
+    ubuntu: ros-jazzy-examples-rclcpp-minimal-subscriber
+examples_rclcpp_minimal_timer:
+    ubuntu: ros-jazzy-examples-rclcpp-minimal-timer
+examples_rclcpp_multithreaded_executor:
+    ubuntu: ros-jazzy-examples-rclcpp-multithreaded-executor
+examples_rclcpp_wait_set:
+    ubuntu: ros-jazzy-examples-rclcpp-wait-set
+examples_rclpy_executors:
+    ubuntu: ros-jazzy-examples-rclpy-executors
+examples_rclpy_guard_conditions:
+    ubuntu: ros-jazzy-examples-rclpy-guard-conditions
+examples_rclpy_minimal_action_client:
+    ubuntu: ros-jazzy-examples-rclpy-minimal-action-client
+examples_rclpy_minimal_action_server:
+    ubuntu: ros-jazzy-examples-rclpy-minimal-action-server
+examples_rclpy_minimal_client:
+    ubuntu: ros-jazzy-examples-rclpy-minimal-client
+examples_rclpy_minimal_publisher:
+    ubuntu: ros-jazzy-examples-rclpy-minimal-publisher
+examples_rclpy_minimal_service:
+    ubuntu: ros-jazzy-examples-rclpy-minimal-service
+examples_rclpy_minimal_subscriber:
+    ubuntu: ros-jazzy-examples-rclpy-minimal-subscriber
+examples_rclpy_pointcloud_publisher:
+    ubuntu: ros-jazzy-examples-rclpy-pointcloud-publisher
+launch_testing_examples:
+    ubuntu: ros-jazzy-launch-testing-examples
+fastcdr:
+    ubuntu: ros-jazzy-fastcdr
+fastrtps:
+    ubuntu: ros-jazzy-fastrtps
+feetech_ros2_driver:
+    ubuntu: ros-jazzy-feetech-ros2-driver
+ffmpeg_encoder_decoder:
+    ubuntu: ros-jazzy-ffmpeg-encoder-decoder
+ffmpeg_image_transport:
+    ubuntu: ros-jazzy-ffmpeg-image-transport
+ffmpeg_image_transport_msgs:
+    ubuntu: ros-jazzy-ffmpeg-image-transport-msgs
+ffmpeg_image_transport_tools:
+    ubuntu: ros-jazzy-ffmpeg-image-transport-tools
+fields2cover:
+    ubuntu: ros-jazzy-fields2cover
+filters:
+    ubuntu: ros-jazzy-filters
+find_object_2d:
+    ubuntu: ros-jazzy-find-object-2d
+flex_sync:
+    ubuntu: ros-jazzy-flex-sync
+flexbe_behavior_engine:
+    ubuntu: ros-jazzy-flexbe-behavior-engine
+flexbe_core:
+    ubuntu: ros-jazzy-flexbe-core
+flexbe_input:
+    ubuntu: ros-jazzy-flexbe-input
+flexbe_mirror:
+    ubuntu: ros-jazzy-flexbe-mirror
+flexbe_msgs:
+    ubuntu: ros-jazzy-flexbe-msgs
+flexbe_onboard:
+    ubuntu: ros-jazzy-flexbe-onboard
+flexbe_states:
+    ubuntu: ros-jazzy-flexbe-states
+flexbe_testing:
+    ubuntu: ros-jazzy-flexbe-testing
+flexbe_widget:
+    ubuntu: ros-jazzy-flexbe-widget
+flir_camera_description:
+    ubuntu: ros-jazzy-flir-camera-description
+flir_camera_msgs:
+    ubuntu: ros-jazzy-flir-camera-msgs
+spinnaker_camera_driver:
+    ubuntu: ros-jazzy-spinnaker-camera-driver
+spinnaker_synchronized_camera_driver:
+    ubuntu: ros-jazzy-spinnaker-synchronized-camera-driver
+fluent_rviz:
+    ubuntu: ros-jazzy-fluent-rviz
+fmi_adapter:
+    ubuntu: ros-jazzy-fmi-adapter
+fmi_adapter_examples:
+    ubuntu: ros-jazzy-fmi-adapter-examples
+fmilibrary_vendor:
+    ubuntu: ros-jazzy-fmilibrary-vendor
+foonathan_memory_vendor:
+    ubuntu: ros-jazzy-foonathan-memory-vendor
+four_wheel_steering_msgs:
+    ubuntu: ros-jazzy-four-wheel-steering-msgs
+foxglove_bridge:
+    ubuntu: ros-jazzy-foxglove-bridge
+foxglove_compressed_video_transport:
+    ubuntu: ros-jazzy-foxglove-compressed-video-transport
+foxglove_msgs:
+    ubuntu: ros-jazzy-foxglove-msgs
+fuse:
+    ubuntu: ros-jazzy-fuse
+fuse_constraints:
+    ubuntu: ros-jazzy-fuse-constraints
+fuse_core:
+    ubuntu: ros-jazzy-fuse-core
+fuse_doc:
+    ubuntu: ros-jazzy-fuse-doc
+fuse_graphs:
+    ubuntu: ros-jazzy-fuse-graphs
+fuse_loss:
+    ubuntu: ros-jazzy-fuse-loss
+fuse_models:
+    ubuntu: ros-jazzy-fuse-models
+fuse_msgs:
+    ubuntu: ros-jazzy-fuse-msgs
+fuse_optimizers:
+    ubuntu: ros-jazzy-fuse-optimizers
+fuse_publishers:
+    ubuntu: ros-jazzy-fuse-publishers
+fuse_tutorials:
+    ubuntu: ros-jazzy-fuse-tutorials
+fuse_variables:
+    ubuntu: ros-jazzy-fuse-variables
+fuse_viz:
+    ubuntu: ros-jazzy-fuse-viz
+game_controller_spl:
+    ubuntu: ros-jazzy-game-controller-spl
+game_controller_spl_interfaces:
+    ubuntu: ros-jazzy-game-controller-spl-interfaces
+gc_spl:
+    ubuntu: ros-jazzy-gc-spl
+gc_spl_2022:
+    ubuntu: ros-jazzy-gc-spl-2022
+gc_spl_interfaces:
+    ubuntu: ros-jazzy-gc-spl-interfaces
+rcgcd_spl_14:
+    ubuntu: ros-jazzy-rcgcd-spl-14
+rcgcd_spl_14_conversion:
+    ubuntu: ros-jazzy-rcgcd-spl-14-conversion
+rcgcrd_spl_4:
+    ubuntu: ros-jazzy-rcgcrd-spl-4
+rcgcrd_spl_4_conversion:
+    ubuntu: ros-jazzy-rcgcrd-spl-4-conversion
+gazebo_msgs:
+    ubuntu: ros-jazzy-gazebo-msgs
+cmake_generate_parameter_module_example:
+    ubuntu: ros-jazzy-cmake-generate-parameter-module-example
+generate_parameter_library:
+    ubuntu: ros-jazzy-generate-parameter-library
+generate_parameter_library_example:
+    ubuntu: ros-jazzy-generate-parameter-library-example
+generate_parameter_library_py:
+    ubuntu: ros-jazzy-generate-parameter-library-py
+generate_parameter_module_example:
+    ubuntu: ros-jazzy-generate-parameter-module-example
+parameter_traits:
+    ubuntu: ros-jazzy-parameter-traits
+geodesy:
+    ubuntu: ros-jazzy-geodesy
+geographic_info:
+    ubuntu: ros-jazzy-geographic-info
+geographic_msgs:
+    ubuntu: ros-jazzy-geographic-msgs
+geometric_shapes:
+    ubuntu: ros-jazzy-geometric-shapes
+examples_tf2_py:
+    ubuntu: ros-jazzy-examples-tf2-py
+geometry2:
+    ubuntu: ros-jazzy-geometry2
+tf2:
+    ubuntu: ros-jazzy-tf2
+tf2_bullet:
+    ubuntu: ros-jazzy-tf2-bullet
+tf2_eigen:
+    ubuntu: ros-jazzy-tf2-eigen
+tf2_eigen_kdl:
+    ubuntu: ros-jazzy-tf2-eigen-kdl
+tf2_geometry_msgs:
+    ubuntu: ros-jazzy-tf2-geometry-msgs
+tf2_kdl:
+    ubuntu: ros-jazzy-tf2-kdl
+tf2_msgs:
+    ubuntu: ros-jazzy-tf2-msgs
+tf2_py:
+    ubuntu: ros-jazzy-tf2-py
+tf2_ros:
+    ubuntu: ros-jazzy-tf2-ros
+tf2_ros_py:
+    ubuntu: ros-jazzy-tf2-ros-py
+tf2_sensor_msgs:
+    ubuntu: ros-jazzy-tf2-sensor-msgs
+tf2_tools:
+    ubuntu: ros-jazzy-tf2-tools
+geometry_tutorials:
+    ubuntu: ros-jazzy-geometry-tutorials
+turtle_tf2_cpp:
+    ubuntu: ros-jazzy-turtle-tf2-cpp
+turtle_tf2_py:
+    ubuntu: ros-jazzy-turtle-tf2-py
+google_benchmark_vendor:
+    ubuntu: ros-jazzy-google-benchmark-vendor
+gmock_vendor:
+    ubuntu: ros-jazzy-gmock-vendor
+gtest_vendor:
+    ubuntu: ros-jazzy-gtest-vendor
+gps_msgs:
+    ubuntu: ros-jazzy-gps-msgs
+gps_tools:
+    ubuntu: ros-jazzy-gps-tools
+gps_umd:
+    ubuntu: ros-jazzy-gps-umd
+gpsd_client:
+    ubuntu: ros-jazzy-gpsd-client
+graph_msgs:
+    ubuntu: ros-jazzy-graph-msgs
+grasping_msgs:
+    ubuntu: ros-jazzy-grasping-msgs
+grbl_msgs:
+    ubuntu: ros-jazzy-grbl-msgs
+grbl_ros:
+    ubuntu: ros-jazzy-grbl-ros
+grid_map:
+    ubuntu: ros-jazzy-grid-map
+grid_map_cmake_helpers:
+    ubuntu: ros-jazzy-grid-map-cmake-helpers
+grid_map_core:
+    ubuntu: ros-jazzy-grid-map-core
+grid_map_costmap_2d:
+    ubuntu: ros-jazzy-grid-map-costmap-2d
+grid_map_cv:
+    ubuntu: ros-jazzy-grid-map-cv
+grid_map_demos:
+    ubuntu: ros-jazzy-grid-map-demos
+grid_map_filters:
+    ubuntu: ros-jazzy-grid-map-filters
+grid_map_loader:
+    ubuntu: ros-jazzy-grid-map-loader
+grid_map_msgs:
+    ubuntu: ros-jazzy-grid-map-msgs
+grid_map_octomap:
+    ubuntu: ros-jazzy-grid-map-octomap
+grid_map_pcl:
+    ubuntu: ros-jazzy-grid-map-pcl
+grid_map_ros:
+    ubuntu: ros-jazzy-grid-map-ros
+grid_map_rviz_plugin:
+    ubuntu: ros-jazzy-grid-map-rviz-plugin
+grid_map_sdf:
+    ubuntu: ros-jazzy-grid-map-sdf
+grid_map_visualization:
+    ubuntu: ros-jazzy-grid-map-visualization
+gscam:
+    ubuntu: ros-jazzy-gscam
+gtsam:
+    ubuntu: ros-jazzy-gtsam
+gz_cmake_vendor:
+    ubuntu: ros-jazzy-gz-cmake-vendor
+gz_common_vendor:
+    ubuntu: ros-jazzy-gz-common-vendor
+gz_dartsim_vendor:
+    ubuntu: ros-jazzy-gz-dartsim-vendor
+gz_fuel_tools_vendor:
+    ubuntu: ros-jazzy-gz-fuel-tools-vendor
+gz_gui_vendor:
+    ubuntu: ros-jazzy-gz-gui-vendor
+gz_launch_vendor:
+    ubuntu: ros-jazzy-gz-launch-vendor
+gz_math_vendor:
+    ubuntu: ros-jazzy-gz-math-vendor
+gz_msgs_vendor:
+    ubuntu: ros-jazzy-gz-msgs-vendor
+gz_ogre_next_vendor:
+    ubuntu: ros-jazzy-gz-ogre-next-vendor
+gz_physics_vendor:
+    ubuntu: ros-jazzy-gz-physics-vendor
+gz_plugin_vendor:
+    ubuntu: ros-jazzy-gz-plugin-vendor
+gz_rendering_vendor:
+    ubuntu: ros-jazzy-gz-rendering-vendor
+gz_ros2_control:
+    ubuntu: ros-jazzy-gz-ros2-control
+gz_ros2_control_demos:
+    ubuntu: ros-jazzy-gz-ros2-control-demos
+gz_sensors_vendor:
+    ubuntu: ros-jazzy-gz-sensors-vendor
+gz_sim_vendor:
+    ubuntu: ros-jazzy-gz-sim-vendor
+gz_tools_vendor:
+    ubuntu: ros-jazzy-gz-tools-vendor
+gz_transport_vendor:
+    ubuntu: ros-jazzy-gz-transport-vendor
+gz_utils_vendor:
+    ubuntu: ros-jazzy-gz-utils-vendor
+hash_library_vendor:
+    ubuntu: ros-jazzy-hash-library-vendor
+hatchbed_common:
+    ubuntu: ros-jazzy-hatchbed-common
+heaphook:
+    ubuntu: ros-jazzy-heaphook
+hector_rviz_overlay:
+    ubuntu: ros-jazzy-hector-rviz-overlay
+hls_lfcd_lds_driver:
+    ubuntu: ros-jazzy-hls-lfcd-lds-driver
+hpp-fcl:
+    ubuntu: ros-jazzy-hpp-fcl
+iceoryx_binding_c:
+    ubuntu: ros-jazzy-iceoryx-binding-c
+iceoryx_hoofs:
+    ubuntu: ros-jazzy-iceoryx-hoofs
+iceoryx_introspection:
+    ubuntu: ros-jazzy-iceoryx-introspection
+iceoryx_posh:
+    ubuntu: ros-jazzy-iceoryx-posh
+ifm3d_core:
+    ubuntu: ros-jazzy-ifm3d-core
+ign_rviz:
+    ubuntu: ros-jazzy-ign-rviz
+ign_rviz_common:
+    ubuntu: ros-jazzy-ign-rviz-common
+ign_rviz_plugins:
+    ubuntu: ros-jazzy-ign-rviz-plugins
+camera_calibration_parsers:
+    ubuntu: ros-jazzy-camera-calibration-parsers
+camera_info_manager:
+    ubuntu: ros-jazzy-camera-info-manager
+camera_info_manager_py:
+    ubuntu: ros-jazzy-camera-info-manager-py
+image_common:
+    ubuntu: ros-jazzy-image-common
+image_transport:
+    ubuntu: ros-jazzy-image-transport
+camera_calibration:
+    ubuntu: ros-jazzy-camera-calibration
+depth_image_proc:
+    ubuntu: ros-jazzy-depth-image-proc
+image_pipeline:
+    ubuntu: ros-jazzy-image-pipeline
+image_proc:
+    ubuntu: ros-jazzy-image-proc
+image_publisher:
+    ubuntu: ros-jazzy-image-publisher
+image_rotate:
+    ubuntu: ros-jazzy-image-rotate
+image_view:
+    ubuntu: ros-jazzy-image-view
+stereo_image_proc:
+    ubuntu: ros-jazzy-stereo-image-proc
+tracetools_image_pipeline:
+    ubuntu: ros-jazzy-tracetools-image-pipeline
+compressed_depth_image_transport:
+    ubuntu: ros-jazzy-compressed-depth-image-transport
+compressed_image_transport:
+    ubuntu: ros-jazzy-compressed-image-transport
+image_transport_plugins:
+    ubuntu: ros-jazzy-image-transport-plugins
+theora_image_transport:
+    ubuntu: ros-jazzy-theora-image-transport
+zstd_image_transport:
+    ubuntu: ros-jazzy-zstd-image-transport
+imu_pipeline:
+    ubuntu: ros-jazzy-imu-pipeline
+imu_processors:
+    ubuntu: ros-jazzy-imu-processors
+imu_transformer:
+    ubuntu: ros-jazzy-imu-transformer
+imu_complementary_filter:
+    ubuntu: ros-jazzy-imu-complementary-filter
+imu_filter_madgwick:
+    ubuntu: ros-jazzy-imu-filter-madgwick
+imu_tools:
+    ubuntu: ros-jazzy-imu-tools
+rviz_imu_plugin:
+    ubuntu: ros-jazzy-rviz-imu-plugin
+interactive_marker_twist_server:
+    ubuntu: ros-jazzy-interactive-marker-twist-server
+interactive_markers:
+    ubuntu: ros-jazzy-interactive-markers
+irobot_create_msgs:
+    ubuntu: ros-jazzy-irobot-create-msgs
+jacro:
+    ubuntu: ros-jazzy-jacro
+joint_state_publisher:
+    ubuntu: ros-jazzy-joint-state-publisher
+joint_state_publisher_gui:
+    ubuntu: ros-jazzy-joint-state-publisher-gui
+joy_tester:
+    ubuntu: ros-jazzy-joy-tester
+joy:
+    ubuntu: ros-jazzy-joy
+joy_linux:
+    ubuntu: ros-jazzy-joy-linux
+sdl2_vendor:
+    ubuntu: ros-jazzy-sdl2-vendor
+spacenav:
+    ubuntu: ros-jazzy-spacenav
+wiimote:
+    ubuntu: ros-jazzy-wiimote
+wiimote_msgs:
+    ubuntu: ros-jazzy-wiimote-msgs
+kdl_parser:
+    ubuntu: ros-jazzy-kdl-parser
+keyboard_handler:
+    ubuntu: ros-jazzy-keyboard-handler
+kinematics_interface:
+    ubuntu: ros-jazzy-kinematics-interface
+kinematics_interface_kdl:
+    ubuntu: ros-jazzy-kinematics-interface-kdl
+kinematics_interface_pinocchio:
+    ubuntu: ros-jazzy-kinematics-interface-pinocchio
+kobuki_core:
+    ubuntu: ros-jazzy-kobuki-core
+kobuki_ros_interfaces:
+    ubuntu: ros-jazzy-kobuki-ros-interfaces
+kobuki_velocity_smoother:
+    ubuntu: ros-jazzy-kobuki-velocity-smoother
+kompass:
+    ubuntu: ros-jazzy-kompass
+lanelet2:
+    ubuntu: ros-jazzy-lanelet2
+lanelet2_core:
+    ubuntu: ros-jazzy-lanelet2-core
+lanelet2_examples:
+    ubuntu: ros-jazzy-lanelet2-examples
+lanelet2_io:
+    ubuntu: ros-jazzy-lanelet2-io
+lanelet2_maps:
+    ubuntu: ros-jazzy-lanelet2-maps
+lanelet2_matching:
+    ubuntu: ros-jazzy-lanelet2-matching
+lanelet2_projection:
+    ubuntu: ros-jazzy-lanelet2-projection
+lanelet2_python:
+    ubuntu: ros-jazzy-lanelet2-python
+lanelet2_routing:
+    ubuntu: ros-jazzy-lanelet2-routing
+lanelet2_traffic_rules:
+    ubuntu: ros-jazzy-lanelet2-traffic-rules
+lanelet2_validation:
+    ubuntu: ros-jazzy-lanelet2-validation
+laser_filters:
+    ubuntu: ros-jazzy-laser-filters
+laser_geometry:
+    ubuntu: ros-jazzy-laser-geometry
+laser_proc:
+    ubuntu: ros-jazzy-laser-proc
+launch:
+    ubuntu: ros-jazzy-launch
+launch_pytest:
+    ubuntu: ros-jazzy-launch-pytest
+launch_testing:
+    ubuntu: ros-jazzy-launch-testing
+launch_testing_ament_cmake:
+    ubuntu: ros-jazzy-launch-testing-ament-cmake
+launch_xml:
+    ubuntu: ros-jazzy-launch-xml
+launch_yaml:
+    ubuntu: ros-jazzy-launch-yaml
+launch_param_builder:
+    ubuntu: ros-jazzy-launch-param-builder
+launch_ros:
+    ubuntu: ros-jazzy-launch-ros
+launch_testing_ros:
+    ubuntu: ros-jazzy-launch-testing-ros
+ros2launch:
+    ubuntu: ros-jazzy-ros2launch
+leo:
+    ubuntu: ros-jazzy-leo
+leo_description:
+    ubuntu: ros-jazzy-leo-description
+leo_msgs:
+    ubuntu: ros-jazzy-leo-msgs
+leo_teleop:
+    ubuntu: ros-jazzy-leo-teleop
+leo_desktop:
+    ubuntu: ros-jazzy-leo-desktop
+leo_viz:
+    ubuntu: ros-jazzy-leo-viz
+leo_bringup:
+    ubuntu: ros-jazzy-leo-bringup
+leo_fw:
+    ubuntu: ros-jazzy-leo-fw
+leo_robot:
+    ubuntu: ros-jazzy-leo-robot
+leo_gz_bringup:
+    ubuntu: ros-jazzy-leo-gz-bringup
+leo_gz_plugins:
+    ubuntu: ros-jazzy-leo-gz-plugins
+leo_gz_worlds:
+    ubuntu: ros-jazzy-leo-gz-worlds
+leo_simulator:
+    ubuntu: ros-jazzy-leo-simulator
+lgsvl_msgs:
+    ubuntu: ros-jazzy-lgsvl-msgs
+libcaer:
+    ubuntu: ros-jazzy-libcaer
+libcaer_driver:
+    ubuntu: ros-jazzy-libcaer-driver
+libcaer_vendor:
+    ubuntu: ros-jazzy-libcaer-vendor
+libcamera:
+    ubuntu: ros-jazzy-libcamera
+libg2o:
+    ubuntu: ros-jazzy-libg2o
+libnabo:
+    ubuntu: ros-jazzy-libnabo
+libpointmatcher:
+    ubuntu: ros-jazzy-libpointmatcher
+librealsense2:
+    ubuntu: ros-jazzy-librealsense2
+libstatistics_collector:
+    ubuntu: ros-jazzy-libstatistics-collector
+libyaml_vendor:
+    ubuntu: ros-jazzy-libyaml-vendor
+linux_isolate_process:
+    ubuntu: ros-jazzy-linux-isolate-process
+log_view:
+    ubuntu: ros-jazzy-log-view
+lusb:
+    ubuntu: ros-jazzy-lusb
+magic_enum:
+    ubuntu: ros-jazzy-magic-enum
+mapviz:
+    ubuntu: ros-jazzy-mapviz
+mapviz_interfaces:
+    ubuntu: ros-jazzy-mapviz-interfaces
+mapviz_plugins:
+    ubuntu: ros-jazzy-mapviz-plugins
+multires_image:
+    ubuntu: ros-jazzy-multires-image
+tile_map:
+    ubuntu: ros-jazzy-tile-map
+marine_acoustic_msgs:
+    ubuntu: ros-jazzy-marine-acoustic-msgs
+marine_sensor_msgs:
+    ubuntu: ros-jazzy-marine-sensor-msgs
+marker_msgs:
+    ubuntu: ros-jazzy-marker-msgs
+swri_cli_tools:
+    ubuntu: ros-jazzy-swri-cli-tools
+swri_console_util:
+    ubuntu: ros-jazzy-swri-console-util
+swri_dbw_interface:
+    ubuntu: ros-jazzy-swri-dbw-interface
+swri_geometry_util:
+    ubuntu: ros-jazzy-swri-geometry-util
+swri_image_util:
+    ubuntu: ros-jazzy-swri-image-util
+swri_math_util:
+    ubuntu: ros-jazzy-swri-math-util
+swri_opencv_util:
+    ubuntu: ros-jazzy-swri-opencv-util
+swri_roscpp:
+    ubuntu: ros-jazzy-swri-roscpp
+swri_route_util:
+    ubuntu: ros-jazzy-swri-route-util
+swri_serial_util:
+    ubuntu: ros-jazzy-swri-serial-util
+swri_system_util:
+    ubuntu: ros-jazzy-swri-system-util
+swri_transform_util:
+    ubuntu: ros-jazzy-swri-transform-util
+marti_can_msgs:
+    ubuntu: ros-jazzy-marti-can-msgs
+marti_common_msgs:
+    ubuntu: ros-jazzy-marti-common-msgs
+marti_dbw_msgs:
+    ubuntu: ros-jazzy-marti-dbw-msgs
+marti_introspection_msgs:
+    ubuntu: ros-jazzy-marti-introspection-msgs
+marti_nav_msgs:
+    ubuntu: ros-jazzy-marti-nav-msgs
+marti_perception_msgs:
+    ubuntu: ros-jazzy-marti-perception-msgs
+marti_sensor_msgs:
+    ubuntu: ros-jazzy-marti-sensor-msgs
+marti_status_msgs:
+    ubuntu: ros-jazzy-marti-status-msgs
+marti_visualization_msgs:
+    ubuntu: ros-jazzy-marti-visualization-msgs
+mavlink:
+    ubuntu: ros-jazzy-mavlink
+libmavconn:
+    ubuntu: ros-jazzy-libmavconn
+mavros:
+    ubuntu: ros-jazzy-mavros
+mavros_extras:
+    ubuntu: ros-jazzy-mavros-extras
+mavros_msgs:
+    ubuntu: ros-jazzy-mavros-msgs
+menge_vendor:
+    ubuntu: ros-jazzy-menge-vendor
+message_filters:
+    ubuntu: ros-jazzy-message-filters
+message_tf_frame_transformer:
+    ubuntu: ros-jazzy-message-tf-frame-transformer
+metavision_driver:
+    ubuntu: ros-jazzy-metavision-driver
+micro_ros_diagnostic_bridge:
+    ubuntu: ros-jazzy-micro-ros-diagnostic-bridge
+micro_ros_diagnostic_msgs:
+    ubuntu: ros-jazzy-micro-ros-diagnostic-msgs
+micro_ros_msgs:
+    ubuntu: ros-jazzy-micro-ros-msgs
+microstrain_inertial_description:
+    ubuntu: ros-jazzy-microstrain-inertial-description
+microstrain_inertial_driver:
+    ubuntu: ros-jazzy-microstrain-inertial-driver
+microstrain_inertial_examples:
+    ubuntu: ros-jazzy-microstrain-inertial-examples
+microstrain_inertial_msgs:
+    ubuntu: ros-jazzy-microstrain-inertial-msgs
+microstrain_inertial_rqt:
+    ubuntu: ros-jazzy-microstrain-inertial-rqt
+mimick_vendor:
+    ubuntu: ros-jazzy-mimick-vendor
+mir_robot:
+    ubuntu: ros-jazzy-mir-robot
+kitti_metrics_eval:
+    ubuntu: ros-jazzy-kitti-metrics-eval
+mola:
+    ubuntu: ros-jazzy-mola
+mola_bridge_ros2:
+    ubuntu: ros-jazzy-mola-bridge-ros2
+mola_demos:
+    ubuntu: ros-jazzy-mola-demos
+mola_input_euroc_dataset:
+    ubuntu: ros-jazzy-mola-input-euroc-dataset
+mola_input_kitti360_dataset:
+    ubuntu: ros-jazzy-mola-input-kitti360-dataset
+mola_input_kitti_dataset:
+    ubuntu: ros-jazzy-mola-input-kitti-dataset
+mola_input_mulran_dataset:
+    ubuntu: ros-jazzy-mola-input-mulran-dataset
+mola_input_paris_luco_dataset:
+    ubuntu: ros-jazzy-mola-input-paris-luco-dataset
+mola_input_rawlog:
+    ubuntu: ros-jazzy-mola-input-rawlog
+mola_input_rosbag2:
+    ubuntu: ros-jazzy-mola-input-rosbag2
+mola_kernel:
+    ubuntu: ros-jazzy-mola-kernel
+mola_launcher:
+    ubuntu: ros-jazzy-mola-launcher
+mola_metric_maps:
+    ubuntu: ros-jazzy-mola-metric-maps
+mola_msgs:
+    ubuntu: ros-jazzy-mola-msgs
+mola_pose_list:
+    ubuntu: ros-jazzy-mola-pose-list
+mola_relocalization:
+    ubuntu: ros-jazzy-mola-relocalization
+mola_traj_tools:
+    ubuntu: ros-jazzy-mola-traj-tools
+mola_viz:
+    ubuntu: ros-jazzy-mola-viz
+mola_yaml:
+    ubuntu: ros-jazzy-mola-yaml
+mola_common:
+    ubuntu: ros-jazzy-mola-common
+mola_lidar_odometry:
+    ubuntu: ros-jazzy-mola-lidar-odometry
+mola_imu_preintegration:
+    ubuntu: ros-jazzy-mola-imu-preintegration
+mola_state_estimation:
+    ubuntu: ros-jazzy-mola-state-estimation
+mola_state_estimation_simple:
+    ubuntu: ros-jazzy-mola-state-estimation-simple
+mola_state_estimation_smoother:
+    ubuntu: ros-jazzy-mola-state-estimation-smoother
+mola_test_datasets:
+    ubuntu: ros-jazzy-mola-test-datasets
+motion_capture_tracking:
+    ubuntu: ros-jazzy-motion-capture-tracking
+motion_capture_tracking_interfaces:
+    ubuntu: ros-jazzy-motion-capture-tracking-interfaces
+chomp_motion_planner:
+    ubuntu: ros-jazzy-chomp-motion-planner
+moveit:
+    ubuntu: ros-jazzy-moveit
+moveit_common:
+    ubuntu: ros-jazzy-moveit-common
+moveit_configs_utils:
+    ubuntu: ros-jazzy-moveit-configs-utils
+moveit_core:
+    ubuntu: ros-jazzy-moveit-core
+moveit_hybrid_planning:
+    ubuntu: ros-jazzy-moveit-hybrid-planning
+moveit_kinematics:
+    ubuntu: ros-jazzy-moveit-kinematics
+moveit_planners:
+    ubuntu: ros-jazzy-moveit-planners
+moveit_planners_chomp:
+    ubuntu: ros-jazzy-moveit-planners-chomp
+moveit_planners_ompl:
+    ubuntu: ros-jazzy-moveit-planners-ompl
+moveit_planners_stomp:
+    ubuntu: ros-jazzy-moveit-planners-stomp
+moveit_plugins:
+    ubuntu: ros-jazzy-moveit-plugins
+moveit_py:
+    ubuntu: ros-jazzy-moveit-py
+moveit_resources_prbt_ikfast_manipulator_plugin:
+    ubuntu: ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin
+moveit_resources_prbt_moveit_config:
+    ubuntu: ros-jazzy-moveit-resources-prbt-moveit-config
+moveit_resources_prbt_pg70_support:
+    ubuntu: ros-jazzy-moveit-resources-prbt-pg70-support
+moveit_resources_prbt_support:
+    ubuntu: ros-jazzy-moveit-resources-prbt-support
+moveit_ros:
+    ubuntu: ros-jazzy-moveit-ros
+moveit_ros_benchmarks:
+    ubuntu: ros-jazzy-moveit-ros-benchmarks
+moveit_ros_control_interface:
+    ubuntu: ros-jazzy-moveit-ros-control-interface
+moveit_ros_move_group:
+    ubuntu: ros-jazzy-moveit-ros-move-group
+moveit_ros_occupancy_map_monitor:
+    ubuntu: ros-jazzy-moveit-ros-occupancy-map-monitor
+moveit_ros_perception:
+    ubuntu: ros-jazzy-moveit-ros-perception
+moveit_ros_planning:
+    ubuntu: ros-jazzy-moveit-ros-planning
+moveit_ros_planning_interface:
+    ubuntu: ros-jazzy-moveit-ros-planning-interface
+moveit_ros_robot_interaction:
+    ubuntu: ros-jazzy-moveit-ros-robot-interaction
+moveit_ros_tests:
+    ubuntu: ros-jazzy-moveit-ros-tests
+moveit_ros_trajectory_cache:
+    ubuntu: ros-jazzy-moveit-ros-trajectory-cache
+moveit_ros_visualization:
+    ubuntu: ros-jazzy-moveit-ros-visualization
+moveit_ros_warehouse:
+    ubuntu: ros-jazzy-moveit-ros-warehouse
+moveit_runtime:
+    ubuntu: ros-jazzy-moveit-runtime
+moveit_servo:
+    ubuntu: ros-jazzy-moveit-servo
+moveit_setup_app_plugins:
+    ubuntu: ros-jazzy-moveit-setup-app-plugins
+moveit_setup_assistant:
+    ubuntu: ros-jazzy-moveit-setup-assistant
+moveit_setup_controllers:
+    ubuntu: ros-jazzy-moveit-setup-controllers
+moveit_setup_core_plugins:
+    ubuntu: ros-jazzy-moveit-setup-core-plugins
+moveit_setup_framework:
+    ubuntu: ros-jazzy-moveit-setup-framework
+moveit_setup_srdf_plugins:
+    ubuntu: ros-jazzy-moveit-setup-srdf-plugins
+moveit_simple_controller_manager:
+    ubuntu: ros-jazzy-moveit-simple-controller-manager
+pilz_industrial_motion_planner:
+    ubuntu: ros-jazzy-pilz-industrial-motion-planner
+pilz_industrial_motion_planner_testutils:
+    ubuntu: ros-jazzy-pilz-industrial-motion-planner-testutils
+moveit_msgs:
+    ubuntu: ros-jazzy-moveit-msgs
+dual_arm_panda_moveit_config:
+    ubuntu: ros-jazzy-dual-arm-panda-moveit-config
+moveit_resources:
+    ubuntu: ros-jazzy-moveit-resources
+moveit_resources_fanuc_description:
+    ubuntu: ros-jazzy-moveit-resources-fanuc-description
+moveit_resources_fanuc_moveit_config:
+    ubuntu: ros-jazzy-moveit-resources-fanuc-moveit-config
+moveit_resources_panda_description:
+    ubuntu: ros-jazzy-moveit-resources-panda-description
+moveit_resources_panda_moveit_config:
+    ubuntu: ros-jazzy-moveit-resources-panda-moveit-config
+moveit_resources_pr2_description:
+    ubuntu: ros-jazzy-moveit-resources-pr2-description
+moveit_visual_tools:
+    ubuntu: ros-jazzy-moveit-visual-tools
+mp2p_icp:
+    ubuntu: ros-jazzy-mp2p-icp
+mqtt_client:
+    ubuntu: ros-jazzy-mqtt-client
+mqtt_client_interfaces:
+    ubuntu: ros-jazzy-mqtt-client-interfaces
+mrpt_msgs:
+    ubuntu: ros-jazzy-mrpt-msgs
+mrpt_map_server:
+    ubuntu: ros-jazzy-mrpt-map-server
+mrpt_msgs_bridge:
+    ubuntu: ros-jazzy-mrpt-msgs-bridge
+mrpt_nav_interfaces:
+    ubuntu: ros-jazzy-mrpt-nav-interfaces
+mrpt_navigation:
+    ubuntu: ros-jazzy-mrpt-navigation
+mrpt_pf_localization:
+    ubuntu: ros-jazzy-mrpt-pf-localization
+mrpt_pointcloud_pipeline:
+    ubuntu: ros-jazzy-mrpt-pointcloud-pipeline
+mrpt_rawlog:
+    ubuntu: ros-jazzy-mrpt-rawlog
+mrpt_reactivenav2d:
+    ubuntu: ros-jazzy-mrpt-reactivenav2d
+mrpt_tps_astar_planner:
+    ubuntu: ros-jazzy-mrpt-tps-astar-planner
+mrpt_tutorials:
+    ubuntu: ros-jazzy-mrpt-tutorials
+mrpt_path_planning:
+    ubuntu: ros-jazzy-mrpt-path-planning
+mrpt_apps:
+    ubuntu: ros-jazzy-mrpt-apps
+mrpt_libapps:
+    ubuntu: ros-jazzy-mrpt-libapps
+mrpt_libbase:
+    ubuntu: ros-jazzy-mrpt-libbase
+mrpt_libgui:
+    ubuntu: ros-jazzy-mrpt-libgui
+mrpt_libhwdrivers:
+    ubuntu: ros-jazzy-mrpt-libhwdrivers
+mrpt_libmaps:
+    ubuntu: ros-jazzy-mrpt-libmaps
+mrpt_libmath:
+    ubuntu: ros-jazzy-mrpt-libmath
+mrpt_libnav:
+    ubuntu: ros-jazzy-mrpt-libnav
+mrpt_libobs:
+    ubuntu: ros-jazzy-mrpt-libobs
+mrpt_libopengl:
+    ubuntu: ros-jazzy-mrpt-libopengl
+mrpt_libposes:
+    ubuntu: ros-jazzy-mrpt-libposes
+mrpt_libros_bridge:
+    ubuntu: ros-jazzy-mrpt-libros-bridge
+mrpt_libslam:
+    ubuntu: ros-jazzy-mrpt-libslam
+mrpt_libtclap:
+    ubuntu: ros-jazzy-mrpt-libtclap
+mrpt_generic_sensor:
+    ubuntu: ros-jazzy-mrpt-generic-sensor
+mrpt_sensor_bumblebee_stereo:
+    ubuntu: ros-jazzy-mrpt-sensor-bumblebee-stereo
+mrpt_sensor_gnss_nmea:
+    ubuntu: ros-jazzy-mrpt-sensor-gnss-nmea
+mrpt_sensor_gnss_novatel:
+    ubuntu: ros-jazzy-mrpt-sensor-gnss-novatel
+mrpt_sensor_imu_taobotics:
+    ubuntu: ros-jazzy-mrpt-sensor-imu-taobotics
+mrpt_sensorlib:
+    ubuntu: ros-jazzy-mrpt-sensorlib
+mrpt_sensors:
+    ubuntu: ros-jazzy-mrpt-sensors
+mrt_cmake_modules:
+    ubuntu: ros-jazzy-mrt-cmake-modules
+mvsim:
+    ubuntu: ros-jazzy-mvsim
+nao_button_sim:
+    ubuntu: ros-jazzy-nao-button-sim
+nao_command_msgs:
+    ubuntu: ros-jazzy-nao-command-msgs
+nao_sensor_msgs:
+    ubuntu: ros-jazzy-nao-sensor-msgs
+nao_lola:
+    ubuntu: ros-jazzy-nao-lola
+nao_lola_client:
+    ubuntu: ros-jazzy-nao-lola-client
+nao_lola_command_msgs:
+    ubuntu: ros-jazzy-nao-lola-command-msgs
+nao_lola_sensor_msgs:
+    ubuntu: ros-jazzy-nao-lola-sensor-msgs
+nav2_minimal_tb3_sim:
+    ubuntu: ros-jazzy-nav2-minimal-tb3-sim
+nav2_minimal_tb4_description:
+    ubuntu: ros-jazzy-nav2-minimal-tb4-description
+nav2_minimal_tb4_sim:
+    ubuntu: ros-jazzy-nav2-minimal-tb4-sim
+costmap_queue:
+    ubuntu: ros-jazzy-costmap-queue
+dwb_core:
+    ubuntu: ros-jazzy-dwb-core
+dwb_critics:
+    ubuntu: ros-jazzy-dwb-critics
+dwb_msgs:
+    ubuntu: ros-jazzy-dwb-msgs
+dwb_plugins:
+    ubuntu: ros-jazzy-dwb-plugins
+nav2_amcl:
+    ubuntu: ros-jazzy-nav2-amcl
+nav2_behavior_tree:
+    ubuntu: ros-jazzy-nav2-behavior-tree
+nav2_behaviors:
+    ubuntu: ros-jazzy-nav2-behaviors
+nav2_bringup:
+    ubuntu: ros-jazzy-nav2-bringup
+nav2_bt_navigator:
+    ubuntu: ros-jazzy-nav2-bt-navigator
+nav2_collision_monitor:
+    ubuntu: ros-jazzy-nav2-collision-monitor
+nav2_common:
+    ubuntu: ros-jazzy-nav2-common
+nav2_constrained_smoother:
+    ubuntu: ros-jazzy-nav2-constrained-smoother
+nav2_controller:
+    ubuntu: ros-jazzy-nav2-controller
+nav2_core:
+    ubuntu: ros-jazzy-nav2-core
+nav2_costmap_2d:
+    ubuntu: ros-jazzy-nav2-costmap-2d
+nav2_dwb_controller:
+    ubuntu: ros-jazzy-nav2-dwb-controller
+nav2_graceful_controller:
+    ubuntu: ros-jazzy-nav2-graceful-controller
+nav2_lifecycle_manager:
+    ubuntu: ros-jazzy-nav2-lifecycle-manager
+nav2_loopback_sim:
+    ubuntu: ros-jazzy-nav2-loopback-sim
+nav2_map_server:
+    ubuntu: ros-jazzy-nav2-map-server
+nav2_mppi_controller:
+    ubuntu: ros-jazzy-nav2-mppi-controller
+nav2_msgs:
+    ubuntu: ros-jazzy-nav2-msgs
+nav2_navfn_planner:
+    ubuntu: ros-jazzy-nav2-navfn-planner
+nav2_planner:
+    ubuntu: ros-jazzy-nav2-planner
+nav2_regulated_pure_pursuit_controller:
+    ubuntu: ros-jazzy-nav2-regulated-pure-pursuit-controller
+nav2_rotation_shim_controller:
+    ubuntu: ros-jazzy-nav2-rotation-shim-controller
+nav2_rviz_plugins:
+    ubuntu: ros-jazzy-nav2-rviz-plugins
+nav2_simple_commander:
+    ubuntu: ros-jazzy-nav2-simple-commander
+nav2_smac_planner:
+    ubuntu: ros-jazzy-nav2-smac-planner
+nav2_smoother:
+    ubuntu: ros-jazzy-nav2-smoother
+nav2_system_tests:
+    ubuntu: ros-jazzy-nav2-system-tests
+nav2_theta_star_planner:
+    ubuntu: ros-jazzy-nav2-theta-star-planner
+nav2_util:
+    ubuntu: ros-jazzy-nav2-util
+nav2_velocity_smoother:
+    ubuntu: ros-jazzy-nav2-velocity-smoother
+nav2_voxel_grid:
+    ubuntu: ros-jazzy-nav2-voxel-grid
+nav2_waypoint_follower:
+    ubuntu: ros-jazzy-nav2-waypoint-follower
+nav_2d_msgs:
+    ubuntu: ros-jazzy-nav-2d-msgs
+nav_2d_utils:
+    ubuntu: ros-jazzy-nav-2d-utils
+navigation2:
+    ubuntu: ros-jazzy-navigation2
+opennav_docking:
+    ubuntu: ros-jazzy-opennav-docking
+opennav_docking_bt:
+    ubuntu: ros-jazzy-opennav-docking-bt
+opennav_docking_core:
+    ubuntu: ros-jazzy-opennav-docking-core
+map_msgs:
+    ubuntu: ros-jazzy-map-msgs
+neo_nav2_bringup:
+    ubuntu: ros-jazzy-neo-nav2-bringup
+neo_simulation2:
+    ubuntu: ros-jazzy-neo-simulation2
+network_bridge:
+    ubuntu: ros-jazzy-network-bridge
+nicla_vision_ros2:
+    ubuntu: ros-jazzy-nicla-vision-ros2
+nlohmann_json_schema_validator_vendor:
+    ubuntu: ros-jazzy-nlohmann-json-schema-validator-vendor
+nmea_hardware_interface:
+    ubuntu: ros-jazzy-nmea-hardware-interface
+nmea_msgs:
+    ubuntu: ros-jazzy-nmea-msgs
+nmea_navsat_driver:
+    ubuntu: ros-jazzy-nmea-navsat-driver
+nodl_python:
+    ubuntu: ros-jazzy-nodl-python
+ros2nodl:
+    ubuntu: ros-jazzy-ros2nodl
+nodl_to_policy:
+    ubuntu: ros-jazzy-nodl-to-policy
+novatel_gps_driver:
+    ubuntu: ros-jazzy-novatel-gps-driver
+novatel_gps_msgs:
+    ubuntu: ros-jazzy-novatel-gps-msgs
+ntpd_driver:
+    ubuntu: ros-jazzy-ntpd-driver
+ntrip_client:
+    ubuntu: ros-jazzy-ntrip-client
+object_recognition_msgs:
+    ubuntu: ros-jazzy-object-recognition-msgs
+dynamic_edt_3d:
+    ubuntu: ros-jazzy-dynamic-edt-3d
+octomap:
+    ubuntu: ros-jazzy-octomap
+octovis:
+    ubuntu: ros-jazzy-octovis
+octomap_mapping:
+    ubuntu: ros-jazzy-octomap-mapping
+octomap_server:
+    ubuntu: ros-jazzy-octomap-server
+octomap_msgs:
+    ubuntu: ros-jazzy-octomap-msgs
+octomap_ros:
+    ubuntu: ros-jazzy-octomap-ros
+octomap_rviz_plugins:
+    ubuntu: ros-jazzy-octomap-rviz-plugins
+odom_to_tf_ros2:
+    ubuntu: ros-jazzy-odom-to-tf-ros2
+odri_master_board_sdk:
+    ubuntu: ros-jazzy-odri-master-board-sdk
+ompl:
+    ubuntu: ros-jazzy-ompl
+openeb_vendor:
+    ubuntu: ros-jazzy-openeb-vendor
+openni2_camera:
+    ubuntu: ros-jazzy-openni2-camera
+opensw:
+    ubuntu: ros-jazzy-opensw
+opensw_ros:
+    ubuntu: ros-jazzy-opensw-ros
+orocos_kdl_vendor:
+    ubuntu: ros-jazzy-orocos-kdl-vendor
+python_orocos_kdl_vendor:
+    ubuntu: ros-jazzy-python-orocos-kdl-vendor
+ortools_vendor:
+    ubuntu: ros-jazzy-ortools-vendor
+osqp_vendor:
+    ubuntu: ros-jazzy-osqp-vendor
+osrf_pycommon:
+    ubuntu: ros-jazzy-osrf-pycommon
+osrf_testing_tools_cpp:
+    ubuntu: ros-jazzy-osrf-testing-tools-cpp
+ouster_ros:
+    ubuntu: ros-jazzy-ouster-ros
+ouster_sensor_msgs:
+    ubuntu: ros-jazzy-ouster-sensor-msgs
+ouxt_common:
+    ubuntu: ros-jazzy-ouxt-common
+ouxt_lint_common:
+    ubuntu: ros-jazzy-ouxt-lint-common
+pal_statistics:
+    ubuntu: ros-jazzy-pal-statistics
+pal_statistics_msgs:
+    ubuntu: ros-jazzy-pal-statistics-msgs
+pangolin:
+    ubuntu: ros-jazzy-pangolin
+pcl_msgs:
+    ubuntu: ros-jazzy-pcl-msgs
+open3d_conversions:
+    ubuntu: ros-jazzy-open3d-conversions
+pcl_conversions:
+    ubuntu: ros-jazzy-pcl-conversions
+pcl_ros:
+    ubuntu: ros-jazzy-pcl-ros
+perception_pcl:
+    ubuntu: ros-jazzy-perception-pcl
+performance_test:
+    ubuntu: ros-jazzy-performance-test
+performance_test_fixture:
+    ubuntu: ros-jazzy-performance-test-fixture
+libphidget22:
+    ubuntu: ros-jazzy-libphidget22
+phidgets_accelerometer:
+    ubuntu: ros-jazzy-phidgets-accelerometer
+phidgets_analog_inputs:
+    ubuntu: ros-jazzy-phidgets-analog-inputs
+phidgets_analog_outputs:
+    ubuntu: ros-jazzy-phidgets-analog-outputs
+phidgets_api:
+    ubuntu: ros-jazzy-phidgets-api
+phidgets_digital_inputs:
+    ubuntu: ros-jazzy-phidgets-digital-inputs
+phidgets_digital_outputs:
+    ubuntu: ros-jazzy-phidgets-digital-outputs
+phidgets_drivers:
+    ubuntu: ros-jazzy-phidgets-drivers
+phidgets_gyroscope:
+    ubuntu: ros-jazzy-phidgets-gyroscope
+phidgets_high_speed_encoder:
+    ubuntu: ros-jazzy-phidgets-high-speed-encoder
+phidgets_ik:
+    ubuntu: ros-jazzy-phidgets-ik
+phidgets_magnetometer:
+    ubuntu: ros-jazzy-phidgets-magnetometer
+phidgets_motors:
+    ubuntu: ros-jazzy-phidgets-motors
+phidgets_msgs:
+    ubuntu: ros-jazzy-phidgets-msgs
+phidgets_spatial:
+    ubuntu: ros-jazzy-phidgets-spatial
+phidgets_temperature:
+    ubuntu: ros-jazzy-phidgets-temperature
+pick_ik:
+    ubuntu: ros-jazzy-pick-ik
+picknik_ament_copyright:
+    ubuntu: ros-jazzy-picknik-ament-copyright
+picknik_reset_fault_controller:
+    ubuntu: ros-jazzy-picknik-reset-fault-controller
+picknik_twist_controller:
+    ubuntu: ros-jazzy-picknik-twist-controller
+pinocchio:
+    ubuntu: ros-jazzy-pinocchio
+plotjuggler:
+    ubuntu: ros-jazzy-plotjuggler
+plotjuggler_msgs:
+    ubuntu: ros-jazzy-plotjuggler-msgs
+plotjuggler_ros:
+    ubuntu: ros-jazzy-plotjuggler-ros
+pluginlib:
+    ubuntu: ros-jazzy-pluginlib
+point_cloud_msg_wrapper:
+    ubuntu: ros-jazzy-point-cloud-msg-wrapper
+point_cloud_transport:
+    ubuntu: ros-jazzy-point-cloud-transport
+point_cloud_transport_py:
+    ubuntu: ros-jazzy-point-cloud-transport-py
+draco_point_cloud_transport:
+    ubuntu: ros-jazzy-draco-point-cloud-transport
+point_cloud_interfaces:
+    ubuntu: ros-jazzy-point-cloud-interfaces
+point_cloud_transport_plugins:
+    ubuntu: ros-jazzy-point-cloud-transport-plugins
+zlib_point_cloud_transport:
+    ubuntu: ros-jazzy-zlib-point-cloud-transport
+zstd_point_cloud_transport:
+    ubuntu: ros-jazzy-zstd-point-cloud-transport
+point_cloud_transport_tutorial:
+    ubuntu: ros-jazzy-point-cloud-transport-tutorial
+pointcloud_to_laserscan:
+    ubuntu: ros-jazzy-pointcloud-to-laserscan
+polygon_demos:
+    ubuntu: ros-jazzy-polygon-demos
+polygon_msgs:
+    ubuntu: ros-jazzy-polygon-msgs
+polygon_rviz_plugins:
+    ubuntu: ros-jazzy-polygon-rviz-plugins
+polygon_utils:
+    ubuntu: ros-jazzy-polygon-utils
+popf:
+    ubuntu: ros-jazzy-popf
+pose_cov_ops:
+    ubuntu: ros-jazzy-pose-cov-ops
+proxsuite:
+    ubuntu: ros-jazzy-proxsuite
+ptz_action_server_msgs:
+    ubuntu: ros-jazzy-ptz-action-server-msgs
+py_binding_tools:
+    ubuntu: ros-jazzy-py-binding-tools
+py_trees:
+    ubuntu: ros-jazzy-py-trees
+py_trees_js:
+    ubuntu: ros-jazzy-py-trees-js
+py_trees_ros:
+    ubuntu: ros-jazzy-py-trees-ros
+py_trees_ros_interfaces:
+    ubuntu: ros-jazzy-py-trees-ros-interfaces
+pybind11_json_vendor:
+    ubuntu: ros-jazzy-pybind11-json-vendor
+pybind11_vendor:
+    ubuntu: ros-jazzy-pybind11-vendor
+python_cmake_module:
+    ubuntu: ros-jazzy-python-cmake-module
+python_mrpt:
+    ubuntu: ros-jazzy-python-mrpt
+python_qt_binding:
+    ubuntu: ros-jazzy-python-qt-binding
+qml_ros2_plugin:
+    ubuntu: ros-jazzy-qml-ros2-plugin
+qpoases_vendor:
+    ubuntu: ros-jazzy-qpoases-vendor
+qt_dotgraph:
+    ubuntu: ros-jazzy-qt-dotgraph
+qt_gui:
+    ubuntu: ros-jazzy-qt-gui
+qt_gui_app:
+    ubuntu: ros-jazzy-qt-gui-app
+qt_gui_core:
+    ubuntu: ros-jazzy-qt-gui-core
+qt_gui_cpp:
+    ubuntu: ros-jazzy-qt-gui-cpp
+qt_gui_py_common:
+    ubuntu: ros-jazzy-qt-gui-py-common
+quaternion_operation:
+    ubuntu: ros-jazzy-quaternion-operation
+r2r_spl_7:
+    ubuntu: ros-jazzy-r2r-spl-7
+splsm_7:
+    ubuntu: ros-jazzy-splsm-7
+splsm_7_conversion:
+    ubuntu: ros-jazzy-splsm-7-conversion
+radar_msgs:
+    ubuntu: ros-jazzy-radar-msgs
+random_numbers:
+    ubuntu: ros-jazzy-random-numbers
+raspimouse:
+    ubuntu: ros-jazzy-raspimouse
+raspimouse_msgs:
+    ubuntu: ros-jazzy-raspimouse-msgs
+raspimouse_description:
+    ubuntu: ros-jazzy-raspimouse-description
+raspimouse_ros2_examples:
+    ubuntu: ros-jazzy-raspimouse-ros2-examples
+raspimouse_fake:
+    ubuntu: ros-jazzy-raspimouse-fake
+raspimouse_gazebo:
+    ubuntu: ros-jazzy-raspimouse-gazebo
+raspimouse_sim:
+    ubuntu: ros-jazzy-raspimouse-sim
+raspimouse_navigation:
+    ubuntu: ros-jazzy-raspimouse-navigation
+raspimouse_slam:
+    ubuntu: ros-jazzy-raspimouse-slam
+raspimouse_slam_navigation:
+    ubuntu: ros-jazzy-raspimouse-slam-navigation
+rc_common_msgs:
+    ubuntu: ros-jazzy-rc-common-msgs
+rc_dynamics_api:
+    ubuntu: ros-jazzy-rc-dynamics-api
+rc_genicam_api:
+    ubuntu: ros-jazzy-rc-genicam-api
+rc_genicam_driver:
+    ubuntu: ros-jazzy-rc-genicam-driver
+rc_reason_clients:
+    ubuntu: ros-jazzy-rc-reason-clients
+rc_reason_msgs:
+    ubuntu: ros-jazzy-rc-reason-msgs
+rcdiscover:
+    ubuntu: ros-jazzy-rcdiscover
+rcl:
+    ubuntu: ros-jazzy-rcl
+rcl_action:
+    ubuntu: ros-jazzy-rcl-action
+rcl_lifecycle:
+    ubuntu: ros-jazzy-rcl-lifecycle
+rcl_yaml_param_parser:
+    ubuntu: ros-jazzy-rcl-yaml-param-parser
+action_msgs:
+    ubuntu: ros-jazzy-action-msgs
+builtin_interfaces:
+    ubuntu: ros-jazzy-builtin-interfaces
+composition_interfaces:
+    ubuntu: ros-jazzy-composition-interfaces
+lifecycle_msgs:
+    ubuntu: ros-jazzy-lifecycle-msgs
+rcl_interfaces:
+    ubuntu: ros-jazzy-rcl-interfaces
+rosgraph_msgs:
+    ubuntu: ros-jazzy-rosgraph-msgs
+service_msgs:
+    ubuntu: ros-jazzy-service-msgs
+statistics_msgs:
+    ubuntu: ros-jazzy-statistics-msgs
+test_msgs:
+    ubuntu: ros-jazzy-test-msgs
+type_description_interfaces:
+    ubuntu: ros-jazzy-type-description-interfaces
+rcl_logging_interface:
+    ubuntu: ros-jazzy-rcl-logging-interface
+rcl_logging_noop:
+    ubuntu: ros-jazzy-rcl-logging-noop
+rcl_logging_spdlog:
+    ubuntu: ros-jazzy-rcl-logging-spdlog
+rcl_logging_rcutils:
+    ubuntu: ros-jazzy-rcl-logging-rcutils
+rclc:
+    ubuntu: ros-jazzy-rclc
+rclc_examples:
+    ubuntu: ros-jazzy-rclc-examples
+rclc_lifecycle:
+    ubuntu: ros-jazzy-rclc-lifecycle
+rclc_parameter:
+    ubuntu: ros-jazzy-rclc-parameter
+rclcpp:
+    ubuntu: ros-jazzy-rclcpp
+rclcpp_action:
+    ubuntu: ros-jazzy-rclcpp-action
+rclcpp_components:
+    ubuntu: ros-jazzy-rclcpp-components
+rclcpp_lifecycle:
+    ubuntu: ros-jazzy-rclcpp-lifecycle
+rclpy:
+    ubuntu: ros-jazzy-rclpy
+rcpputils:
+    ubuntu: ros-jazzy-rcpputils
+rcss3d_agent:
+    ubuntu: ros-jazzy-rcss3d-agent
+rcss3d_agent_basic:
+    ubuntu: ros-jazzy-rcss3d-agent-basic
+rcss3d_agent_msgs:
+    ubuntu: ros-jazzy-rcss3d-agent-msgs
+rcss3d_agent_msgs_to_soccer_interfaces:
+    ubuntu: ros-jazzy-rcss3d-agent-msgs-to-soccer-interfaces
+rcss3d_nao:
+    ubuntu: ros-jazzy-rcss3d-nao
+rcutils:
+    ubuntu: ros-jazzy-rcutils
+reach:
+    ubuntu: ros-jazzy-reach
+reach_ros:
+    ubuntu: ros-jazzy-reach-ros
+realsense2_camera:
+    ubuntu: ros-jazzy-realsense2-camera
+realsense2_camera_msgs:
+    ubuntu: ros-jazzy-realsense2-camera-msgs
+realsense2_description:
+    ubuntu: ros-jazzy-realsense2-description
+rttest:
+    ubuntu: ros-jazzy-rttest
+tlsf_cpp:
+    ubuntu: ros-jazzy-tlsf-cpp
+realtime_tools:
+    ubuntu: ros-jazzy-realtime-tools
+libcurl_vendor:
+    ubuntu: ros-jazzy-libcurl-vendor
+resource_retriever:
+    ubuntu: ros-jazzy-resource-retriever
+rig_reconfigure:
+    ubuntu: ros-jazzy-rig-reconfigure
+rmf_api_msgs:
+    ubuntu: ros-jazzy-rmf-api-msgs
+rmf_battery:
+    ubuntu: ros-jazzy-rmf-battery
+rmf_building_map_msgs:
+    ubuntu: ros-jazzy-rmf-building-map-msgs
+rmf_demos:
+    ubuntu: ros-jazzy-rmf-demos
+rmf_charger_msgs:
+    ubuntu: ros-jazzy-rmf-charger-msgs
+rmf_dispenser_msgs:
+    ubuntu: ros-jazzy-rmf-dispenser-msgs
+rmf_door_msgs:
+    ubuntu: ros-jazzy-rmf-door-msgs
+rmf_fleet_msgs:
+    ubuntu: ros-jazzy-rmf-fleet-msgs
+rmf_ingestor_msgs:
+    ubuntu: ros-jazzy-rmf-ingestor-msgs
+rmf_lift_msgs:
+    ubuntu: ros-jazzy-rmf-lift-msgs
+rmf_obstacle_msgs:
+    ubuntu: ros-jazzy-rmf-obstacle-msgs
+rmf_scheduler_msgs:
+    ubuntu: ros-jazzy-rmf-scheduler-msgs
+rmf_site_map_msgs:
+    ubuntu: ros-jazzy-rmf-site-map-msgs
+rmf_task_msgs:
+    ubuntu: ros-jazzy-rmf-task-msgs
+rmf_traffic_msgs:
+    ubuntu: ros-jazzy-rmf-traffic-msgs
+rmf_workcell_msgs:
+    ubuntu: ros-jazzy-rmf-workcell-msgs
+rmf_charging_schedule:
+    ubuntu: ros-jazzy-rmf-charging-schedule
+rmf_fleet_adapter:
+    ubuntu: ros-jazzy-rmf-fleet-adapter
+rmf_fleet_adapter_python:
+    ubuntu: ros-jazzy-rmf-fleet-adapter-python
+rmf_task_ros2:
+    ubuntu: ros-jazzy-rmf-task-ros2
+rmf_traffic_ros2:
+    ubuntu: ros-jazzy-rmf-traffic-ros2
+rmf_websocket:
+    ubuntu: ros-jazzy-rmf-websocket
+rmf_building_sim_gz_plugins:
+    ubuntu: ros-jazzy-rmf-building-sim-gz-plugins
+rmf_robot_sim_common:
+    ubuntu: ros-jazzy-rmf-robot-sim-common
+rmf_robot_sim_gz_plugins:
+    ubuntu: ros-jazzy-rmf-robot-sim-gz-plugins
+rmf_task:
+    ubuntu: ros-jazzy-rmf-task
+rmf_task_sequence:
+    ubuntu: ros-jazzy-rmf-task-sequence
+rmf_traffic:
+    ubuntu: ros-jazzy-rmf-traffic
+rmf_traffic_examples:
+    ubuntu: ros-jazzy-rmf-traffic-examples
+rmf_building_map_tools:
+    ubuntu: ros-jazzy-rmf-building-map-tools
+rmf_traffic_editor:
+    ubuntu: ros-jazzy-rmf-traffic-editor
+rmf_traffic_editor_assets:
+    ubuntu: ros-jazzy-rmf-traffic-editor-assets
+rmf_traffic_editor_test_maps:
+    ubuntu: ros-jazzy-rmf-traffic-editor-test-maps
+rmf_utils:
+    ubuntu: ros-jazzy-rmf-utils
+rmf_dev:
+    ubuntu: ros-jazzy-rmf-dev
+rmf_visualization:
+    ubuntu: ros-jazzy-rmf-visualization
+rmf_visualization_building_systems:
+    ubuntu: ros-jazzy-rmf-visualization-building-systems
+rmf_visualization_fleet_states:
+    ubuntu: ros-jazzy-rmf-visualization-fleet-states
+rmf_visualization_floorplans:
+    ubuntu: ros-jazzy-rmf-visualization-floorplans
+rmf_visualization_navgraphs:
+    ubuntu: ros-jazzy-rmf-visualization-navgraphs
+rmf_visualization_obstacles:
+    ubuntu: ros-jazzy-rmf-visualization-obstacles
+rmf_visualization_rviz2_plugins:
+    ubuntu: ros-jazzy-rmf-visualization-rviz2-plugins
+rmf_visualization_schedule:
+    ubuntu: ros-jazzy-rmf-visualization-schedule
+rmf_visualization_msgs:
+    ubuntu: ros-jazzy-rmf-visualization-msgs
+rmw:
+    ubuntu: ros-jazzy-rmw
+rmw_implementation_cmake:
+    ubuntu: ros-jazzy-rmw-implementation-cmake
+rmw_connextdds:
+    ubuntu: ros-jazzy-rmw-connextdds
+rmw_connextdds_common:
+    ubuntu: ros-jazzy-rmw-connextdds-common
+rti_connext_dds_cmake_module:
+    ubuntu: ros-jazzy-rti-connext-dds-cmake-module
+rmw_cyclonedds_cpp:
+    ubuntu: ros-jazzy-rmw-cyclonedds-cpp
+rmw_dds_common:
+    ubuntu: ros-jazzy-rmw-dds-common
+rmw_fastrtps_cpp:
+    ubuntu: ros-jazzy-rmw-fastrtps-cpp
+rmw_fastrtps_dynamic_cpp:
+    ubuntu: ros-jazzy-rmw-fastrtps-dynamic-cpp
+rmw_fastrtps_shared_cpp:
+    ubuntu: ros-jazzy-rmw-fastrtps-shared-cpp
+gurumdds_cmake_module:
+    ubuntu: ros-jazzy-gurumdds-cmake-module
+rmw_gurumdds_cpp:
+    ubuntu: ros-jazzy-rmw-gurumdds-cpp
+rmw_implementation:
+    ubuntu: ros-jazzy-rmw-implementation
+rmw_zenoh_cpp:
+    ubuntu: ros-jazzy-rmw-zenoh-cpp
+zenoh_cpp_vendor:
+    ubuntu: ros-jazzy-zenoh-cpp-vendor
+robosoft_openai:
+    ubuntu: ros-jazzy-robosoft-openai
+robot_calibration:
+    ubuntu: ros-jazzy-robot-calibration
+robot_calibration_msgs:
+    ubuntu: ros-jazzy-robot-calibration-msgs
+robot_localization:
+    ubuntu: ros-jazzy-robot-localization
+robot_state_publisher:
+    ubuntu: ros-jazzy-robot-state-publisher
+robot_upstart:
+    ubuntu: ros-jazzy-robot-upstart
+robotraconteur:
+    ubuntu: ros-jazzy-robotraconteur
+ros1_bridge:
+    ubuntu: ros-jazzy-ros1-bridge
+canopen:
+    ubuntu: ros-jazzy-canopen
+canopen_402_driver:
+    ubuntu: ros-jazzy-canopen-402-driver
+canopen_base_driver:
+    ubuntu: ros-jazzy-canopen-base-driver
+canopen_core:
+    ubuntu: ros-jazzy-canopen-core
+canopen_fake_slaves:
+    ubuntu: ros-jazzy-canopen-fake-slaves
+canopen_interfaces:
+    ubuntu: ros-jazzy-canopen-interfaces
+canopen_master_driver:
+    ubuntu: ros-jazzy-canopen-master-driver
+canopen_proxy_driver:
+    ubuntu: ros-jazzy-canopen-proxy-driver
+canopen_ros2_control:
+    ubuntu: ros-jazzy-canopen-ros2-control
+canopen_ros2_controllers:
+    ubuntu: ros-jazzy-canopen-ros2-controllers
+canopen_tests:
+    ubuntu: ros-jazzy-canopen-tests
+canopen_utils:
+    ubuntu: ros-jazzy-canopen-utils
+lely_core_libraries:
+    ubuntu: ros-jazzy-lely-core-libraries
+controller_interface:
+    ubuntu: ros-jazzy-controller-interface
+controller_manager:
+    ubuntu: ros-jazzy-controller-manager
+controller_manager_msgs:
+    ubuntu: ros-jazzy-controller-manager-msgs
+hardware_interface:
+    ubuntu: ros-jazzy-hardware-interface
+hardware_interface_testing:
+    ubuntu: ros-jazzy-hardware-interface-testing
+joint_limits:
+    ubuntu: ros-jazzy-joint-limits
+ros2_control:
+    ubuntu: ros-jazzy-ros2-control
+ros2_control_test_assets:
+    ubuntu: ros-jazzy-ros2-control-test-assets
+ros2controlcli:
+    ubuntu: ros-jazzy-ros2controlcli
+rqt_controller_manager:
+    ubuntu: ros-jazzy-rqt-controller-manager
+transmission_interface:
+    ubuntu: ros-jazzy-transmission-interface
+ackermann_steering_controller:
+    ubuntu: ros-jazzy-ackermann-steering-controller
+admittance_controller:
+    ubuntu: ros-jazzy-admittance-controller
+bicycle_steering_controller:
+    ubuntu: ros-jazzy-bicycle-steering-controller
+diff_drive_controller:
+    ubuntu: ros-jazzy-diff-drive-controller
+effort_controllers:
+    ubuntu: ros-jazzy-effort-controllers
+force_torque_sensor_broadcaster:
+    ubuntu: ros-jazzy-force-torque-sensor-broadcaster
+forward_command_controller:
+    ubuntu: ros-jazzy-forward-command-controller
+gpio_controllers:
+    ubuntu: ros-jazzy-gpio-controllers
+gripper_controllers:
+    ubuntu: ros-jazzy-gripper-controllers
+imu_sensor_broadcaster:
+    ubuntu: ros-jazzy-imu-sensor-broadcaster
+joint_state_broadcaster:
+    ubuntu: ros-jazzy-joint-state-broadcaster
+joint_trajectory_controller:
+    ubuntu: ros-jazzy-joint-trajectory-controller
+mecanum_drive_controller:
+    ubuntu: ros-jazzy-mecanum-drive-controller
+parallel_gripper_controller:
+    ubuntu: ros-jazzy-parallel-gripper-controller
+pid_controller:
+    ubuntu: ros-jazzy-pid-controller
+pose_broadcaster:
+    ubuntu: ros-jazzy-pose-broadcaster
+position_controllers:
+    ubuntu: ros-jazzy-position-controllers
+range_sensor_broadcaster:
+    ubuntu: ros-jazzy-range-sensor-broadcaster
+ros2_controllers:
+    ubuntu: ros-jazzy-ros2-controllers
+ros2_controllers_test_nodes:
+    ubuntu: ros-jazzy-ros2-controllers-test-nodes
+rqt_joint_trajectory_controller:
+    ubuntu: ros-jazzy-rqt-joint-trajectory-controller
+steering_controllers_library:
+    ubuntu: ros-jazzy-steering-controllers-library
+tricycle_controller:
+    ubuntu: ros-jazzy-tricycle-controller
+tricycle_steering_controller:
+    ubuntu: ros-jazzy-tricycle-steering-controller
+velocity_controllers:
+    ubuntu: ros-jazzy-velocity-controllers
+kinova_gen3_6dof_robotiq_2f_85_moveit_config:
+    ubuntu: ros-jazzy-kinova-gen3-6dof-robotiq-2f-85-moveit-config
+kinova_gen3_7dof_robotiq_2f_85_moveit_config:
+    ubuntu: ros-jazzy-kinova-gen3-7dof-robotiq-2f-85-moveit-config
+kortex_api:
+    ubuntu: ros-jazzy-kortex-api
+kortex_bringup:
+    ubuntu: ros-jazzy-kortex-bringup
+kortex_description:
+    ubuntu: ros-jazzy-kortex-description
+kortex_driver:
+    ubuntu: ros-jazzy-kortex-driver
+ros2_ouster_drivers:
+    ubuntu: ros-jazzy-ros2-ouster-drivers
+plansys2_bringup:
+    ubuntu: ros-jazzy-plansys2-bringup
+plansys2_bt_actions:
+    ubuntu: ros-jazzy-plansys2-bt-actions
+plansys2_core:
+    ubuntu: ros-jazzy-plansys2-core
+plansys2_domain_expert:
+    ubuntu: ros-jazzy-plansys2-domain-expert
+plansys2_executor:
+    ubuntu: ros-jazzy-plansys2-executor
+plansys2_lifecycle_manager:
+    ubuntu: ros-jazzy-plansys2-lifecycle-manager
+plansys2_msgs:
+    ubuntu: ros-jazzy-plansys2-msgs
+plansys2_pddl_parser:
+    ubuntu: ros-jazzy-plansys2-pddl-parser
+plansys2_planner:
+    ubuntu: ros-jazzy-plansys2-planner
+plansys2_popf_plan_solver:
+    ubuntu: ros-jazzy-plansys2-popf-plan-solver
+plansys2_problem_expert:
+    ubuntu: ros-jazzy-plansys2-problem-expert
+plansys2_support_py:
+    ubuntu: ros-jazzy-plansys2-support-py
+plansys2_terminal:
+    ubuntu: ros-jazzy-plansys2-terminal
+plansys2_tests:
+    ubuntu: ros-jazzy-plansys2-tests
+plansys2_tools:
+    ubuntu: ros-jazzy-plansys2-tools
+robotiq_controllers:
+    ubuntu: ros-jazzy-robotiq-controllers
+robotiq_description:
+    ubuntu: ros-jazzy-robotiq-description
+ros2_socketcan:
+    ubuntu: ros-jazzy-ros2-socketcan
+ros2_socketcan_msgs:
+    ubuntu: ros-jazzy-ros2-socketcan-msgs
+lttngpy:
+    ubuntu: ros-jazzy-lttngpy
+ros2trace:
+    ubuntu: ros-jazzy-ros2trace
+tracetools:
+    ubuntu: ros-jazzy-tracetools
+tracetools_launch:
+    ubuntu: ros-jazzy-tracetools-launch
+tracetools_read:
+    ubuntu: ros-jazzy-tracetools-read
+tracetools_test:
+    ubuntu: ros-jazzy-tracetools-test
+tracetools_trace:
+    ubuntu: ros-jazzy-tracetools-trace
+ros2acceleration:
+    ubuntu: ros-jazzy-ros2acceleration
+ros2action:
+    ubuntu: ros-jazzy-ros2action
+ros2cli:
+    ubuntu: ros-jazzy-ros2cli
+ros2cli_test_interfaces:
+    ubuntu: ros-jazzy-ros2cli-test-interfaces
+ros2component:
+    ubuntu: ros-jazzy-ros2component
+ros2doctor:
+    ubuntu: ros-jazzy-ros2doctor
+ros2interface:
+    ubuntu: ros-jazzy-ros2interface
+ros2lifecycle:
+    ubuntu: ros-jazzy-ros2lifecycle
+ros2lifecycle_test_fixtures:
+    ubuntu: ros-jazzy-ros2lifecycle-test-fixtures
+ros2multicast:
+    ubuntu: ros-jazzy-ros2multicast
+ros2node:
+    ubuntu: ros-jazzy-ros2node
+ros2param:
+    ubuntu: ros-jazzy-ros2param
+ros2pkg:
+    ubuntu: ros-jazzy-ros2pkg
+ros2run:
+    ubuntu: ros-jazzy-ros2run
+ros2service:
+    ubuntu: ros-jazzy-ros2service
+ros2topic:
+    ubuntu: ros-jazzy-ros2topic
+ros2cli_common_extensions:
+    ubuntu: ros-jazzy-ros2cli-common-extensions
+ros2launch_security:
+    ubuntu: ros-jazzy-ros2launch-security
+ros2launch_security_examples:
+    ubuntu: ros-jazzy-ros2launch-security-examples
+ros_babel_fish:
+    ubuntu: ros-jazzy-ros-babel-fish
+ros_babel_fish_test_msgs:
+    ubuntu: ros-jazzy-ros-babel-fish-test-msgs
+ros_babel_fish_test_msgs:
+    ubuntu: ros-jazzy-ros-babel-fish-test-msgs
+battery_state_broadcaster:
+    ubuntu: ros-jazzy-battery-state-broadcaster
+battery_state_rviz_overlay:
+    ubuntu: ros-jazzy-battery-state-rviz-overlay
+can_msgs:
+    ubuntu: ros-jazzy-can-msgs
+ros_environment:
+    ubuntu: ros-jazzy-ros-environment
+ros_gz:
+    ubuntu: ros-jazzy-ros-gz
+ros_gz_bridge:
+    ubuntu: ros-jazzy-ros-gz-bridge
+ros_gz_image:
+    ubuntu: ros-jazzy-ros-gz-image
+ros_gz_interfaces:
+    ubuntu: ros-jazzy-ros-gz-interfaces
+ros_gz_sim:
+    ubuntu: ros-jazzy-ros-gz-sim
+ros_gz_sim_demos:
+    ubuntu: ros-jazzy-ros-gz-sim-demos
+test_ros_gz_bridge:
+    ubuntu: ros-jazzy-test-ros-gz-bridge
+ros_image_to_qimage:
+    ubuntu: ros-jazzy-ros-image-to-qimage
+ros_industrial_cmake_boilerplate:
+    ubuntu: ros-jazzy-ros-industrial-cmake-boilerplate
+ros2test:
+    ubuntu: ros-jazzy-ros2test
+ros_testing:
+    ubuntu: ros-jazzy-ros-testing
+turtlesim:
+    ubuntu: ros-jazzy-turtlesim
+ros_workspace:
+    ubuntu: ros-jazzy-ros-workspace
+liblz4_vendor:
+    ubuntu: ros-jazzy-liblz4-vendor
+mcap_vendor:
+    ubuntu: ros-jazzy-mcap-vendor
+ros2bag:
+    ubuntu: ros-jazzy-ros2bag
+rosbag2:
+    ubuntu: ros-jazzy-rosbag2
+rosbag2_compression:
+    ubuntu: ros-jazzy-rosbag2-compression
+rosbag2_compression_zstd:
+    ubuntu: ros-jazzy-rosbag2-compression-zstd
+rosbag2_cpp:
+    ubuntu: ros-jazzy-rosbag2-cpp
+rosbag2_examples_cpp:
+    ubuntu: ros-jazzy-rosbag2-examples-cpp
+rosbag2_examples_py:
+    ubuntu: ros-jazzy-rosbag2-examples-py
+rosbag2_interfaces:
+    ubuntu: ros-jazzy-rosbag2-interfaces
+rosbag2_performance_benchmarking:
+    ubuntu: ros-jazzy-rosbag2-performance-benchmarking
+rosbag2_performance_benchmarking_msgs:
+    ubuntu: ros-jazzy-rosbag2-performance-benchmarking-msgs
+rosbag2_py:
+    ubuntu: ros-jazzy-rosbag2-py
+rosbag2_storage:
+    ubuntu: ros-jazzy-rosbag2-storage
+rosbag2_storage_default_plugins:
+    ubuntu: ros-jazzy-rosbag2-storage-default-plugins
+rosbag2_storage_mcap:
+    ubuntu: ros-jazzy-rosbag2-storage-mcap
+rosbag2_storage_sqlite3:
+    ubuntu: ros-jazzy-rosbag2-storage-sqlite3
+rosbag2_test_common:
+    ubuntu: ros-jazzy-rosbag2-test-common
+rosbag2_test_msgdefs:
+    ubuntu: ros-jazzy-rosbag2-test-msgdefs
+rosbag2_tests:
+    ubuntu: ros-jazzy-rosbag2-tests
+rosbag2_transport:
+    ubuntu: ros-jazzy-rosbag2-transport
+shared_queues_vendor:
+    ubuntu: ros-jazzy-shared-queues-vendor
+sqlite3_vendor:
+    ubuntu: ros-jazzy-sqlite3-vendor
+zstd_vendor:
+    ubuntu: ros-jazzy-zstd-vendor
+rosbag2_bag_v2:
+    ubuntu: ros-jazzy-rosbag2-bag-v2
+rosbag2_to_video:
+    ubuntu: ros-jazzy-rosbag2-to-video
+rosapi:
+    ubuntu: ros-jazzy-rosapi
+rosapi_msgs:
+    ubuntu: ros-jazzy-rosapi-msgs
+rosbridge_library:
+    ubuntu: ros-jazzy-rosbridge-library
+rosbridge_msgs:
+    ubuntu: ros-jazzy-rosbridge-msgs
+rosbridge_server:
+    ubuntu: ros-jazzy-rosbridge-server
+rosbridge_suite:
+    ubuntu: ros-jazzy-rosbridge-suite
+rosbridge_test_msgs:
+    ubuntu: ros-jazzy-rosbridge-test-msgs
+rosidl_adapter:
+    ubuntu: ros-jazzy-rosidl-adapter
+rosidl_cli:
+    ubuntu: ros-jazzy-rosidl-cli
+rosidl_cmake:
+    ubuntu: ros-jazzy-rosidl-cmake
+rosidl_generator_c:
+    ubuntu: ros-jazzy-rosidl-generator-c
+rosidl_generator_cpp:
+    ubuntu: ros-jazzy-rosidl-generator-cpp
+rosidl_generator_type_description:
+    ubuntu: ros-jazzy-rosidl-generator-type-description
+rosidl_parser:
+    ubuntu: ros-jazzy-rosidl-parser
+rosidl_pycommon:
+    ubuntu: ros-jazzy-rosidl-pycommon
+rosidl_runtime_c:
+    ubuntu: ros-jazzy-rosidl-runtime-c
+rosidl_runtime_cpp:
+    ubuntu: ros-jazzy-rosidl-runtime-cpp
+rosidl_typesupport_interface:
+    ubuntu: ros-jazzy-rosidl-typesupport-interface
+rosidl_typesupport_introspection_c:
+    ubuntu: ros-jazzy-rosidl-typesupport-introspection-c
+rosidl_typesupport_introspection_cpp:
+    ubuntu: ros-jazzy-rosidl-typesupport-introspection-cpp
+rosidl_core_generators:
+    ubuntu: ros-jazzy-rosidl-core-generators
+rosidl_core_runtime:
+    ubuntu: ros-jazzy-rosidl-core-runtime
+rosidl_generator_dds_idl:
+    ubuntu: ros-jazzy-rosidl-generator-dds-idl
+rosidl_default_generators:
+    ubuntu: ros-jazzy-rosidl-default-generators
+rosidl_default_runtime:
+    ubuntu: ros-jazzy-rosidl-default-runtime
+rosidl_dynamic_typesupport:
+    ubuntu: ros-jazzy-rosidl-dynamic-typesupport
+rosidl_dynamic_typesupport_fastrtps:
+    ubuntu: ros-jazzy-rosidl-dynamic-typesupport-fastrtps
+rosidl_generator_py:
+    ubuntu: ros-jazzy-rosidl-generator-py
+rosidl_runtime_py:
+    ubuntu: ros-jazzy-rosidl-runtime-py
+rosidl_typesupport_c:
+    ubuntu: ros-jazzy-rosidl-typesupport-c
+rosidl_typesupport_cpp:
+    ubuntu: ros-jazzy-rosidl-typesupport-cpp
+fastrtps_cmake_module:
+    ubuntu: ros-jazzy-fastrtps-cmake-module
+rosidl_typesupport_fastrtps_c:
+    ubuntu: ros-jazzy-rosidl-typesupport-fastrtps-c
+rosidl_typesupport_fastrtps_cpp:
+    ubuntu: ros-jazzy-rosidl-typesupport-fastrtps-cpp
+rclpy_message_converter:
+    ubuntu: ros-jazzy-rclpy-message-converter
+rclpy_message_converter_msgs:
+    ubuntu: ros-jazzy-rclpy-message-converter-msgs
+rosx_introspection:
+    ubuntu: ros-jazzy-rosx-introspection
+rot_conv:
+    ubuntu: ros-jazzy-rot-conv
+rplidar_ros:
+    ubuntu: ros-jazzy-rplidar-ros
+rpyutils:
+    ubuntu: ros-jazzy-rpyutils
+rqt:
+    ubuntu: ros-jazzy-rqt
+rqt_gui:
+    ubuntu: ros-jazzy-rqt-gui
+rqt_gui_cpp:
+    ubuntu: ros-jazzy-rqt-gui-cpp
+rqt_gui_py:
+    ubuntu: ros-jazzy-rqt-gui-py
+rqt_py_common:
+    ubuntu: ros-jazzy-rqt-py-common
+rqt_action:
+    ubuntu: ros-jazzy-rqt-action
+rqt_bag:
+    ubuntu: ros-jazzy-rqt-bag
+rqt_bag_plugins:
+    ubuntu: ros-jazzy-rqt-bag-plugins
+rqt_common_plugins:
+    ubuntu: ros-jazzy-rqt-common-plugins
+rqt_console:
+    ubuntu: ros-jazzy-rqt-console
+rqt_dotgraph:
+    ubuntu: ros-jazzy-rqt-dotgraph
+rqt_gauges:
+    ubuntu: ros-jazzy-rqt-gauges
+rqt_graph:
+    ubuntu: ros-jazzy-rqt-graph
+rqt_image_overlay:
+    ubuntu: ros-jazzy-rqt-image-overlay
+rqt_image_overlay_layer:
+    ubuntu: ros-jazzy-rqt-image-overlay-layer
+rqt_image_view:
+    ubuntu: ros-jazzy-rqt-image-view
+rqt_moveit:
+    ubuntu: ros-jazzy-rqt-moveit
+rqt_msg:
+    ubuntu: ros-jazzy-rqt-msg
+rqt_plot:
+    ubuntu: ros-jazzy-rqt-plot
+rqt_publisher:
+    ubuntu: ros-jazzy-rqt-publisher
+rqt_py_console:
+    ubuntu: ros-jazzy-rqt-py-console
+rqt_reconfigure:
+    ubuntu: ros-jazzy-rqt-reconfigure
+rqt_robot_dashboard:
+    ubuntu: ros-jazzy-rqt-robot-dashboard
+rqt_robot_monitor:
+    ubuntu: ros-jazzy-rqt-robot-monitor
+rqt_robot_steering:
+    ubuntu: ros-jazzy-rqt-robot-steering
+rqt_runtime_monitor:
+    ubuntu: ros-jazzy-rqt-runtime-monitor
+rqt_service_caller:
+    ubuntu: ros-jazzy-rqt-service-caller
+rqt_shell:
+    ubuntu: ros-jazzy-rqt-shell
+rqt_srv:
+    ubuntu: ros-jazzy-rqt-srv
+rqt_tf_tree:
+    ubuntu: ros-jazzy-rqt-tf-tree
+rqt_topic:
+    ubuntu: ros-jazzy-rqt-topic
+rsl:
+    ubuntu: ros-jazzy-rsl
+rslidar_msg:
+    ubuntu: ros-jazzy-rslidar-msg
+rslidar_sdk:
+    ubuntu: ros-jazzy-rslidar-sdk
+rt_manipulators_cpp:
+    ubuntu: ros-jazzy-rt-manipulators-cpp
+rt_manipulators_examples:
+    ubuntu: ros-jazzy-rt-manipulators-examples
+rt_usb_9axisimu_driver:
+    ubuntu: ros-jazzy-rt-usb-9axisimu-driver
+rtabmap:
+    ubuntu: ros-jazzy-rtabmap
+rtabmap_conversions:
+    ubuntu: ros-jazzy-rtabmap-conversions
+rtabmap_demos:
+    ubuntu: ros-jazzy-rtabmap-demos
+rtabmap_examples:
+    ubuntu: ros-jazzy-rtabmap-examples
+rtabmap_launch:
+    ubuntu: ros-jazzy-rtabmap-launch
+rtabmap_msgs:
+    ubuntu: ros-jazzy-rtabmap-msgs
+rtabmap_odom:
+    ubuntu: ros-jazzy-rtabmap-odom
+rtabmap_python:
+    ubuntu: ros-jazzy-rtabmap-python
+rtabmap_ros:
+    ubuntu: ros-jazzy-rtabmap-ros
+rtabmap_rviz_plugins:
+    ubuntu: ros-jazzy-rtabmap-rviz-plugins
+rtabmap_slam:
+    ubuntu: ros-jazzy-rtabmap-slam
+rtabmap_sync:
+    ubuntu: ros-jazzy-rtabmap-sync
+rtabmap_util:
+    ubuntu: ros-jazzy-rtabmap-util
+rtabmap_viz:
+    ubuntu: ros-jazzy-rtabmap-viz
+rtcm_msgs:
+    ubuntu: ros-jazzy-rtcm-msgs
+ruckig:
+    ubuntu: ros-jazzy-ruckig
+rviz2:
+    ubuntu: ros-jazzy-rviz2
+rviz_assimp_vendor:
+    ubuntu: ros-jazzy-rviz-assimp-vendor
+rviz_common:
+    ubuntu: ros-jazzy-rviz-common
+rviz_default_plugins:
+    ubuntu: ros-jazzy-rviz-default-plugins
+rviz_ogre_vendor:
+    ubuntu: ros-jazzy-rviz-ogre-vendor
+rviz_rendering:
+    ubuntu: ros-jazzy-rviz-rendering
+rviz_rendering_tests:
+    ubuntu: ros-jazzy-rviz-rendering-tests
+rviz_visual_testing_framework:
+    ubuntu: ros-jazzy-rviz-visual-testing-framework
+rviz_2d_overlay_msgs:
+    ubuntu: ros-jazzy-rviz-2d-overlay-msgs
+rviz_2d_overlay_plugins:
+    ubuntu: ros-jazzy-rviz-2d-overlay-plugins
+rviz_satellite:
+    ubuntu: ros-jazzy-rviz-satellite
+rviz_visual_tools:
+    ubuntu: ros-jazzy-rviz-visual-tools
+sbg_driver:
+    ubuntu: ros-jazzy-sbg-driver
+scenario_execution:
+    ubuntu: ros-jazzy-scenario-execution
+scenario_execution_control:
+    ubuntu: ros-jazzy-scenario-execution-control
+scenario_execution_coverage:
+    ubuntu: ros-jazzy-scenario-execution-coverage
+scenario_execution_gazebo:
+    ubuntu: ros-jazzy-scenario-execution-gazebo
+scenario_execution_interfaces:
+    ubuntu: ros-jazzy-scenario-execution-interfaces
+scenario_execution_nav2:
+    ubuntu: ros-jazzy-scenario-execution-nav2
+scenario_execution_os:
+    ubuntu: ros-jazzy-scenario-execution-os
+scenario_execution_py_trees_ros:
+    ubuntu: ros-jazzy-scenario-execution-py-trees-ros
+scenario_execution_ros:
+    ubuntu: ros-jazzy-scenario-execution-ros
+scenario_execution_rviz:
+    ubuntu: ros-jazzy-scenario-execution-rviz
+scenario_execution_x11:
+    ubuntu: ros-jazzy-scenario-execution-x11
+sdformat_test_files:
+    ubuntu: ros-jazzy-sdformat-test-files
+sdformat_urdf:
+    ubuntu: ros-jazzy-sdformat-urdf
+sdformat_vendor:
+    ubuntu: ros-jazzy-sdformat-vendor
+septentrio_gnss_driver:
+    ubuntu: ros-jazzy-septentrio-gnss-driver
+sick_safetyscanners2:
+    ubuntu: ros-jazzy-sick-safetyscanners2
+sick_safetyscanners2_interfaces:
+    ubuntu: ros-jazzy-sick-safetyscanners2-interfaces
+sick_safetyscanners_base:
+    ubuntu: ros-jazzy-sick-safetyscanners-base
+sick_safevisionary_base:
+    ubuntu: ros-jazzy-sick-safevisionary-base
+sick_safevisionary_driver:
+    ubuntu: ros-jazzy-sick-safevisionary-driver
+sick_safevisionary_interfaces:
+    ubuntu: ros-jazzy-sick-safevisionary-interfaces
+sick_safevisionary_tests:
+    ubuntu: ros-jazzy-sick-safevisionary-tests
+sick_scan_xd:
+    ubuntu: ros-jazzy-sick-scan-xd
+simple_actions:
+    ubuntu: ros-jazzy-simple-actions
+simple_grasping:
+    ubuntu: ros-jazzy-simple-grasping
+simple_launch:
+    ubuntu: ros-jazzy-simple-launch
+simple_term_menu_vendor:
+    ubuntu: ros-jazzy-simple-term-menu-vendor
+slam_toolbox:
+    ubuntu: ros-jazzy-slam-toolbox
+slider_publisher:
+    ubuntu: ros-jazzy-slider-publisher
+executive_smach:
+    ubuntu: ros-jazzy-executive-smach
+smach:
+    ubuntu: ros-jazzy-smach
+smach_msgs:
+    ubuntu: ros-jazzy-smach-msgs
+smach_ros:
+    ubuntu: ros-jazzy-smach-ros
+snowbot_operating_system:
+    ubuntu: ros-jazzy-snowbot-operating-system
+soar_ros:
+    ubuntu: ros-jazzy-soar-ros
+soccer_geometry_msgs:
+    ubuntu: ros-jazzy-soccer-geometry-msgs
+soccer_interfaces:
+    ubuntu: ros-jazzy-soccer-interfaces
+soccer_model_msgs:
+    ubuntu: ros-jazzy-soccer-model-msgs
+soccer_vision_2d_msgs:
+    ubuntu: ros-jazzy-soccer-vision-2d-msgs
+soccer_vision_3d_msgs:
+    ubuntu: ros-jazzy-soccer-vision-3d-msgs
+soccer_vision_attribute_msgs:
+    ubuntu: ros-jazzy-soccer-vision-attribute-msgs
+soccer_vision_3d_rviz_markers:
+    ubuntu: ros-jazzy-soccer-vision-3d-rviz-markers
+sol_vendor:
+    ubuntu: ros-jazzy-sol-vendor
+sophus:
+    ubuntu: ros-jazzy-sophus
+openvdb_vendor:
+    ubuntu: ros-jazzy-openvdb-vendor
+spatio_temporal_voxel_layer:
+    ubuntu: ros-jazzy-spatio-temporal-voxel-layer
+spdlog_vendor:
+    ubuntu: ros-jazzy-spdlog-vendor
+srdfdom:
+    ubuntu: ros-jazzy-srdfdom
+sros2:
+    ubuntu: ros-jazzy-sros2
+sros2_cmake:
+    ubuntu: ros-jazzy-sros2-cmake
+steering_functions:
+    ubuntu: ros-jazzy-steering-functions
+stomp:
+    ubuntu: ros-jazzy-stomp
+swri_console:
+    ubuntu: ros-jazzy-swri-console
+system_fingerprint:
+    ubuntu: ros-jazzy-system-fingerprint
+launch_system_modes:
+    ubuntu: ros-jazzy-launch-system-modes
+system_modes:
+    ubuntu: ros-jazzy-system-modes
+system_modes_examples:
+    ubuntu: ros-jazzy-system-modes-examples
+system_modes_msgs:
+    ubuntu: ros-jazzy-system-modes-msgs
+system_tests:
+    ubuntu: ros-jazzy-system-tests
+tango_icons_vendor:
+    ubuntu: ros-jazzy-tango-icons-vendor
+joy_teleop:
+    ubuntu: ros-jazzy-joy-teleop
+key_teleop:
+    ubuntu: ros-jazzy-key-teleop
+mouse_teleop:
+    ubuntu: ros-jazzy-mouse-teleop
+teleop_tools:
+    ubuntu: ros-jazzy-teleop-tools
+teleop_tools_msgs:
+    ubuntu: ros-jazzy-teleop-tools-msgs
+teleop_twist_joy:
+    ubuntu: ros-jazzy-teleop-twist-joy
+teleop_twist_keyboard:
+    ubuntu: ros-jazzy-teleop-twist-keyboard
+tensorrt_cmake_module:
+    ubuntu: ros-jazzy-tensorrt-cmake-module
+test_interface_files:
+    ubuntu: ros-jazzy-test-interface-files
+tf2_2d:
+    ubuntu: ros-jazzy-tf2-2d
+tf_transformations:
+    ubuntu: ros-jazzy-tf-transformations
+tinyspline_vendor:
+    ubuntu: ros-jazzy-tinyspline-vendor
+tinyxml2_vendor:
+    ubuntu: ros-jazzy-tinyxml2-vendor
+tinyxml_vendor:
+    ubuntu: ros-jazzy-tinyxml-vendor
+tlsf:
+    ubuntu: ros-jazzy-tlsf
+topic_based_ros2_control:
+    ubuntu: ros-jazzy-topic-based-ros2-control
+topic_tools:
+    ubuntu: ros-jazzy-topic-tools
+topic_tools_interfaces:
+    ubuntu: ros-jazzy-topic-tools-interfaces
+trac_ik:
+    ubuntu: ros-jazzy-trac-ik
+trac_ik_kinematics_plugin:
+    ubuntu: ros-jazzy-trac-ik-kinematics-plugin
+trac_ik_lib:
+    ubuntu: ros-jazzy-trac-ik-lib
+tracetools_acceleration:
+    ubuntu: ros-jazzy-tracetools-acceleration
+ros2trace_analysis:
+    ubuntu: ros-jazzy-ros2trace-analysis
+tracetools_analysis:
+    ubuntu: ros-jazzy-tracetools-analysis
+asio_cmake_module:
+    ubuntu: ros-jazzy-asio-cmake-module
+io_context:
+    ubuntu: ros-jazzy-io-context
+serial_driver:
+    ubuntu: ros-jazzy-serial-driver
+udp_driver:
+    ubuntu: ros-jazzy-udp-driver
+turbojpeg_compressed_image_transport:
+    ubuntu: ros-jazzy-turbojpeg-compressed-image-transport
+turtle_nest:
+    ubuntu: ros-jazzy-turtle-nest
+turtlebot3_msgs:
+    ubuntu: ros-jazzy-turtlebot3-msgs
+turtlebot3_fake_node:
+    ubuntu: ros-jazzy-turtlebot3-fake-node
+turtlebot3_gazebo:
+    ubuntu: ros-jazzy-turtlebot3-gazebo
+turtlebot3_simulations:
+    ubuntu: ros-jazzy-turtlebot3-simulations
+turtlebot4_description:
+    ubuntu: ros-jazzy-turtlebot4-description
+turtlebot4_msgs:
+    ubuntu: ros-jazzy-turtlebot4-msgs
+turtlebot4_navigation:
+    ubuntu: ros-jazzy-turtlebot4-navigation
+turtlebot4_node:
+    ubuntu: ros-jazzy-turtlebot4-node
+turtlebot4_desktop:
+    ubuntu: ros-jazzy-turtlebot4-desktop
+turtlebot4_viz:
+    ubuntu: ros-jazzy-turtlebot4-viz
+turtlebot4_base:
+    ubuntu: ros-jazzy-turtlebot4-base
+turtlebot4_bringup:
+    ubuntu: ros-jazzy-turtlebot4-bringup
+turtlebot4_diagnostics:
+    ubuntu: ros-jazzy-turtlebot4-diagnostics
+turtlebot4_robot:
+    ubuntu: ros-jazzy-turtlebot4-robot
+turtlebot4_tests:
+    ubuntu: ros-jazzy-turtlebot4-tests
+turtlebot4_setup:
+    ubuntu: ros-jazzy-turtlebot4-setup
+turtlebot4_gz_bringup:
+    ubuntu: ros-jazzy-turtlebot4-gz-bringup
+turtlebot4_gz_gui_plugins:
+    ubuntu: ros-jazzy-turtlebot4-gz-gui-plugins
+turtlebot4_gz_toolbox:
+    ubuntu: ros-jazzy-turtlebot4-gz-toolbox
+turtlebot4_simulator:
+    ubuntu: ros-jazzy-turtlebot4-simulator
+tuw_geometry:
+    ubuntu: ros-jazzy-tuw-geometry
+tuw_airskin_msgs:
+    ubuntu: ros-jazzy-tuw-airskin-msgs
+tuw_geo_msgs:
+    ubuntu: ros-jazzy-tuw-geo-msgs
+tuw_geometry_msgs:
+    ubuntu: ros-jazzy-tuw-geometry-msgs
+tuw_graph_msgs:
+    ubuntu: ros-jazzy-tuw-graph-msgs
+tuw_msgs:
+    ubuntu: ros-jazzy-tuw-msgs
+tuw_multi_robot_msgs:
+    ubuntu: ros-jazzy-tuw-multi-robot-msgs
+tuw_nav_msgs:
+    ubuntu: ros-jazzy-tuw-nav-msgs
+tuw_object_map_msgs:
+    ubuntu: ros-jazzy-tuw-object-map-msgs
+tuw_object_msgs:
+    ubuntu: ros-jazzy-tuw-object-msgs
+tuw_std_msgs:
+    ubuntu: ros-jazzy-tuw-std-msgs
+tuw_robotics:
+    ubuntu: ros-jazzy-tuw-robotics
+tvm_vendor:
+    ubuntu: ros-jazzy-tvm-vendor
+twist_mux:
+    ubuntu: ros-jazzy-twist-mux
+twist_mux_msgs:
+    ubuntu: ros-jazzy-twist-mux-msgs
+twist_stamper:
+    ubuntu: ros-jazzy-twist-stamper
+ublox:
+    ubuntu: ros-jazzy-ublox
+ublox_gps:
+    ubuntu: ros-jazzy-ublox-gps
+ublox_msgs:
+    ubuntu: ros-jazzy-ublox-msgs
+ublox_serialization:
+    ubuntu: ros-jazzy-ublox-serialization
+ntrip_client_node:
+    ubuntu: ros-jazzy-ntrip-client-node
+ublox_dgnss:
+    ubuntu: ros-jazzy-ublox-dgnss
+ublox_dgnss_node:
+    ubuntu: ros-jazzy-ublox-dgnss-node
+ublox_nav_sat_fix_hp_node:
+    ubuntu: ros-jazzy-ublox-nav-sat-fix-hp-node
+ublox_ubx_interfaces:
+    ubuntu: ros-jazzy-ublox-ubx-interfaces
+ublox_ubx_msgs:
+    ubuntu: ros-jazzy-ublox-ubx-msgs
+udp_msgs:
+    ubuntu: ros-jazzy-udp-msgs
+uncrustify_vendor:
+    ubuntu: ros-jazzy-uncrustify-vendor
+unique_identifier_msgs:
+    ubuntu: ros-jazzy-unique-identifier-msgs
+ur_client_library:
+    ubuntu: ros-jazzy-ur-client-library
+ur_description:
+    ubuntu: ros-jazzy-ur-description
+ur_msgs:
+    ubuntu: ros-jazzy-ur-msgs
+ur:
+    ubuntu: ros-jazzy-ur
+ur_calibration:
+    ubuntu: ros-jazzy-ur-calibration
+ur_controllers:
+    ubuntu: ros-jazzy-ur-controllers
+ur_dashboard_msgs:
+    ubuntu: ros-jazzy-ur-dashboard-msgs
+ur_moveit_config:
+    ubuntu: ros-jazzy-ur-moveit-config
+ur_robot_driver:
+    ubuntu: ros-jazzy-ur-robot-driver
+ur_simulation_gz:
+    ubuntu: ros-jazzy-ur-simulation-gz
+urdf:
+    ubuntu: ros-jazzy-urdf
+urdf_parser_plugin:
+    ubuntu: ros-jazzy-urdf-parser-plugin
+urdf_launch:
+    ubuntu: ros-jazzy-urdf-launch
+urdfdom_py:
+    ubuntu: ros-jazzy-urdfdom-py
+urdf_tutorial:
+    ubuntu: ros-jazzy-urdf-tutorial
+urdfdom:
+    ubuntu: ros-jazzy-urdfdom
+urdfdom_headers:
+    ubuntu: ros-jazzy-urdfdom-headers
+urg_c:
+    ubuntu: ros-jazzy-urg-c
+urg_node:
+    ubuntu: ros-jazzy-urg-node
+urg_node_msgs:
+    ubuntu: ros-jazzy-urg-node-msgs
+usb_cam:
+    ubuntu: ros-jazzy-usb-cam
+v4l2_camera:
+    ubuntu: ros-jazzy-v4l2-camera
+desktop:
+    ubuntu: ros-jazzy-desktop
+desktop_full:
+    ubuntu: ros-jazzy-desktop-full
+perception:
+    ubuntu: ros-jazzy-perception
+ros_base:
+    ubuntu: ros-jazzy-ros-base
+ros_core:
+    ubuntu: ros-jazzy-ros-core
+simulation:
+    ubuntu: ros-jazzy-simulation
+velodyne:
+    ubuntu: ros-jazzy-velodyne
+velodyne_driver:
+    ubuntu: ros-jazzy-velodyne-driver
+velodyne_laserscan:
+    ubuntu: ros-jazzy-velodyne-laserscan
+velodyne_msgs:
+    ubuntu: ros-jazzy-velodyne-msgs
+velodyne_pointcloud:
+    ubuntu: ros-jazzy-velodyne-pointcloud
+velodyne_description:
+    ubuntu: ros-jazzy-velodyne-description
+velodyne_gazebo_plugins:
+    ubuntu: ros-jazzy-velodyne-gazebo-plugins
+velodyne_simulator:
+    ubuntu: ros-jazzy-velodyne-simulator
+vision_msgs:
+    ubuntu: ros-jazzy-vision-msgs
+vision_msgs_rviz_plugins:
+    ubuntu: ros-jazzy-vision-msgs-rviz-plugins
+vision_msgs_layers:
+    ubuntu: ros-jazzy-vision-msgs-layers
+cv_bridge:
+    ubuntu: ros-jazzy-cv-bridge
+image_geometry:
+    ubuntu: ros-jazzy-image-geometry
+vision_opencv:
+    ubuntu: ros-jazzy-vision-opencv
+visp:
+    ubuntu: ros-jazzy-visp
+vitis_common:
+    ubuntu: ros-jazzy-vitis-common
+vizanti:
+    ubuntu: ros-jazzy-vizanti
+vrpn:
+    ubuntu: ros-jazzy-vrpn
+vrpn_mocap:
+    ubuntu: ros-jazzy-vrpn-mocap
+warehouse_ros:
+    ubuntu: ros-jazzy-warehouse-ros
+warehouse_ros_sqlite:
+    ubuntu: ros-jazzy-warehouse-ros-sqlite
+web_video_server:
+    ubuntu: ros-jazzy-web-video-server
+webots_ros2:
+    ubuntu: ros-jazzy-webots-ros2
+webots_ros2_control:
+    ubuntu: ros-jazzy-webots-ros2-control
+webots_ros2_driver:
+    ubuntu: ros-jazzy-webots-ros2-driver
+webots_ros2_epuck:
+    ubuntu: ros-jazzy-webots-ros2-epuck
+webots_ros2_importer:
+    ubuntu: ros-jazzy-webots-ros2-importer
+webots_ros2_mavic:
+    ubuntu: ros-jazzy-webots-ros2-mavic
+webots_ros2_msgs:
+    ubuntu: ros-jazzy-webots-ros2-msgs
+webots_ros2_tesla:
+    ubuntu: ros-jazzy-webots-ros2-tesla
+webots_ros2_tests:
+    ubuntu: ros-jazzy-webots-ros2-tests
+webots_ros2_tiago:
+    ubuntu: ros-jazzy-webots-ros2-tiago
+webots_ros2_turtlebot:
+    ubuntu: ros-jazzy-webots-ros2-turtlebot
+webots_ros2_universal_robot:
+    ubuntu: ros-jazzy-webots-ros2-universal-robot
+wireless_msgs:
+    ubuntu: ros-jazzy-wireless-msgs
+wireless_watcher:
+    ubuntu: ros-jazzy-wireless-watcher
+xacro:
+    ubuntu: ros-jazzy-xacro
+yaets:
+    ubuntu: ros-jazzy-yaets
+yaml_cpp_vendor:
+    ubuntu: ros-jazzy-yaml-cpp-vendor
+yasmin:
+    ubuntu: ros-jazzy-yasmin
+yasmin_demos:
+    ubuntu: ros-jazzy-yasmin-demos
+yasmin_msgs:
+    ubuntu: ros-jazzy-yasmin-msgs
+yasmin_ros:
+    ubuntu: ros-jazzy-yasmin-ros
+yasmin_viewer:
+    ubuntu: ros-jazzy-yasmin-viewer
+zbar_ros:
+    ubuntu: ros-jazzy-zbar-ros
+zbar_ros_interfaces:
+    ubuntu: ros-jazzy-zbar-ros-interfaces
+zenoh_bridge_dds:
+    ubuntu: ros-jazzy-zenoh-bridge-dds
+zmqpp_vendor:
+    ubuntu: ros-jazzy-zmqpp-vendor

--- a/ros.osdeps-rolling
+++ b/ros.osdeps-rolling
@@ -1,0 +1,2636 @@
+#
+# This file is generated, do not edit!
+# based on https://raw.githubusercontent.com/ros/rosdistro/refs/heads/master/rolling/distribution.yaml
+#
+smacc2:
+    ubuntu: ros-rolling-smacc2
+smacc2_msgs:
+    ubuntu: ros-rolling-smacc2-msgs
+acado_vendor:
+    ubuntu: ros-rolling-acado-vendor
+ackermann_msgs:
+    ubuntu: ros-rolling-ackermann-msgs
+actuator_msgs:
+    ubuntu: ros-rolling-actuator-msgs
+adaptive_component:
+    ubuntu: ros-rolling-adaptive-component
+ament_acceleration:
+    ubuntu: ros-rolling-ament-acceleration
+ament_black:
+    ubuntu: ros-rolling-ament-black
+ament_cmake_black:
+    ubuntu: ros-rolling-ament-cmake-black
+ament_cmake:
+    ubuntu: ros-rolling-ament-cmake
+ament_cmake_auto:
+    ubuntu: ros-rolling-ament-cmake-auto
+ament_cmake_core:
+    ubuntu: ros-rolling-ament-cmake-core
+ament_cmake_export_definitions:
+    ubuntu: ros-rolling-ament-cmake-export-definitions
+ament_cmake_export_dependencies:
+    ubuntu: ros-rolling-ament-cmake-export-dependencies
+ament_cmake_export_include_directories:
+    ubuntu: ros-rolling-ament-cmake-export-include-directories
+ament_cmake_export_interfaces:
+    ubuntu: ros-rolling-ament-cmake-export-interfaces
+ament_cmake_export_libraries:
+    ubuntu: ros-rolling-ament-cmake-export-libraries
+ament_cmake_export_link_flags:
+    ubuntu: ros-rolling-ament-cmake-export-link-flags
+ament_cmake_export_targets:
+    ubuntu: ros-rolling-ament-cmake-export-targets
+ament_cmake_gen_version_h:
+    ubuntu: ros-rolling-ament-cmake-gen-version-h
+ament_cmake_gmock:
+    ubuntu: ros-rolling-ament-cmake-gmock
+ament_cmake_google_benchmark:
+    ubuntu: ros-rolling-ament-cmake-google-benchmark
+ament_cmake_gtest:
+    ubuntu: ros-rolling-ament-cmake-gtest
+ament_cmake_include_directories:
+    ubuntu: ros-rolling-ament-cmake-include-directories
+ament_cmake_libraries:
+    ubuntu: ros-rolling-ament-cmake-libraries
+ament_cmake_pytest:
+    ubuntu: ros-rolling-ament-cmake-pytest
+ament_cmake_python:
+    ubuntu: ros-rolling-ament-cmake-python
+ament_cmake_target_dependencies:
+    ubuntu: ros-rolling-ament-cmake-target-dependencies
+ament_cmake_test:
+    ubuntu: ros-rolling-ament-cmake-test
+ament_cmake_vendor_package:
+    ubuntu: ros-rolling-ament-cmake-vendor-package
+ament_cmake_version:
+    ubuntu: ros-rolling-ament-cmake-version
+ament_cmake_catch2:
+    ubuntu: ros-rolling-ament-cmake-catch2
+ament_cmake_ros:
+    ubuntu: ros-rolling-ament-cmake-ros
+domain_coordinator:
+    ubuntu: ros-rolling-domain-coordinator
+ament_download:
+    ubuntu: ros-rolling-ament-download
+ament_index_cpp:
+    ubuntu: ros-rolling-ament-index-cpp
+ament_index_python:
+    ubuntu: ros-rolling-ament-index-python
+ament_clang_format:
+    ubuntu: ros-rolling-ament-clang-format
+ament_clang_tidy:
+    ubuntu: ros-rolling-ament-clang-tidy
+ament_cmake_clang_format:
+    ubuntu: ros-rolling-ament-cmake-clang-format
+ament_cmake_clang_tidy:
+    ubuntu: ros-rolling-ament-cmake-clang-tidy
+ament_cmake_copyright:
+    ubuntu: ros-rolling-ament-cmake-copyright
+ament_cmake_cppcheck:
+    ubuntu: ros-rolling-ament-cmake-cppcheck
+ament_cmake_cpplint:
+    ubuntu: ros-rolling-ament-cmake-cpplint
+ament_cmake_flake8:
+    ubuntu: ros-rolling-ament-cmake-flake8
+ament_cmake_lint_cmake:
+    ubuntu: ros-rolling-ament-cmake-lint-cmake
+ament_cmake_mypy:
+    ubuntu: ros-rolling-ament-cmake-mypy
+ament_cmake_pclint:
+    ubuntu: ros-rolling-ament-cmake-pclint
+ament_cmake_pep257:
+    ubuntu: ros-rolling-ament-cmake-pep257
+ament_cmake_pycodestyle:
+    ubuntu: ros-rolling-ament-cmake-pycodestyle
+ament_cmake_pyflakes:
+    ubuntu: ros-rolling-ament-cmake-pyflakes
+ament_cmake_uncrustify:
+    ubuntu: ros-rolling-ament-cmake-uncrustify
+ament_cmake_xmllint:
+    ubuntu: ros-rolling-ament-cmake-xmllint
+ament_copyright:
+    ubuntu: ros-rolling-ament-copyright
+ament_cppcheck:
+    ubuntu: ros-rolling-ament-cppcheck
+ament_cpplint:
+    ubuntu: ros-rolling-ament-cpplint
+ament_flake8:
+    ubuntu: ros-rolling-ament-flake8
+ament_lint:
+    ubuntu: ros-rolling-ament-lint
+ament_lint_auto:
+    ubuntu: ros-rolling-ament-lint-auto
+ament_lint_cmake:
+    ubuntu: ros-rolling-ament-lint-cmake
+ament_lint_common:
+    ubuntu: ros-rolling-ament-lint-common
+ament_mypy:
+    ubuntu: ros-rolling-ament-mypy
+ament_pclint:
+    ubuntu: ros-rolling-ament-pclint
+ament_pep257:
+    ubuntu: ros-rolling-ament-pep257
+ament_pycodestyle:
+    ubuntu: ros-rolling-ament-pycodestyle
+ament_pyflakes:
+    ubuntu: ros-rolling-ament-pyflakes
+ament_uncrustify:
+    ubuntu: ros-rolling-ament-uncrustify
+ament_xmllint:
+    ubuntu: ros-rolling-ament-xmllint
+ament_nodl:
+    ubuntu: ros-rolling-ament-nodl
+ament_package:
+    ubuntu: ros-rolling-ament-package
+ament_vitis:
+    ubuntu: ros-rolling-ament-vitis
+angles:
+    ubuntu: ros-rolling-angles
+apex_test_tools:
+    ubuntu: ros-rolling-apex-test-tools
+test_apex_test_tools:
+    ubuntu: ros-rolling-test-apex-test-tools
+apriltag:
+    ubuntu: ros-rolling-apriltag
+apriltag_detector:
+    ubuntu: ros-rolling-apriltag-detector
+apriltag_detector_mit:
+    ubuntu: ros-rolling-apriltag-detector-mit
+apriltag_detector_umich:
+    ubuntu: ros-rolling-apriltag-detector-umich
+apriltag_draw:
+    ubuntu: ros-rolling-apriltag-draw
+apriltag_mit:
+    ubuntu: ros-rolling-apriltag-mit
+apriltag_msgs:
+    ubuntu: ros-rolling-apriltag-msgs
+apriltag_ros:
+    ubuntu: ros-rolling-apriltag-ros
+aruco_opencv:
+    ubuntu: ros-rolling-aruco-opencv
+aruco_opencv_msgs:
+    ubuntu: ros-rolling-aruco-opencv-msgs
+aruco:
+    ubuntu: ros-rolling-aruco
+aruco_msgs:
+    ubuntu: ros-rolling-aruco-msgs
+aruco_ros:
+    ubuntu: ros-rolling-aruco-ros
+delphi_esr_msgs:
+    ubuntu: ros-rolling-delphi-esr-msgs
+delphi_mrr_msgs:
+    ubuntu: ros-rolling-delphi-mrr-msgs
+delphi_srr_msgs:
+    ubuntu: ros-rolling-delphi-srr-msgs
+derived_object_msgs:
+    ubuntu: ros-rolling-derived-object-msgs
+ibeo_msgs:
+    ubuntu: ros-rolling-ibeo-msgs
+kartech_linear_actuator_msgs:
+    ubuntu: ros-rolling-kartech-linear-actuator-msgs
+mobileye_560_660_msgs:
+    ubuntu: ros-rolling-mobileye-560-660-msgs
+neobotix_usboard_msgs:
+    ubuntu: ros-rolling-neobotix-usboard-msgs
+async_web_server_cpp:
+    ubuntu: ros-rolling-async-web-server-cpp
+asyncapi_gencpp:
+    ubuntu: ros-rolling-asyncapi-gencpp
+automatika_ros_sugar:
+    ubuntu: ros-rolling-automatika-ros-sugar
+automotive_autonomy_msgs:
+    ubuntu: ros-rolling-automotive-autonomy-msgs
+automotive_navigation_msgs:
+    ubuntu: ros-rolling-automotive-navigation-msgs
+automotive_platform_msgs:
+    ubuntu: ros-rolling-automotive-platform-msgs
+autoware_adapi_v1_msgs:
+    ubuntu: ros-rolling-autoware-adapi-v1-msgs
+autoware_adapi_version_msgs:
+    ubuntu: ros-rolling-autoware-adapi-version-msgs
+autoware_auto_msgs:
+    ubuntu: ros-rolling-autoware-auto-msgs
+autoware_cmake:
+    ubuntu: ros-rolling-autoware-cmake
+autoware_lint_common:
+    ubuntu: ros-rolling-autoware-lint-common
+autoware_internal_debug_msgs:
+    ubuntu: ros-rolling-autoware-internal-debug-msgs
+autoware_internal_msgs:
+    ubuntu: ros-rolling-autoware-internal-msgs
+autoware_internal_perception_msgs:
+    ubuntu: ros-rolling-autoware-internal-perception-msgs
+autoware_lanelet2_extension:
+    ubuntu: ros-rolling-autoware-lanelet2-extension
+autoware_lanelet2_extension_python:
+    ubuntu: ros-rolling-autoware-lanelet2-extension-python
+autoware_common_msgs:
+    ubuntu: ros-rolling-autoware-common-msgs
+autoware_control_msgs:
+    ubuntu: ros-rolling-autoware-control-msgs
+autoware_localization_msgs:
+    ubuntu: ros-rolling-autoware-localization-msgs
+autoware_map_msgs:
+    ubuntu: ros-rolling-autoware-map-msgs
+autoware_perception_msgs:
+    ubuntu: ros-rolling-autoware-perception-msgs
+autoware_planning_msgs:
+    ubuntu: ros-rolling-autoware-planning-msgs
+autoware_sensing_msgs:
+    ubuntu: ros-rolling-autoware-sensing-msgs
+autoware_system_msgs:
+    ubuntu: ros-rolling-autoware-system-msgs
+autoware_v2x_msgs:
+    ubuntu: ros-rolling-autoware-v2x-msgs
+autoware_vehicle_msgs:
+    ubuntu: ros-rolling-autoware-vehicle-msgs
+autoware_utils:
+    ubuntu: ros-rolling-autoware-utils
+avt_vimba_camera:
+    ubuntu: ros-rolling-avt-vimba-camera
+aws_robomaker_small_warehouse_world:
+    ubuntu: ros-rolling-aws-robomaker-small-warehouse-world
+aws_sdk_cpp_vendor:
+    ubuntu: ros-rolling-aws-sdk-cpp-vendor
+azure_iot_sdk_c:
+    ubuntu: ros-rolling-azure-iot-sdk-c
+backward_ros:
+    ubuntu: ros-rolling-backward-ros
+bag2_to_image:
+    ubuntu: ros-rolling-bag2-to-image
+behaviortree_cpp_v3:
+    ubuntu: ros-rolling-behaviortree-cpp-v3
+behaviortree_cpp:
+    ubuntu: ros-rolling-behaviortree-cpp
+bno055:
+    ubuntu: ros-rolling-bno055
+bond:
+    ubuntu: ros-rolling-bond
+bond_core:
+    ubuntu: ros-rolling-bond-core
+bondcpp:
+    ubuntu: ros-rolling-bondcpp
+bondpy:
+    ubuntu: ros-rolling-bondpy
+smclib:
+    ubuntu: ros-rolling-smclib
+boost_geometry_util:
+    ubuntu: ros-rolling-boost-geometry-util
+boost_plugin_loader:
+    ubuntu: ros-rolling-boost-plugin-loader
+camera_ros:
+    ubuntu: ros-rolling-camera-ros
+cartographer:
+    ubuntu: ros-rolling-cartographer
+cartographer_ros:
+    ubuntu: ros-rolling-cartographer-ros
+cartographer_ros_msgs:
+    ubuntu: ros-rolling-cartographer-ros-msgs
+cartographer_rviz:
+    ubuntu: ros-rolling-cartographer-rviz
+cascade_lifecycle_msgs:
+    ubuntu: ros-rolling-cascade-lifecycle-msgs
+rclcpp_cascade_lifecycle:
+    ubuntu: ros-rolling-rclcpp-cascade-lifecycle
+catch_ros2:
+    ubuntu: ros-rolling-catch-ros2
+class_loader:
+    ubuntu: ros-rolling-class-loader
+classic_bags:
+    ubuntu: ros-rolling-classic-bags
+clips_vendor:
+    ubuntu: ros-rolling-clips-vendor
+coal:
+    ubuntu: ros-rolling-coal
+color_names:
+    ubuntu: ros-rolling-color-names
+color_util:
+    ubuntu: ros-rolling-color-util
+actionlib_msgs:
+    ubuntu: ros-rolling-actionlib-msgs
+common_interfaces:
+    ubuntu: ros-rolling-common-interfaces
+diagnostic_msgs:
+    ubuntu: ros-rolling-diagnostic-msgs
+geometry_msgs:
+    ubuntu: ros-rolling-geometry-msgs
+nav_msgs:
+    ubuntu: ros-rolling-nav-msgs
+sensor_msgs:
+    ubuntu: ros-rolling-sensor-msgs
+sensor_msgs_py:
+    ubuntu: ros-rolling-sensor-msgs-py
+shape_msgs:
+    ubuntu: ros-rolling-shape-msgs
+std_msgs:
+    ubuntu: ros-rolling-std-msgs
+std_srvs:
+    ubuntu: ros-rolling-std-srvs
+stereo_msgs:
+    ubuntu: ros-rolling-stereo-msgs
+trajectory_msgs:
+    ubuntu: ros-rolling-trajectory-msgs
+visualization_msgs:
+    ubuntu: ros-rolling-visualization-msgs
+console_bridge_vendor:
+    ubuntu: ros-rolling-console-bridge-vendor
+control_box_rst:
+    ubuntu: ros-rolling-control-box-rst
+control_msgs:
+    ubuntu: ros-rolling-control-msgs
+control_toolbox:
+    ubuntu: ros-rolling-control-toolbox
+tcb_span:
+    ubuntu: ros-rolling-tcb-span
+tl_expected:
+    ubuntu: ros-rolling-tl-expected
+cudnn_cmake_module:
+    ubuntu: ros-rolling-cudnn-cmake-module
+cyclonedds:
+    ubuntu: ros-rolling-cyclonedds
+data_tamer_cpp:
+    ubuntu: ros-rolling-data-tamer-cpp
+data_tamer_msgs:
+    ubuntu: ros-rolling-data-tamer-msgs
+action_tutorials_cpp:
+    ubuntu: ros-rolling-action-tutorials-cpp
+action_tutorials_py:
+    ubuntu: ros-rolling-action-tutorials-py
+composition:
+    ubuntu: ros-rolling-composition
+demo_nodes_cpp:
+    ubuntu: ros-rolling-demo-nodes-cpp
+demo_nodes_cpp_native:
+    ubuntu: ros-rolling-demo-nodes-cpp-native
+demo_nodes_py:
+    ubuntu: ros-rolling-demo-nodes-py
+dummy_map_server:
+    ubuntu: ros-rolling-dummy-map-server
+dummy_robot_bringup:
+    ubuntu: ros-rolling-dummy-robot-bringup
+dummy_sensors:
+    ubuntu: ros-rolling-dummy-sensors
+image_tools:
+    ubuntu: ros-rolling-image-tools
+intra_process_demo:
+    ubuntu: ros-rolling-intra-process-demo
+lifecycle:
+    ubuntu: ros-rolling-lifecycle
+lifecycle_py:
+    ubuntu: ros-rolling-lifecycle-py
+logging_demo:
+    ubuntu: ros-rolling-logging-demo
+pendulum_control:
+    ubuntu: ros-rolling-pendulum-control
+pendulum_msgs:
+    ubuntu: ros-rolling-pendulum-msgs
+quality_of_service_demo_cpp:
+    ubuntu: ros-rolling-quality-of-service-demo-cpp
+quality_of_service_demo_py:
+    ubuntu: ros-rolling-quality-of-service-demo-py
+topic_monitor:
+    ubuntu: ros-rolling-topic-monitor
+topic_statistics_demo:
+    ubuntu: ros-rolling-topic-statistics-demo
+depthimage_to_laserscan:
+    ubuntu: ros-rolling-depthimage-to-laserscan
+diagnostic_aggregator:
+    ubuntu: ros-rolling-diagnostic-aggregator
+diagnostic_common_diagnostics:
+    ubuntu: ros-rolling-diagnostic-common-diagnostics
+diagnostic_updater:
+    ubuntu: ros-rolling-diagnostic-updater
+diagnostics:
+    ubuntu: ros-rolling-diagnostics
+self_test:
+    ubuntu: ros-rolling-self-test
+dolly:
+    ubuntu: ros-rolling-dolly
+dolly_follow:
+    ubuntu: ros-rolling-dolly-follow
+dolly_gazebo:
+    ubuntu: ros-rolling-dolly-gazebo
+dolly_ignition:
+    ubuntu: ros-rolling-dolly-ignition
+domain_bridge:
+    ubuntu: ros-rolling-domain-bridge
+dual_laser_merger:
+    ubuntu: ros-rolling-dual-laser-merger
+dynamixel_hardware:
+    ubuntu: ros-rolling-dynamixel-hardware
+dynamixel_sdk:
+    ubuntu: ros-rolling-dynamixel-sdk
+dynamixel_sdk_custom_interfaces:
+    ubuntu: ros-rolling-dynamixel-sdk-custom-interfaces
+dynamixel_sdk_examples:
+    ubuntu: ros-rolling-dynamixel-sdk-examples
+dynamixel_workbench:
+    ubuntu: ros-rolling-dynamixel-workbench
+dynamixel_workbench_toolbox:
+    ubuntu: ros-rolling-dynamixel-workbench-toolbox
+dynamixel_workbench_msgs:
+    ubuntu: ros-rolling-dynamixel-workbench-msgs
+ecal:
+    ubuntu: ros-rolling-ecal
+ecl_command_line:
+    ubuntu: ros-rolling-ecl-command-line
+ecl_concepts:
+    ubuntu: ros-rolling-ecl-concepts
+ecl_containers:
+    ubuntu: ros-rolling-ecl-containers
+ecl_converters:
+    ubuntu: ros-rolling-ecl-converters
+ecl_core:
+    ubuntu: ros-rolling-ecl-core
+ecl_core_apps:
+    ubuntu: ros-rolling-ecl-core-apps
+ecl_devices:
+    ubuntu: ros-rolling-ecl-devices
+ecl_eigen:
+    ubuntu: ros-rolling-ecl-eigen
+ecl_exceptions:
+    ubuntu: ros-rolling-ecl-exceptions
+ecl_filesystem:
+    ubuntu: ros-rolling-ecl-filesystem
+ecl_formatters:
+    ubuntu: ros-rolling-ecl-formatters
+ecl_geometry:
+    ubuntu: ros-rolling-ecl-geometry
+ecl_ipc:
+    ubuntu: ros-rolling-ecl-ipc
+ecl_linear_algebra:
+    ubuntu: ros-rolling-ecl-linear-algebra
+ecl_manipulators:
+    ubuntu: ros-rolling-ecl-manipulators
+ecl_math:
+    ubuntu: ros-rolling-ecl-math
+ecl_mobile_robot:
+    ubuntu: ros-rolling-ecl-mobile-robot
+ecl_mpl:
+    ubuntu: ros-rolling-ecl-mpl
+ecl_sigslots:
+    ubuntu: ros-rolling-ecl-sigslots
+ecl_statistics:
+    ubuntu: ros-rolling-ecl-statistics
+ecl_streams:
+    ubuntu: ros-rolling-ecl-streams
+ecl_threads:
+    ubuntu: ros-rolling-ecl-threads
+ecl_time:
+    ubuntu: ros-rolling-ecl-time
+ecl_type_traits:
+    ubuntu: ros-rolling-ecl-type-traits
+ecl_utilities:
+    ubuntu: ros-rolling-ecl-utilities
+ecl_config:
+    ubuntu: ros-rolling-ecl-config
+ecl_console:
+    ubuntu: ros-rolling-ecl-console
+ecl_converters_lite:
+    ubuntu: ros-rolling-ecl-converters-lite
+ecl_errors:
+    ubuntu: ros-rolling-ecl-errors
+ecl_io:
+    ubuntu: ros-rolling-ecl-io
+ecl_lite:
+    ubuntu: ros-rolling-ecl-lite
+ecl_sigslots_lite:
+    ubuntu: ros-rolling-ecl-sigslots-lite
+ecl_time_lite:
+    ubuntu: ros-rolling-ecl-time-lite
+ecl_build:
+    ubuntu: ros-rolling-ecl-build
+ecl_license:
+    ubuntu: ros-rolling-ecl-license
+ecl_tools:
+    ubuntu: ros-rolling-ecl-tools
+eigen3_cmake_module:
+    ubuntu: ros-rolling-eigen3-cmake-module
+eigen_stl_containers:
+    ubuntu: ros-rolling-eigen-stl-containers
+eigenpy:
+    ubuntu: ros-rolling-eigenpy
+eiquadprog:
+    ubuntu: ros-rolling-eiquadprog
+event_camera_codecs:
+    ubuntu: ros-rolling-event-camera-codecs
+event_camera_msgs:
+    ubuntu: ros-rolling-event-camera-msgs
+event_camera_py:
+    ubuntu: ros-rolling-event-camera-py
+event_camera_renderer:
+    ubuntu: ros-rolling-event-camera-renderer
+example_interfaces:
+    ubuntu: ros-rolling-example-interfaces
+examples_rclcpp_async_client:
+    ubuntu: ros-rolling-examples-rclcpp-async-client
+examples_rclcpp_cbg_executor:
+    ubuntu: ros-rolling-examples-rclcpp-cbg-executor
+examples_rclcpp_minimal_action_client:
+    ubuntu: ros-rolling-examples-rclcpp-minimal-action-client
+examples_rclcpp_minimal_action_server:
+    ubuntu: ros-rolling-examples-rclcpp-minimal-action-server
+examples_rclcpp_minimal_client:
+    ubuntu: ros-rolling-examples-rclcpp-minimal-client
+examples_rclcpp_minimal_composition:
+    ubuntu: ros-rolling-examples-rclcpp-minimal-composition
+examples_rclcpp_minimal_publisher:
+    ubuntu: ros-rolling-examples-rclcpp-minimal-publisher
+examples_rclcpp_minimal_service:
+    ubuntu: ros-rolling-examples-rclcpp-minimal-service
+examples_rclcpp_minimal_subscriber:
+    ubuntu: ros-rolling-examples-rclcpp-minimal-subscriber
+examples_rclcpp_minimal_timer:
+    ubuntu: ros-rolling-examples-rclcpp-minimal-timer
+examples_rclcpp_multithreaded_executor:
+    ubuntu: ros-rolling-examples-rclcpp-multithreaded-executor
+examples_rclcpp_wait_set:
+    ubuntu: ros-rolling-examples-rclcpp-wait-set
+examples_rclpy_executors:
+    ubuntu: ros-rolling-examples-rclpy-executors
+examples_rclpy_guard_conditions:
+    ubuntu: ros-rolling-examples-rclpy-guard-conditions
+examples_rclpy_minimal_action_client:
+    ubuntu: ros-rolling-examples-rclpy-minimal-action-client
+examples_rclpy_minimal_action_server:
+    ubuntu: ros-rolling-examples-rclpy-minimal-action-server
+examples_rclpy_minimal_client:
+    ubuntu: ros-rolling-examples-rclpy-minimal-client
+examples_rclpy_minimal_publisher:
+    ubuntu: ros-rolling-examples-rclpy-minimal-publisher
+examples_rclpy_minimal_service:
+    ubuntu: ros-rolling-examples-rclpy-minimal-service
+examples_rclpy_minimal_subscriber:
+    ubuntu: ros-rolling-examples-rclpy-minimal-subscriber
+examples_rclpy_pointcloud_publisher:
+    ubuntu: ros-rolling-examples-rclpy-pointcloud-publisher
+launch_testing_examples:
+    ubuntu: ros-rolling-launch-testing-examples
+fastcdr:
+    ubuntu: ros-rolling-fastcdr
+fastrtps:
+    ubuntu: ros-rolling-fastrtps
+feetech_ros2_driver:
+    ubuntu: ros-rolling-feetech-ros2-driver
+ffmpeg_encoder_decoder:
+    ubuntu: ros-rolling-ffmpeg-encoder-decoder
+ffmpeg_image_transport:
+    ubuntu: ros-rolling-ffmpeg-image-transport
+ffmpeg_image_transport_msgs:
+    ubuntu: ros-rolling-ffmpeg-image-transport-msgs
+ffmpeg_image_transport_tools:
+    ubuntu: ros-rolling-ffmpeg-image-transport-tools
+fields2cover:
+    ubuntu: ros-rolling-fields2cover
+filters:
+    ubuntu: ros-rolling-filters
+find_object_2d:
+    ubuntu: ros-rolling-find-object-2d
+flex_sync:
+    ubuntu: ros-rolling-flex-sync
+flexbe_behavior_engine:
+    ubuntu: ros-rolling-flexbe-behavior-engine
+flexbe_core:
+    ubuntu: ros-rolling-flexbe-core
+flexbe_input:
+    ubuntu: ros-rolling-flexbe-input
+flexbe_mirror:
+    ubuntu: ros-rolling-flexbe-mirror
+flexbe_msgs:
+    ubuntu: ros-rolling-flexbe-msgs
+flexbe_onboard:
+    ubuntu: ros-rolling-flexbe-onboard
+flexbe_states:
+    ubuntu: ros-rolling-flexbe-states
+flexbe_testing:
+    ubuntu: ros-rolling-flexbe-testing
+flexbe_widget:
+    ubuntu: ros-rolling-flexbe-widget
+flir_camera_description:
+    ubuntu: ros-rolling-flir-camera-description
+flir_camera_msgs:
+    ubuntu: ros-rolling-flir-camera-msgs
+spinnaker_camera_driver:
+    ubuntu: ros-rolling-spinnaker-camera-driver
+spinnaker_synchronized_camera_driver:
+    ubuntu: ros-rolling-spinnaker-synchronized-camera-driver
+fluent_rviz:
+    ubuntu: ros-rolling-fluent-rviz
+fmi_adapter:
+    ubuntu: ros-rolling-fmi-adapter
+fmi_adapter_examples:
+    ubuntu: ros-rolling-fmi-adapter-examples
+fmilibrary_vendor:
+    ubuntu: ros-rolling-fmilibrary-vendor
+foonathan_memory_vendor:
+    ubuntu: ros-rolling-foonathan-memory-vendor
+four_wheel_steering_msgs:
+    ubuntu: ros-rolling-four-wheel-steering-msgs
+foxglove_bridge:
+    ubuntu: ros-rolling-foxglove-bridge
+foxglove_compressed_video_transport:
+    ubuntu: ros-rolling-foxglove-compressed-video-transport
+foxglove_msgs:
+    ubuntu: ros-rolling-foxglove-msgs
+fuse:
+    ubuntu: ros-rolling-fuse
+fuse_constraints:
+    ubuntu: ros-rolling-fuse-constraints
+fuse_core:
+    ubuntu: ros-rolling-fuse-core
+fuse_doc:
+    ubuntu: ros-rolling-fuse-doc
+fuse_graphs:
+    ubuntu: ros-rolling-fuse-graphs
+fuse_loss:
+    ubuntu: ros-rolling-fuse-loss
+fuse_models:
+    ubuntu: ros-rolling-fuse-models
+fuse_msgs:
+    ubuntu: ros-rolling-fuse-msgs
+fuse_optimizers:
+    ubuntu: ros-rolling-fuse-optimizers
+fuse_publishers:
+    ubuntu: ros-rolling-fuse-publishers
+fuse_tutorials:
+    ubuntu: ros-rolling-fuse-tutorials
+fuse_variables:
+    ubuntu: ros-rolling-fuse-variables
+fuse_viz:
+    ubuntu: ros-rolling-fuse-viz
+game_controller_spl:
+    ubuntu: ros-rolling-game-controller-spl
+game_controller_spl_interfaces:
+    ubuntu: ros-rolling-game-controller-spl-interfaces
+cmake_generate_parameter_module_example:
+    ubuntu: ros-rolling-cmake-generate-parameter-module-example
+generate_parameter_library:
+    ubuntu: ros-rolling-generate-parameter-library
+generate_parameter_library_example:
+    ubuntu: ros-rolling-generate-parameter-library-example
+generate_parameter_library_py:
+    ubuntu: ros-rolling-generate-parameter-library-py
+generate_parameter_module_example:
+    ubuntu: ros-rolling-generate-parameter-module-example
+parameter_traits:
+    ubuntu: ros-rolling-parameter-traits
+geodesy:
+    ubuntu: ros-rolling-geodesy
+geographic_info:
+    ubuntu: ros-rolling-geographic-info
+geographic_msgs:
+    ubuntu: ros-rolling-geographic-msgs
+geometric_shapes:
+    ubuntu: ros-rolling-geometric-shapes
+examples_tf2_py:
+    ubuntu: ros-rolling-examples-tf2-py
+geometry2:
+    ubuntu: ros-rolling-geometry2
+tf2:
+    ubuntu: ros-rolling-tf2
+tf2_bullet:
+    ubuntu: ros-rolling-tf2-bullet
+tf2_eigen:
+    ubuntu: ros-rolling-tf2-eigen
+tf2_eigen_kdl:
+    ubuntu: ros-rolling-tf2-eigen-kdl
+tf2_geometry_msgs:
+    ubuntu: ros-rolling-tf2-geometry-msgs
+tf2_kdl:
+    ubuntu: ros-rolling-tf2-kdl
+tf2_msgs:
+    ubuntu: ros-rolling-tf2-msgs
+tf2_py:
+    ubuntu: ros-rolling-tf2-py
+tf2_ros:
+    ubuntu: ros-rolling-tf2-ros
+tf2_ros_py:
+    ubuntu: ros-rolling-tf2-ros-py
+tf2_sensor_msgs:
+    ubuntu: ros-rolling-tf2-sensor-msgs
+tf2_tools:
+    ubuntu: ros-rolling-tf2-tools
+geometry_tutorials:
+    ubuntu: ros-rolling-geometry-tutorials
+turtle_tf2_cpp:
+    ubuntu: ros-rolling-turtle-tf2-cpp
+turtle_tf2_py:
+    ubuntu: ros-rolling-turtle-tf2-py
+google_benchmark_vendor:
+    ubuntu: ros-rolling-google-benchmark-vendor
+gmock_vendor:
+    ubuntu: ros-rolling-gmock-vendor
+gtest_vendor:
+    ubuntu: ros-rolling-gtest-vendor
+gps_msgs:
+    ubuntu: ros-rolling-gps-msgs
+gps_tools:
+    ubuntu: ros-rolling-gps-tools
+gps_umd:
+    ubuntu: ros-rolling-gps-umd
+gpsd_client:
+    ubuntu: ros-rolling-gpsd-client
+graph_msgs:
+    ubuntu: ros-rolling-graph-msgs
+grasping_msgs:
+    ubuntu: ros-rolling-grasping-msgs
+grbl_msgs:
+    ubuntu: ros-rolling-grbl-msgs
+grbl_ros:
+    ubuntu: ros-rolling-grbl-ros
+gscam:
+    ubuntu: ros-rolling-gscam
+gtsam:
+    ubuntu: ros-rolling-gtsam
+gz_cmake_vendor:
+    ubuntu: ros-rolling-gz-cmake-vendor
+gz_common_vendor:
+    ubuntu: ros-rolling-gz-common-vendor
+gz_dartsim_vendor:
+    ubuntu: ros-rolling-gz-dartsim-vendor
+gz_fuel_tools_vendor:
+    ubuntu: ros-rolling-gz-fuel-tools-vendor
+gz_gui_vendor:
+    ubuntu: ros-rolling-gz-gui-vendor
+gz_launch_vendor:
+    ubuntu: ros-rolling-gz-launch-vendor
+gz_math_vendor:
+    ubuntu: ros-rolling-gz-math-vendor
+gz_msgs_vendor:
+    ubuntu: ros-rolling-gz-msgs-vendor
+gz_ogre_next_vendor:
+    ubuntu: ros-rolling-gz-ogre-next-vendor
+gz_physics_vendor:
+    ubuntu: ros-rolling-gz-physics-vendor
+gz_plugin_vendor:
+    ubuntu: ros-rolling-gz-plugin-vendor
+gz_rendering_vendor:
+    ubuntu: ros-rolling-gz-rendering-vendor
+gz_ros2_control:
+    ubuntu: ros-rolling-gz-ros2-control
+gz_ros2_control_demos:
+    ubuntu: ros-rolling-gz-ros2-control-demos
+gz_sensors_vendor:
+    ubuntu: ros-rolling-gz-sensors-vendor
+gz_sim_vendor:
+    ubuntu: ros-rolling-gz-sim-vendor
+gz_tools_vendor:
+    ubuntu: ros-rolling-gz-tools-vendor
+gz_transport_vendor:
+    ubuntu: ros-rolling-gz-transport-vendor
+gz_utils_vendor:
+    ubuntu: ros-rolling-gz-utils-vendor
+hash_library_vendor:
+    ubuntu: ros-rolling-hash-library-vendor
+hatchbed_common:
+    ubuntu: ros-rolling-hatchbed-common
+heaphook:
+    ubuntu: ros-rolling-heaphook
+hls_lfcd_lds_driver:
+    ubuntu: ros-rolling-hls-lfcd-lds-driver
+hpp-fcl:
+    ubuntu: ros-rolling-hpp-fcl
+iceoryx_binding_c:
+    ubuntu: ros-rolling-iceoryx-binding-c
+iceoryx_hoofs:
+    ubuntu: ros-rolling-iceoryx-hoofs
+iceoryx_introspection:
+    ubuntu: ros-rolling-iceoryx-introspection
+iceoryx_posh:
+    ubuntu: ros-rolling-iceoryx-posh
+ifm3d_core:
+    ubuntu: ros-rolling-ifm3d-core
+ign_rviz:
+    ubuntu: ros-rolling-ign-rviz
+ign_rviz_common:
+    ubuntu: ros-rolling-ign-rviz-common
+ign_rviz_plugins:
+    ubuntu: ros-rolling-ign-rviz-plugins
+camera_calibration_parsers:
+    ubuntu: ros-rolling-camera-calibration-parsers
+camera_info_manager:
+    ubuntu: ros-rolling-camera-info-manager
+camera_info_manager_py:
+    ubuntu: ros-rolling-camera-info-manager-py
+image_common:
+    ubuntu: ros-rolling-image-common
+image_transport:
+    ubuntu: ros-rolling-image-transport
+image_transport_py:
+    ubuntu: ros-rolling-image-transport-py
+camera_calibration:
+    ubuntu: ros-rolling-camera-calibration
+depth_image_proc:
+    ubuntu: ros-rolling-depth-image-proc
+image_pipeline:
+    ubuntu: ros-rolling-image-pipeline
+image_proc:
+    ubuntu: ros-rolling-image-proc
+image_publisher:
+    ubuntu: ros-rolling-image-publisher
+image_rotate:
+    ubuntu: ros-rolling-image-rotate
+image_view:
+    ubuntu: ros-rolling-image-view
+stereo_image_proc:
+    ubuntu: ros-rolling-stereo-image-proc
+tracetools_image_pipeline:
+    ubuntu: ros-rolling-tracetools-image-pipeline
+compressed_depth_image_transport:
+    ubuntu: ros-rolling-compressed-depth-image-transport
+compressed_image_transport:
+    ubuntu: ros-rolling-compressed-image-transport
+image_transport_plugins:
+    ubuntu: ros-rolling-image-transport-plugins
+theora_image_transport:
+    ubuntu: ros-rolling-theora-image-transport
+zstd_image_transport:
+    ubuntu: ros-rolling-zstd-image-transport
+imu_pipeline:
+    ubuntu: ros-rolling-imu-pipeline
+imu_processors:
+    ubuntu: ros-rolling-imu-processors
+imu_transformer:
+    ubuntu: ros-rolling-imu-transformer
+imu_complementary_filter:
+    ubuntu: ros-rolling-imu-complementary-filter
+imu_filter_madgwick:
+    ubuntu: ros-rolling-imu-filter-madgwick
+imu_tools:
+    ubuntu: ros-rolling-imu-tools
+rviz_imu_plugin:
+    ubuntu: ros-rolling-rviz-imu-plugin
+interactive_marker_twist_server:
+    ubuntu: ros-rolling-interactive-marker-twist-server
+interactive_markers:
+    ubuntu: ros-rolling-interactive-markers
+irobot_create_msgs:
+    ubuntu: ros-rolling-irobot-create-msgs
+jacro:
+    ubuntu: ros-rolling-jacro
+joint_state_publisher:
+    ubuntu: ros-rolling-joint-state-publisher
+joint_state_publisher_gui:
+    ubuntu: ros-rolling-joint-state-publisher-gui
+joy_tester:
+    ubuntu: ros-rolling-joy-tester
+joy:
+    ubuntu: ros-rolling-joy
+joy_linux:
+    ubuntu: ros-rolling-joy-linux
+sdl2_vendor:
+    ubuntu: ros-rolling-sdl2-vendor
+spacenav:
+    ubuntu: ros-rolling-spacenav
+wiimote:
+    ubuntu: ros-rolling-wiimote
+wiimote_msgs:
+    ubuntu: ros-rolling-wiimote-msgs
+kdl_parser:
+    ubuntu: ros-rolling-kdl-parser
+keyboard_handler:
+    ubuntu: ros-rolling-keyboard-handler
+kinematics_interface:
+    ubuntu: ros-rolling-kinematics-interface
+kinematics_interface_kdl:
+    ubuntu: ros-rolling-kinematics-interface-kdl
+kinematics_interface_pinocchio:
+    ubuntu: ros-rolling-kinematics-interface-pinocchio
+kobuki_core:
+    ubuntu: ros-rolling-kobuki-core
+kobuki_ros_interfaces:
+    ubuntu: ros-rolling-kobuki-ros-interfaces
+kobuki_velocity_smoother:
+    ubuntu: ros-rolling-kobuki-velocity-smoother
+kompass:
+    ubuntu: ros-rolling-kompass
+lanelet2:
+    ubuntu: ros-rolling-lanelet2
+lanelet2_core:
+    ubuntu: ros-rolling-lanelet2-core
+lanelet2_examples:
+    ubuntu: ros-rolling-lanelet2-examples
+lanelet2_io:
+    ubuntu: ros-rolling-lanelet2-io
+lanelet2_maps:
+    ubuntu: ros-rolling-lanelet2-maps
+lanelet2_matching:
+    ubuntu: ros-rolling-lanelet2-matching
+lanelet2_projection:
+    ubuntu: ros-rolling-lanelet2-projection
+lanelet2_python:
+    ubuntu: ros-rolling-lanelet2-python
+lanelet2_routing:
+    ubuntu: ros-rolling-lanelet2-routing
+lanelet2_traffic_rules:
+    ubuntu: ros-rolling-lanelet2-traffic-rules
+lanelet2_validation:
+    ubuntu: ros-rolling-lanelet2-validation
+laser_filters:
+    ubuntu: ros-rolling-laser-filters
+laser_geometry:
+    ubuntu: ros-rolling-laser-geometry
+laser_proc:
+    ubuntu: ros-rolling-laser-proc
+laser_segmentation:
+    ubuntu: ros-rolling-laser-segmentation
+launch:
+    ubuntu: ros-rolling-launch
+launch_pytest:
+    ubuntu: ros-rolling-launch-pytest
+launch_testing:
+    ubuntu: ros-rolling-launch-testing
+launch_testing_ament_cmake:
+    ubuntu: ros-rolling-launch-testing-ament-cmake
+launch_xml:
+    ubuntu: ros-rolling-launch-xml
+launch_yaml:
+    ubuntu: ros-rolling-launch-yaml
+launch_param_builder:
+    ubuntu: ros-rolling-launch-param-builder
+launch_ros:
+    ubuntu: ros-rolling-launch-ros
+launch_testing_ros:
+    ubuntu: ros-rolling-launch-testing-ros
+ros2launch:
+    ubuntu: ros-rolling-ros2launch
+leo:
+    ubuntu: ros-rolling-leo
+leo_description:
+    ubuntu: ros-rolling-leo-description
+leo_msgs:
+    ubuntu: ros-rolling-leo-msgs
+leo_teleop:
+    ubuntu: ros-rolling-leo-teleop
+leo_desktop:
+    ubuntu: ros-rolling-leo-desktop
+leo_viz:
+    ubuntu: ros-rolling-leo-viz
+leo_bringup:
+    ubuntu: ros-rolling-leo-bringup
+leo_fw:
+    ubuntu: ros-rolling-leo-fw
+leo_robot:
+    ubuntu: ros-rolling-leo-robot
+leo_gz_bringup:
+    ubuntu: ros-rolling-leo-gz-bringup
+leo_gz_plugins:
+    ubuntu: ros-rolling-leo-gz-plugins
+leo_gz_worlds:
+    ubuntu: ros-rolling-leo-gz-worlds
+leo_simulator:
+    ubuntu: ros-rolling-leo-simulator
+lgsvl_msgs:
+    ubuntu: ros-rolling-lgsvl-msgs
+libcaer:
+    ubuntu: ros-rolling-libcaer
+libcaer_driver:
+    ubuntu: ros-rolling-libcaer-driver
+libcaer_vendor:
+    ubuntu: ros-rolling-libcaer-vendor
+libcamera:
+    ubuntu: ros-rolling-libcamera
+libg2o:
+    ubuntu: ros-rolling-libg2o
+libnabo:
+    ubuntu: ros-rolling-libnabo
+libpointmatcher:
+    ubuntu: ros-rolling-libpointmatcher
+libstatistics_collector:
+    ubuntu: ros-rolling-libstatistics-collector
+libyaml_vendor:
+    ubuntu: ros-rolling-libyaml-vendor
+linux_isolate_process:
+    ubuntu: ros-rolling-linux-isolate-process
+log_view:
+    ubuntu: ros-rolling-log-view
+magic_enum:
+    ubuntu: ros-rolling-magic-enum
+mapviz:
+    ubuntu: ros-rolling-mapviz
+mapviz_interfaces:
+    ubuntu: ros-rolling-mapviz-interfaces
+mapviz_plugins:
+    ubuntu: ros-rolling-mapviz-plugins
+multires_image:
+    ubuntu: ros-rolling-multires-image
+tile_map:
+    ubuntu: ros-rolling-tile-map
+marine_acoustic_msgs:
+    ubuntu: ros-rolling-marine-acoustic-msgs
+marine_sensor_msgs:
+    ubuntu: ros-rolling-marine-sensor-msgs
+marker_msgs:
+    ubuntu: ros-rolling-marker-msgs
+swri_cli_tools:
+    ubuntu: ros-rolling-swri-cli-tools
+swri_console_util:
+    ubuntu: ros-rolling-swri-console-util
+swri_dbw_interface:
+    ubuntu: ros-rolling-swri-dbw-interface
+swri_geometry_util:
+    ubuntu: ros-rolling-swri-geometry-util
+swri_image_util:
+    ubuntu: ros-rolling-swri-image-util
+swri_math_util:
+    ubuntu: ros-rolling-swri-math-util
+swri_opencv_util:
+    ubuntu: ros-rolling-swri-opencv-util
+swri_roscpp:
+    ubuntu: ros-rolling-swri-roscpp
+swri_route_util:
+    ubuntu: ros-rolling-swri-route-util
+swri_serial_util:
+    ubuntu: ros-rolling-swri-serial-util
+swri_system_util:
+    ubuntu: ros-rolling-swri-system-util
+swri_transform_util:
+    ubuntu: ros-rolling-swri-transform-util
+marti_can_msgs:
+    ubuntu: ros-rolling-marti-can-msgs
+marti_common_msgs:
+    ubuntu: ros-rolling-marti-common-msgs
+marti_dbw_msgs:
+    ubuntu: ros-rolling-marti-dbw-msgs
+marti_introspection_msgs:
+    ubuntu: ros-rolling-marti-introspection-msgs
+marti_nav_msgs:
+    ubuntu: ros-rolling-marti-nav-msgs
+marti_perception_msgs:
+    ubuntu: ros-rolling-marti-perception-msgs
+marti_sensor_msgs:
+    ubuntu: ros-rolling-marti-sensor-msgs
+marti_status_msgs:
+    ubuntu: ros-rolling-marti-status-msgs
+marti_visualization_msgs:
+    ubuntu: ros-rolling-marti-visualization-msgs
+mavlink:
+    ubuntu: ros-rolling-mavlink
+libmavconn:
+    ubuntu: ros-rolling-libmavconn
+mavros:
+    ubuntu: ros-rolling-mavros
+mavros_extras:
+    ubuntu: ros-rolling-mavros-extras
+mavros_msgs:
+    ubuntu: ros-rolling-mavros-msgs
+menge_vendor:
+    ubuntu: ros-rolling-menge-vendor
+message_filters:
+    ubuntu: ros-rolling-message-filters
+message_tf_frame_transformer:
+    ubuntu: ros-rolling-message-tf-frame-transformer
+metavision_driver:
+    ubuntu: ros-rolling-metavision-driver
+micro_ros_diagnostic_bridge:
+    ubuntu: ros-rolling-micro-ros-diagnostic-bridge
+micro_ros_diagnostic_msgs:
+    ubuntu: ros-rolling-micro-ros-diagnostic-msgs
+micro_ros_msgs:
+    ubuntu: ros-rolling-micro-ros-msgs
+microstrain_inertial_description:
+    ubuntu: ros-rolling-microstrain-inertial-description
+microstrain_inertial_driver:
+    ubuntu: ros-rolling-microstrain-inertial-driver
+microstrain_inertial_examples:
+    ubuntu: ros-rolling-microstrain-inertial-examples
+microstrain_inertial_msgs:
+    ubuntu: ros-rolling-microstrain-inertial-msgs
+microstrain_inertial_rqt:
+    ubuntu: ros-rolling-microstrain-inertial-rqt
+mimick_vendor:
+    ubuntu: ros-rolling-mimick-vendor
+mini_tof:
+    ubuntu: ros-rolling-mini-tof
+mini_tof_interfaces:
+    ubuntu: ros-rolling-mini-tof-interfaces
+mir_robot:
+    ubuntu: ros-rolling-mir-robot
+kitti_metrics_eval:
+    ubuntu: ros-rolling-kitti-metrics-eval
+mola:
+    ubuntu: ros-rolling-mola
+mola_bridge_ros2:
+    ubuntu: ros-rolling-mola-bridge-ros2
+mola_demos:
+    ubuntu: ros-rolling-mola-demos
+mola_input_euroc_dataset:
+    ubuntu: ros-rolling-mola-input-euroc-dataset
+mola_input_kitti360_dataset:
+    ubuntu: ros-rolling-mola-input-kitti360-dataset
+mola_input_kitti_dataset:
+    ubuntu: ros-rolling-mola-input-kitti-dataset
+mola_input_mulran_dataset:
+    ubuntu: ros-rolling-mola-input-mulran-dataset
+mola_input_paris_luco_dataset:
+    ubuntu: ros-rolling-mola-input-paris-luco-dataset
+mola_input_rawlog:
+    ubuntu: ros-rolling-mola-input-rawlog
+mola_input_rosbag2:
+    ubuntu: ros-rolling-mola-input-rosbag2
+mola_kernel:
+    ubuntu: ros-rolling-mola-kernel
+mola_launcher:
+    ubuntu: ros-rolling-mola-launcher
+mola_metric_maps:
+    ubuntu: ros-rolling-mola-metric-maps
+mola_msgs:
+    ubuntu: ros-rolling-mola-msgs
+mola_pose_list:
+    ubuntu: ros-rolling-mola-pose-list
+mola_relocalization:
+    ubuntu: ros-rolling-mola-relocalization
+mola_traj_tools:
+    ubuntu: ros-rolling-mola-traj-tools
+mola_viz:
+    ubuntu: ros-rolling-mola-viz
+mola_yaml:
+    ubuntu: ros-rolling-mola-yaml
+mola_common:
+    ubuntu: ros-rolling-mola-common
+mola_lidar_odometry:
+    ubuntu: ros-rolling-mola-lidar-odometry
+mola_imu_preintegration:
+    ubuntu: ros-rolling-mola-imu-preintegration
+mola_state_estimation:
+    ubuntu: ros-rolling-mola-state-estimation
+mola_state_estimation_simple:
+    ubuntu: ros-rolling-mola-state-estimation-simple
+mola_state_estimation_smoother:
+    ubuntu: ros-rolling-mola-state-estimation-smoother
+mola_test_datasets:
+    ubuntu: ros-rolling-mola-test-datasets
+motion_capture_tracking:
+    ubuntu: ros-rolling-motion-capture-tracking
+motion_capture_tracking_interfaces:
+    ubuntu: ros-rolling-motion-capture-tracking-interfaces
+chomp_motion_planner:
+    ubuntu: ros-rolling-chomp-motion-planner
+moveit:
+    ubuntu: ros-rolling-moveit
+moveit_common:
+    ubuntu: ros-rolling-moveit-common
+moveit_configs_utils:
+    ubuntu: ros-rolling-moveit-configs-utils
+moveit_core:
+    ubuntu: ros-rolling-moveit-core
+moveit_hybrid_planning:
+    ubuntu: ros-rolling-moveit-hybrid-planning
+moveit_kinematics:
+    ubuntu: ros-rolling-moveit-kinematics
+moveit_planners:
+    ubuntu: ros-rolling-moveit-planners
+moveit_planners_chomp:
+    ubuntu: ros-rolling-moveit-planners-chomp
+moveit_planners_ompl:
+    ubuntu: ros-rolling-moveit-planners-ompl
+moveit_planners_stomp:
+    ubuntu: ros-rolling-moveit-planners-stomp
+moveit_plugins:
+    ubuntu: ros-rolling-moveit-plugins
+moveit_py:
+    ubuntu: ros-rolling-moveit-py
+moveit_resources_prbt_ikfast_manipulator_plugin:
+    ubuntu: ros-rolling-moveit-resources-prbt-ikfast-manipulator-plugin
+moveit_resources_prbt_moveit_config:
+    ubuntu: ros-rolling-moveit-resources-prbt-moveit-config
+moveit_resources_prbt_pg70_support:
+    ubuntu: ros-rolling-moveit-resources-prbt-pg70-support
+moveit_resources_prbt_support:
+    ubuntu: ros-rolling-moveit-resources-prbt-support
+moveit_ros:
+    ubuntu: ros-rolling-moveit-ros
+moveit_ros_benchmarks:
+    ubuntu: ros-rolling-moveit-ros-benchmarks
+moveit_ros_control_interface:
+    ubuntu: ros-rolling-moveit-ros-control-interface
+moveit_ros_move_group:
+    ubuntu: ros-rolling-moveit-ros-move-group
+moveit_ros_occupancy_map_monitor:
+    ubuntu: ros-rolling-moveit-ros-occupancy-map-monitor
+moveit_ros_perception:
+    ubuntu: ros-rolling-moveit-ros-perception
+moveit_ros_planning:
+    ubuntu: ros-rolling-moveit-ros-planning
+moveit_ros_planning_interface:
+    ubuntu: ros-rolling-moveit-ros-planning-interface
+moveit_ros_robot_interaction:
+    ubuntu: ros-rolling-moveit-ros-robot-interaction
+moveit_ros_tests:
+    ubuntu: ros-rolling-moveit-ros-tests
+moveit_ros_trajectory_cache:
+    ubuntu: ros-rolling-moveit-ros-trajectory-cache
+moveit_ros_visualization:
+    ubuntu: ros-rolling-moveit-ros-visualization
+moveit_ros_warehouse:
+    ubuntu: ros-rolling-moveit-ros-warehouse
+moveit_runtime:
+    ubuntu: ros-rolling-moveit-runtime
+moveit_servo:
+    ubuntu: ros-rolling-moveit-servo
+moveit_setup_app_plugins:
+    ubuntu: ros-rolling-moveit-setup-app-plugins
+moveit_setup_assistant:
+    ubuntu: ros-rolling-moveit-setup-assistant
+moveit_setup_controllers:
+    ubuntu: ros-rolling-moveit-setup-controllers
+moveit_setup_core_plugins:
+    ubuntu: ros-rolling-moveit-setup-core-plugins
+moveit_setup_framework:
+    ubuntu: ros-rolling-moveit-setup-framework
+moveit_setup_srdf_plugins:
+    ubuntu: ros-rolling-moveit-setup-srdf-plugins
+moveit_simple_controller_manager:
+    ubuntu: ros-rolling-moveit-simple-controller-manager
+pilz_industrial_motion_planner:
+    ubuntu: ros-rolling-pilz-industrial-motion-planner
+pilz_industrial_motion_planner_testutils:
+    ubuntu: ros-rolling-pilz-industrial-motion-planner-testutils
+moveit_msgs:
+    ubuntu: ros-rolling-moveit-msgs
+dual_arm_panda_moveit_config:
+    ubuntu: ros-rolling-dual-arm-panda-moveit-config
+moveit_resources:
+    ubuntu: ros-rolling-moveit-resources
+moveit_resources_fanuc_description:
+    ubuntu: ros-rolling-moveit-resources-fanuc-description
+moveit_resources_fanuc_moveit_config:
+    ubuntu: ros-rolling-moveit-resources-fanuc-moveit-config
+moveit_resources_panda_description:
+    ubuntu: ros-rolling-moveit-resources-panda-description
+moveit_resources_panda_moveit_config:
+    ubuntu: ros-rolling-moveit-resources-panda-moveit-config
+moveit_resources_pr2_description:
+    ubuntu: ros-rolling-moveit-resources-pr2-description
+moveit_visual_tools:
+    ubuntu: ros-rolling-moveit-visual-tools
+mp2p_icp:
+    ubuntu: ros-rolling-mp2p-icp
+mqtt_client:
+    ubuntu: ros-rolling-mqtt-client
+mqtt_client_interfaces:
+    ubuntu: ros-rolling-mqtt-client-interfaces
+mrpt_msgs:
+    ubuntu: ros-rolling-mrpt-msgs
+mrpt_map_server:
+    ubuntu: ros-rolling-mrpt-map-server
+mrpt_msgs_bridge:
+    ubuntu: ros-rolling-mrpt-msgs-bridge
+mrpt_nav_interfaces:
+    ubuntu: ros-rolling-mrpt-nav-interfaces
+mrpt_navigation:
+    ubuntu: ros-rolling-mrpt-navigation
+mrpt_pf_localization:
+    ubuntu: ros-rolling-mrpt-pf-localization
+mrpt_pointcloud_pipeline:
+    ubuntu: ros-rolling-mrpt-pointcloud-pipeline
+mrpt_rawlog:
+    ubuntu: ros-rolling-mrpt-rawlog
+mrpt_reactivenav2d:
+    ubuntu: ros-rolling-mrpt-reactivenav2d
+mrpt_tps_astar_planner:
+    ubuntu: ros-rolling-mrpt-tps-astar-planner
+mrpt_tutorials:
+    ubuntu: ros-rolling-mrpt-tutorials
+mrpt_path_planning:
+    ubuntu: ros-rolling-mrpt-path-planning
+mrpt_apps:
+    ubuntu: ros-rolling-mrpt-apps
+mrpt_libapps:
+    ubuntu: ros-rolling-mrpt-libapps
+mrpt_libbase:
+    ubuntu: ros-rolling-mrpt-libbase
+mrpt_libgui:
+    ubuntu: ros-rolling-mrpt-libgui
+mrpt_libhwdrivers:
+    ubuntu: ros-rolling-mrpt-libhwdrivers
+mrpt_libmaps:
+    ubuntu: ros-rolling-mrpt-libmaps
+mrpt_libmath:
+    ubuntu: ros-rolling-mrpt-libmath
+mrpt_libnav:
+    ubuntu: ros-rolling-mrpt-libnav
+mrpt_libobs:
+    ubuntu: ros-rolling-mrpt-libobs
+mrpt_libopengl:
+    ubuntu: ros-rolling-mrpt-libopengl
+mrpt_libposes:
+    ubuntu: ros-rolling-mrpt-libposes
+mrpt_libros_bridge:
+    ubuntu: ros-rolling-mrpt-libros-bridge
+mrpt_libslam:
+    ubuntu: ros-rolling-mrpt-libslam
+mrpt_libtclap:
+    ubuntu: ros-rolling-mrpt-libtclap
+mrpt_generic_sensor:
+    ubuntu: ros-rolling-mrpt-generic-sensor
+mrpt_sensor_bumblebee_stereo:
+    ubuntu: ros-rolling-mrpt-sensor-bumblebee-stereo
+mrpt_sensor_gnss_nmea:
+    ubuntu: ros-rolling-mrpt-sensor-gnss-nmea
+mrpt_sensor_gnss_novatel:
+    ubuntu: ros-rolling-mrpt-sensor-gnss-novatel
+mrpt_sensor_imu_taobotics:
+    ubuntu: ros-rolling-mrpt-sensor-imu-taobotics
+mrpt_sensorlib:
+    ubuntu: ros-rolling-mrpt-sensorlib
+mrpt_sensors:
+    ubuntu: ros-rolling-mrpt-sensors
+mrt_cmake_modules:
+    ubuntu: ros-rolling-mrt-cmake-modules
+mvsim:
+    ubuntu: ros-rolling-mvsim
+nao_button_sim:
+    ubuntu: ros-rolling-nao-button-sim
+nao_command_msgs:
+    ubuntu: ros-rolling-nao-command-msgs
+nao_sensor_msgs:
+    ubuntu: ros-rolling-nao-sensor-msgs
+nao_lola:
+    ubuntu: ros-rolling-nao-lola
+nao_lola_client:
+    ubuntu: ros-rolling-nao-lola-client
+nao_lola_command_msgs:
+    ubuntu: ros-rolling-nao-lola-command-msgs
+nao_lola_sensor_msgs:
+    ubuntu: ros-rolling-nao-lola-sensor-msgs
+nav2_minimal_tb3_sim:
+    ubuntu: ros-rolling-nav2-minimal-tb3-sim
+nav2_minimal_tb4_description:
+    ubuntu: ros-rolling-nav2-minimal-tb4-description
+nav2_minimal_tb4_sim:
+    ubuntu: ros-rolling-nav2-minimal-tb4-sim
+map_msgs:
+    ubuntu: ros-rolling-map-msgs
+neo_simulation2:
+    ubuntu: ros-rolling-neo-simulation2
+nlohmann_json_schema_validator_vendor:
+    ubuntu: ros-rolling-nlohmann-json-schema-validator-vendor
+nmea_hardware_interface:
+    ubuntu: ros-rolling-nmea-hardware-interface
+nmea_msgs:
+    ubuntu: ros-rolling-nmea-msgs
+nmea_navsat_driver:
+    ubuntu: ros-rolling-nmea-navsat-driver
+nodl_python:
+    ubuntu: ros-rolling-nodl-python
+ros2nodl:
+    ubuntu: ros-rolling-ros2nodl
+nodl_to_policy:
+    ubuntu: ros-rolling-nodl-to-policy
+novatel_gps_driver:
+    ubuntu: ros-rolling-novatel-gps-driver
+novatel_gps_msgs:
+    ubuntu: ros-rolling-novatel-gps-msgs
+ntpd_driver:
+    ubuntu: ros-rolling-ntpd-driver
+ntrip_client:
+    ubuntu: ros-rolling-ntrip-client
+object_recognition_msgs:
+    ubuntu: ros-rolling-object-recognition-msgs
+octomap_mapping:
+    ubuntu: ros-rolling-octomap-mapping
+octomap_server:
+    ubuntu: ros-rolling-octomap-server
+octomap_msgs:
+    ubuntu: ros-rolling-octomap-msgs
+octomap_ros:
+    ubuntu: ros-rolling-octomap-ros
+octomap_rviz_plugins:
+    ubuntu: ros-rolling-octomap-rviz-plugins
+odom_to_tf_ros2:
+    ubuntu: ros-rolling-odom-to-tf-ros2
+odri_master_board_sdk:
+    ubuntu: ros-rolling-odri-master-board-sdk
+ompl:
+    ubuntu: ros-rolling-ompl
+openeb_vendor:
+    ubuntu: ros-rolling-openeb-vendor
+openni2_camera:
+    ubuntu: ros-rolling-openni2-camera
+opensw:
+    ubuntu: ros-rolling-opensw
+opensw_ros:
+    ubuntu: ros-rolling-opensw-ros
+orocos_kdl_vendor:
+    ubuntu: ros-rolling-orocos-kdl-vendor
+python_orocos_kdl_vendor:
+    ubuntu: ros-rolling-python-orocos-kdl-vendor
+ortools_vendor:
+    ubuntu: ros-rolling-ortools-vendor
+osqp_vendor:
+    ubuntu: ros-rolling-osqp-vendor
+osrf_pycommon:
+    ubuntu: ros-rolling-osrf-pycommon
+osrf_testing_tools_cpp:
+    ubuntu: ros-rolling-osrf-testing-tools-cpp
+ouster_ros:
+    ubuntu: ros-rolling-ouster-ros
+ouster_sensor_msgs:
+    ubuntu: ros-rolling-ouster-sensor-msgs
+ouxt_common:
+    ubuntu: ros-rolling-ouxt-common
+ouxt_lint_common:
+    ubuntu: ros-rolling-ouxt-lint-common
+pal_statistics:
+    ubuntu: ros-rolling-pal-statistics
+pal_statistics_msgs:
+    ubuntu: ros-rolling-pal-statistics-msgs
+pangolin:
+    ubuntu: ros-rolling-pangolin
+pcl_msgs:
+    ubuntu: ros-rolling-pcl-msgs
+open3d_conversions:
+    ubuntu: ros-rolling-open3d-conversions
+pcl_conversions:
+    ubuntu: ros-rolling-pcl-conversions
+pcl_ros:
+    ubuntu: ros-rolling-pcl-ros
+perception_pcl:
+    ubuntu: ros-rolling-perception-pcl
+performance_test:
+    ubuntu: ros-rolling-performance-test
+performance_test_fixture:
+    ubuntu: ros-rolling-performance-test-fixture
+libphidget22:
+    ubuntu: ros-rolling-libphidget22
+phidgets_accelerometer:
+    ubuntu: ros-rolling-phidgets-accelerometer
+phidgets_analog_inputs:
+    ubuntu: ros-rolling-phidgets-analog-inputs
+phidgets_analog_outputs:
+    ubuntu: ros-rolling-phidgets-analog-outputs
+phidgets_api:
+    ubuntu: ros-rolling-phidgets-api
+phidgets_digital_inputs:
+    ubuntu: ros-rolling-phidgets-digital-inputs
+phidgets_digital_outputs:
+    ubuntu: ros-rolling-phidgets-digital-outputs
+phidgets_drivers:
+    ubuntu: ros-rolling-phidgets-drivers
+phidgets_gyroscope:
+    ubuntu: ros-rolling-phidgets-gyroscope
+phidgets_high_speed_encoder:
+    ubuntu: ros-rolling-phidgets-high-speed-encoder
+phidgets_ik:
+    ubuntu: ros-rolling-phidgets-ik
+phidgets_magnetometer:
+    ubuntu: ros-rolling-phidgets-magnetometer
+phidgets_motors:
+    ubuntu: ros-rolling-phidgets-motors
+phidgets_msgs:
+    ubuntu: ros-rolling-phidgets-msgs
+phidgets_spatial:
+    ubuntu: ros-rolling-phidgets-spatial
+phidgets_temperature:
+    ubuntu: ros-rolling-phidgets-temperature
+pick_ik:
+    ubuntu: ros-rolling-pick-ik
+picknik_ament_copyright:
+    ubuntu: ros-rolling-picknik-ament-copyright
+picknik_reset_fault_controller:
+    ubuntu: ros-rolling-picknik-reset-fault-controller
+picknik_twist_controller:
+    ubuntu: ros-rolling-picknik-twist-controller
+pinocchio:
+    ubuntu: ros-rolling-pinocchio
+plotjuggler:
+    ubuntu: ros-rolling-plotjuggler
+plotjuggler_msgs:
+    ubuntu: ros-rolling-plotjuggler-msgs
+plotjuggler_ros:
+    ubuntu: ros-rolling-plotjuggler-ros
+pluginlib:
+    ubuntu: ros-rolling-pluginlib
+point_cloud_msg_wrapper:
+    ubuntu: ros-rolling-point-cloud-msg-wrapper
+point_cloud_transport:
+    ubuntu: ros-rolling-point-cloud-transport
+point_cloud_transport_py:
+    ubuntu: ros-rolling-point-cloud-transport-py
+draco_point_cloud_transport:
+    ubuntu: ros-rolling-draco-point-cloud-transport
+point_cloud_interfaces:
+    ubuntu: ros-rolling-point-cloud-interfaces
+point_cloud_transport_plugins:
+    ubuntu: ros-rolling-point-cloud-transport-plugins
+zlib_point_cloud_transport:
+    ubuntu: ros-rolling-zlib-point-cloud-transport
+zstd_point_cloud_transport:
+    ubuntu: ros-rolling-zstd-point-cloud-transport
+point_cloud_transport_tutorial:
+    ubuntu: ros-rolling-point-cloud-transport-tutorial
+pointcloud_to_laserscan:
+    ubuntu: ros-rolling-pointcloud-to-laserscan
+polygon_demos:
+    ubuntu: ros-rolling-polygon-demos
+polygon_msgs:
+    ubuntu: ros-rolling-polygon-msgs
+polygon_rviz_plugins:
+    ubuntu: ros-rolling-polygon-rviz-plugins
+polygon_utils:
+    ubuntu: ros-rolling-polygon-utils
+pose_cov_ops:
+    ubuntu: ros-rolling-pose-cov-ops
+proxsuite:
+    ubuntu: ros-rolling-proxsuite
+py_binding_tools:
+    ubuntu: ros-rolling-py-binding-tools
+py_trees:
+    ubuntu: ros-rolling-py-trees
+py_trees_js:
+    ubuntu: ros-rolling-py-trees-js
+py_trees_ros:
+    ubuntu: ros-rolling-py-trees-ros
+py_trees_ros_interfaces:
+    ubuntu: ros-rolling-py-trees-ros-interfaces
+pybind11_json_vendor:
+    ubuntu: ros-rolling-pybind11-json-vendor
+pybind11_vendor:
+    ubuntu: ros-rolling-pybind11-vendor
+python_cmake_module:
+    ubuntu: ros-rolling-python-cmake-module
+python_mrpt:
+    ubuntu: ros-rolling-python-mrpt
+python_qt_binding:
+    ubuntu: ros-rolling-python-qt-binding
+qml_ros2_plugin:
+    ubuntu: ros-rolling-qml-ros2-plugin
+qpoases_vendor:
+    ubuntu: ros-rolling-qpoases-vendor
+qt_dotgraph:
+    ubuntu: ros-rolling-qt-dotgraph
+qt_gui:
+    ubuntu: ros-rolling-qt-gui
+qt_gui_app:
+    ubuntu: ros-rolling-qt-gui-app
+qt_gui_core:
+    ubuntu: ros-rolling-qt-gui-core
+qt_gui_cpp:
+    ubuntu: ros-rolling-qt-gui-cpp
+qt_gui_py_common:
+    ubuntu: ros-rolling-qt-gui-py-common
+quaternion_operation:
+    ubuntu: ros-rolling-quaternion-operation
+r2r_spl_7:
+    ubuntu: ros-rolling-r2r-spl-7
+splsm_7:
+    ubuntu: ros-rolling-splsm-7
+splsm_7_conversion:
+    ubuntu: ros-rolling-splsm-7-conversion
+radar_msgs:
+    ubuntu: ros-rolling-radar-msgs
+random_numbers:
+    ubuntu: ros-rolling-random-numbers
+raspimouse:
+    ubuntu: ros-rolling-raspimouse
+raspimouse_msgs:
+    ubuntu: ros-rolling-raspimouse-msgs
+rc_common_msgs:
+    ubuntu: ros-rolling-rc-common-msgs
+rc_dynamics_api:
+    ubuntu: ros-rolling-rc-dynamics-api
+rc_genicam_api:
+    ubuntu: ros-rolling-rc-genicam-api
+rc_genicam_driver:
+    ubuntu: ros-rolling-rc-genicam-driver
+rc_reason_clients:
+    ubuntu: ros-rolling-rc-reason-clients
+rc_reason_msgs:
+    ubuntu: ros-rolling-rc-reason-msgs
+rcdiscover:
+    ubuntu: ros-rolling-rcdiscover
+rcl:
+    ubuntu: ros-rolling-rcl
+rcl_action:
+    ubuntu: ros-rolling-rcl-action
+rcl_lifecycle:
+    ubuntu: ros-rolling-rcl-lifecycle
+rcl_yaml_param_parser:
+    ubuntu: ros-rolling-rcl-yaml-param-parser
+action_msgs:
+    ubuntu: ros-rolling-action-msgs
+builtin_interfaces:
+    ubuntu: ros-rolling-builtin-interfaces
+composition_interfaces:
+    ubuntu: ros-rolling-composition-interfaces
+lifecycle_msgs:
+    ubuntu: ros-rolling-lifecycle-msgs
+rcl_interfaces:
+    ubuntu: ros-rolling-rcl-interfaces
+rosgraph_msgs:
+    ubuntu: ros-rolling-rosgraph-msgs
+service_msgs:
+    ubuntu: ros-rolling-service-msgs
+statistics_msgs:
+    ubuntu: ros-rolling-statistics-msgs
+test_msgs:
+    ubuntu: ros-rolling-test-msgs
+type_description_interfaces:
+    ubuntu: ros-rolling-type-description-interfaces
+rcl_logging_interface:
+    ubuntu: ros-rolling-rcl-logging-interface
+rcl_logging_noop:
+    ubuntu: ros-rolling-rcl-logging-noop
+rcl_logging_spdlog:
+    ubuntu: ros-rolling-rcl-logging-spdlog
+rcl_logging_rcutils:
+    ubuntu: ros-rolling-rcl-logging-rcutils
+rclc:
+    ubuntu: ros-rolling-rclc
+rclc_examples:
+    ubuntu: ros-rolling-rclc-examples
+rclc_lifecycle:
+    ubuntu: ros-rolling-rclc-lifecycle
+rclc_parameter:
+    ubuntu: ros-rolling-rclc-parameter
+rclcpp:
+    ubuntu: ros-rolling-rclcpp
+rclcpp_action:
+    ubuntu: ros-rolling-rclcpp-action
+rclcpp_components:
+    ubuntu: ros-rolling-rclcpp-components
+rclcpp_lifecycle:
+    ubuntu: ros-rolling-rclcpp-lifecycle
+rclpy:
+    ubuntu: ros-rolling-rclpy
+rcpputils:
+    ubuntu: ros-rolling-rcpputils
+rcss3d_agent:
+    ubuntu: ros-rolling-rcss3d-agent
+rcss3d_agent_basic:
+    ubuntu: ros-rolling-rcss3d-agent-basic
+rcss3d_agent_msgs:
+    ubuntu: ros-rolling-rcss3d-agent-msgs
+rcss3d_agent_msgs_to_soccer_interfaces:
+    ubuntu: ros-rolling-rcss3d-agent-msgs-to-soccer-interfaces
+rcss3d_nao:
+    ubuntu: ros-rolling-rcss3d-nao
+rcutils:
+    ubuntu: ros-rolling-rcutils
+reach:
+    ubuntu: ros-rolling-reach
+reach_ros:
+    ubuntu: ros-rolling-reach-ros
+rttest:
+    ubuntu: ros-rolling-rttest
+tlsf_cpp:
+    ubuntu: ros-rolling-tlsf-cpp
+realtime_tools:
+    ubuntu: ros-rolling-realtime-tools
+libcurl_vendor:
+    ubuntu: ros-rolling-libcurl-vendor
+resource_retriever:
+    ubuntu: ros-rolling-resource-retriever
+rig_reconfigure:
+    ubuntu: ros-rolling-rig-reconfigure
+rmf_api_msgs:
+    ubuntu: ros-rolling-rmf-api-msgs
+rmf_battery:
+    ubuntu: ros-rolling-rmf-battery
+rmf_building_map_msgs:
+    ubuntu: ros-rolling-rmf-building-map-msgs
+rmf_cmake_uncrustify:
+    ubuntu: ros-rolling-rmf-cmake-uncrustify
+rmf_demos:
+    ubuntu: ros-rolling-rmf-demos
+rmf_demos_assets:
+    ubuntu: ros-rolling-rmf-demos-assets
+rmf_demos_bridges:
+    ubuntu: ros-rolling-rmf-demos-bridges
+rmf_demos_fleet_adapter:
+    ubuntu: ros-rolling-rmf-demos-fleet-adapter
+rmf_demos_gz:
+    ubuntu: ros-rolling-rmf-demos-gz
+rmf_demos_maps:
+    ubuntu: ros-rolling-rmf-demos-maps
+rmf_demos_tasks:
+    ubuntu: ros-rolling-rmf-demos-tasks
+rmf_charger_msgs:
+    ubuntu: ros-rolling-rmf-charger-msgs
+rmf_dispenser_msgs:
+    ubuntu: ros-rolling-rmf-dispenser-msgs
+rmf_door_msgs:
+    ubuntu: ros-rolling-rmf-door-msgs
+rmf_fleet_msgs:
+    ubuntu: ros-rolling-rmf-fleet-msgs
+rmf_ingestor_msgs:
+    ubuntu: ros-rolling-rmf-ingestor-msgs
+rmf_lift_msgs:
+    ubuntu: ros-rolling-rmf-lift-msgs
+rmf_obstacle_msgs:
+    ubuntu: ros-rolling-rmf-obstacle-msgs
+rmf_reservation_msgs:
+    ubuntu: ros-rolling-rmf-reservation-msgs
+rmf_scheduler_msgs:
+    ubuntu: ros-rolling-rmf-scheduler-msgs
+rmf_site_map_msgs:
+    ubuntu: ros-rolling-rmf-site-map-msgs
+rmf_task_msgs:
+    ubuntu: ros-rolling-rmf-task-msgs
+rmf_traffic_msgs:
+    ubuntu: ros-rolling-rmf-traffic-msgs
+rmf_workcell_msgs:
+    ubuntu: ros-rolling-rmf-workcell-msgs
+rmf_charging_schedule:
+    ubuntu: ros-rolling-rmf-charging-schedule
+rmf_fleet_adapter:
+    ubuntu: ros-rolling-rmf-fleet-adapter
+rmf_fleet_adapter_python:
+    ubuntu: ros-rolling-rmf-fleet-adapter-python
+rmf_reservation_node:
+    ubuntu: ros-rolling-rmf-reservation-node
+rmf_task_ros2:
+    ubuntu: ros-rolling-rmf-task-ros2
+rmf_traffic_ros2:
+    ubuntu: ros-rolling-rmf-traffic-ros2
+rmf_websocket:
+    ubuntu: ros-rolling-rmf-websocket
+rmf_building_sim_gz_plugins:
+    ubuntu: ros-rolling-rmf-building-sim-gz-plugins
+rmf_robot_sim_common:
+    ubuntu: ros-rolling-rmf-robot-sim-common
+rmf_robot_sim_gz_plugins:
+    ubuntu: ros-rolling-rmf-robot-sim-gz-plugins
+rmf_task:
+    ubuntu: ros-rolling-rmf-task
+rmf_task_sequence:
+    ubuntu: ros-rolling-rmf-task-sequence
+rmf_traffic:
+    ubuntu: ros-rolling-rmf-traffic
+rmf_traffic_examples:
+    ubuntu: ros-rolling-rmf-traffic-examples
+rmf_building_map_tools:
+    ubuntu: ros-rolling-rmf-building-map-tools
+rmf_traffic_editor:
+    ubuntu: ros-rolling-rmf-traffic-editor
+rmf_traffic_editor_assets:
+    ubuntu: ros-rolling-rmf-traffic-editor-assets
+rmf_traffic_editor_test_maps:
+    ubuntu: ros-rolling-rmf-traffic-editor-test-maps
+rmf_utils:
+    ubuntu: ros-rolling-rmf-utils
+rmf_dev:
+    ubuntu: ros-rolling-rmf-dev
+rmf_visualization:
+    ubuntu: ros-rolling-rmf-visualization
+rmf_visualization_building_systems:
+    ubuntu: ros-rolling-rmf-visualization-building-systems
+rmf_visualization_fleet_states:
+    ubuntu: ros-rolling-rmf-visualization-fleet-states
+rmf_visualization_floorplans:
+    ubuntu: ros-rolling-rmf-visualization-floorplans
+rmf_visualization_navgraphs:
+    ubuntu: ros-rolling-rmf-visualization-navgraphs
+rmf_visualization_obstacles:
+    ubuntu: ros-rolling-rmf-visualization-obstacles
+rmf_visualization_rviz2_plugins:
+    ubuntu: ros-rolling-rmf-visualization-rviz2-plugins
+rmf_visualization_schedule:
+    ubuntu: ros-rolling-rmf-visualization-schedule
+rmf_visualization_msgs:
+    ubuntu: ros-rolling-rmf-visualization-msgs
+rmw:
+    ubuntu: ros-rolling-rmw
+rmw_implementation_cmake:
+    ubuntu: ros-rolling-rmw-implementation-cmake
+rmw_connextdds:
+    ubuntu: ros-rolling-rmw-connextdds
+rmw_connextdds_common:
+    ubuntu: ros-rolling-rmw-connextdds-common
+rti_connext_dds_cmake_module:
+    ubuntu: ros-rolling-rti-connext-dds-cmake-module
+rmw_cyclonedds_cpp:
+    ubuntu: ros-rolling-rmw-cyclonedds-cpp
+rmw_dds_common:
+    ubuntu: ros-rolling-rmw-dds-common
+rmw_fastrtps_cpp:
+    ubuntu: ros-rolling-rmw-fastrtps-cpp
+rmw_fastrtps_dynamic_cpp:
+    ubuntu: ros-rolling-rmw-fastrtps-dynamic-cpp
+rmw_fastrtps_shared_cpp:
+    ubuntu: ros-rolling-rmw-fastrtps-shared-cpp
+gurumdds_cmake_module:
+    ubuntu: ros-rolling-gurumdds-cmake-module
+rmw_gurumdds_cpp:
+    ubuntu: ros-rolling-rmw-gurumdds-cpp
+rmw_implementation:
+    ubuntu: ros-rolling-rmw-implementation
+rmw_zenoh_cpp:
+    ubuntu: ros-rolling-rmw-zenoh-cpp
+zenoh_cpp_vendor:
+    ubuntu: ros-rolling-zenoh-cpp-vendor
+robot_calibration:
+    ubuntu: ros-rolling-robot-calibration
+robot_calibration_msgs:
+    ubuntu: ros-rolling-robot-calibration-msgs
+robot_localization:
+    ubuntu: ros-rolling-robot-localization
+robot_state_publisher:
+    ubuntu: ros-rolling-robot-state-publisher
+robotraconteur:
+    ubuntu: ros-rolling-robotraconteur
+ros1_bridge:
+    ubuntu: ros-rolling-ros1-bridge
+canopen:
+    ubuntu: ros-rolling-canopen
+canopen_402_driver:
+    ubuntu: ros-rolling-canopen-402-driver
+canopen_base_driver:
+    ubuntu: ros-rolling-canopen-base-driver
+canopen_core:
+    ubuntu: ros-rolling-canopen-core
+canopen_fake_slaves:
+    ubuntu: ros-rolling-canopen-fake-slaves
+canopen_interfaces:
+    ubuntu: ros-rolling-canopen-interfaces
+canopen_master_driver:
+    ubuntu: ros-rolling-canopen-master-driver
+canopen_proxy_driver:
+    ubuntu: ros-rolling-canopen-proxy-driver
+canopen_ros2_control:
+    ubuntu: ros-rolling-canopen-ros2-control
+canopen_ros2_controllers:
+    ubuntu: ros-rolling-canopen-ros2-controllers
+canopen_tests:
+    ubuntu: ros-rolling-canopen-tests
+canopen_utils:
+    ubuntu: ros-rolling-canopen-utils
+lely_core_libraries:
+    ubuntu: ros-rolling-lely-core-libraries
+controller_interface:
+    ubuntu: ros-rolling-controller-interface
+controller_manager:
+    ubuntu: ros-rolling-controller-manager
+controller_manager_msgs:
+    ubuntu: ros-rolling-controller-manager-msgs
+hardware_interface:
+    ubuntu: ros-rolling-hardware-interface
+hardware_interface_testing:
+    ubuntu: ros-rolling-hardware-interface-testing
+joint_limits:
+    ubuntu: ros-rolling-joint-limits
+ros2_control:
+    ubuntu: ros-rolling-ros2-control
+ros2_control_test_assets:
+    ubuntu: ros-rolling-ros2-control-test-assets
+ros2controlcli:
+    ubuntu: ros-rolling-ros2controlcli
+rqt_controller_manager:
+    ubuntu: ros-rolling-rqt-controller-manager
+transmission_interface:
+    ubuntu: ros-rolling-transmission-interface
+ackermann_steering_controller:
+    ubuntu: ros-rolling-ackermann-steering-controller
+admittance_controller:
+    ubuntu: ros-rolling-admittance-controller
+bicycle_steering_controller:
+    ubuntu: ros-rolling-bicycle-steering-controller
+diff_drive_controller:
+    ubuntu: ros-rolling-diff-drive-controller
+effort_controllers:
+    ubuntu: ros-rolling-effort-controllers
+force_torque_sensor_broadcaster:
+    ubuntu: ros-rolling-force-torque-sensor-broadcaster
+forward_command_controller:
+    ubuntu: ros-rolling-forward-command-controller
+gpio_controllers:
+    ubuntu: ros-rolling-gpio-controllers
+gripper_controllers:
+    ubuntu: ros-rolling-gripper-controllers
+imu_sensor_broadcaster:
+    ubuntu: ros-rolling-imu-sensor-broadcaster
+joint_state_broadcaster:
+    ubuntu: ros-rolling-joint-state-broadcaster
+joint_trajectory_controller:
+    ubuntu: ros-rolling-joint-trajectory-controller
+mecanum_drive_controller:
+    ubuntu: ros-rolling-mecanum-drive-controller
+parallel_gripper_controller:
+    ubuntu: ros-rolling-parallel-gripper-controller
+pid_controller:
+    ubuntu: ros-rolling-pid-controller
+pose_broadcaster:
+    ubuntu: ros-rolling-pose-broadcaster
+position_controllers:
+    ubuntu: ros-rolling-position-controllers
+range_sensor_broadcaster:
+    ubuntu: ros-rolling-range-sensor-broadcaster
+ros2_controllers:
+    ubuntu: ros-rolling-ros2-controllers
+ros2_controllers_test_nodes:
+    ubuntu: ros-rolling-ros2-controllers-test-nodes
+rqt_joint_trajectory_controller:
+    ubuntu: ros-rolling-rqt-joint-trajectory-controller
+steering_controllers_library:
+    ubuntu: ros-rolling-steering-controllers-library
+tricycle_controller:
+    ubuntu: ros-rolling-tricycle-controller
+tricycle_steering_controller:
+    ubuntu: ros-rolling-tricycle-steering-controller
+velocity_controllers:
+    ubuntu: ros-rolling-velocity-controllers
+ros2_easy_test:
+    ubuntu: ros-rolling-ros2-easy-test
+kinova_gen3_6dof_robotiq_2f_85_moveit_config:
+    ubuntu: ros-rolling-kinova-gen3-6dof-robotiq-2f-85-moveit-config
+kinova_gen3_7dof_robotiq_2f_85_moveit_config:
+    ubuntu: ros-rolling-kinova-gen3-7dof-robotiq-2f-85-moveit-config
+kortex_api:
+    ubuntu: ros-rolling-kortex-api
+kortex_bringup:
+    ubuntu: ros-rolling-kortex-bringup
+kortex_description:
+    ubuntu: ros-rolling-kortex-description
+kortex_driver:
+    ubuntu: ros-rolling-kortex-driver
+robotiq_controllers:
+    ubuntu: ros-rolling-robotiq-controllers
+robotiq_description:
+    ubuntu: ros-rolling-robotiq-description
+ros2_socketcan:
+    ubuntu: ros-rolling-ros2-socketcan
+ros2_socketcan_msgs:
+    ubuntu: ros-rolling-ros2-socketcan-msgs
+lttngpy:
+    ubuntu: ros-rolling-lttngpy
+ros2trace:
+    ubuntu: ros-rolling-ros2trace
+tracetools:
+    ubuntu: ros-rolling-tracetools
+tracetools_launch:
+    ubuntu: ros-rolling-tracetools-launch
+tracetools_read:
+    ubuntu: ros-rolling-tracetools-read
+tracetools_test:
+    ubuntu: ros-rolling-tracetools-test
+tracetools_trace:
+    ubuntu: ros-rolling-tracetools-trace
+ros2acceleration:
+    ubuntu: ros-rolling-ros2acceleration
+ros2action:
+    ubuntu: ros-rolling-ros2action
+ros2cli:
+    ubuntu: ros-rolling-ros2cli
+ros2cli_test_interfaces:
+    ubuntu: ros-rolling-ros2cli-test-interfaces
+ros2component:
+    ubuntu: ros-rolling-ros2component
+ros2doctor:
+    ubuntu: ros-rolling-ros2doctor
+ros2interface:
+    ubuntu: ros-rolling-ros2interface
+ros2lifecycle:
+    ubuntu: ros-rolling-ros2lifecycle
+ros2lifecycle_test_fixtures:
+    ubuntu: ros-rolling-ros2lifecycle-test-fixtures
+ros2multicast:
+    ubuntu: ros-rolling-ros2multicast
+ros2node:
+    ubuntu: ros-rolling-ros2node
+ros2param:
+    ubuntu: ros-rolling-ros2param
+ros2pkg:
+    ubuntu: ros-rolling-ros2pkg
+ros2run:
+    ubuntu: ros-rolling-ros2run
+ros2service:
+    ubuntu: ros-rolling-ros2service
+ros2topic:
+    ubuntu: ros-rolling-ros2topic
+ros2cli_common_extensions:
+    ubuntu: ros-rolling-ros2cli-common-extensions
+ros2launch_security:
+    ubuntu: ros-rolling-ros2launch-security
+ros2launch_security_examples:
+    ubuntu: ros-rolling-ros2launch-security-examples
+ros_babel_fish:
+    ubuntu: ros-rolling-ros-babel-fish
+ros_babel_fish_test_msgs:
+    ubuntu: ros-rolling-ros-babel-fish-test-msgs
+battery_state_broadcaster:
+    ubuntu: ros-rolling-battery-state-broadcaster
+battery_state_rviz_overlay:
+    ubuntu: ros-rolling-battery-state-rviz-overlay
+can_msgs:
+    ubuntu: ros-rolling-can-msgs
+ros_environment:
+    ubuntu: ros-rolling-ros-environment
+ros_gz:
+    ubuntu: ros-rolling-ros-gz
+ros_gz_bridge:
+    ubuntu: ros-rolling-ros-gz-bridge
+ros_gz_image:
+    ubuntu: ros-rolling-ros-gz-image
+ros_gz_interfaces:
+    ubuntu: ros-rolling-ros-gz-interfaces
+ros_gz_sim:
+    ubuntu: ros-rolling-ros-gz-sim
+ros_gz_sim_demos:
+    ubuntu: ros-rolling-ros-gz-sim-demos
+test_ros_gz_bridge:
+    ubuntu: ros-rolling-test-ros-gz-bridge
+ros_image_to_qimage:
+    ubuntu: ros-rolling-ros-image-to-qimage
+ros_industrial_cmake_boilerplate:
+    ubuntu: ros-rolling-ros-industrial-cmake-boilerplate
+ros2test:
+    ubuntu: ros-rolling-ros2test
+ros_testing:
+    ubuntu: ros-rolling-ros-testing
+turtlesim:
+    ubuntu: ros-rolling-turtlesim
+turtlesim_msgs:
+    ubuntu: ros-rolling-turtlesim-msgs
+ros_workspace:
+    ubuntu: ros-rolling-ros-workspace
+liblz4_vendor:
+    ubuntu: ros-rolling-liblz4-vendor
+mcap_vendor:
+    ubuntu: ros-rolling-mcap-vendor
+ros2bag:
+    ubuntu: ros-rolling-ros2bag
+rosbag2:
+    ubuntu: ros-rolling-rosbag2
+rosbag2_compression:
+    ubuntu: ros-rolling-rosbag2-compression
+rosbag2_compression_zstd:
+    ubuntu: ros-rolling-rosbag2-compression-zstd
+rosbag2_cpp:
+    ubuntu: ros-rolling-rosbag2-cpp
+rosbag2_examples_cpp:
+    ubuntu: ros-rolling-rosbag2-examples-cpp
+rosbag2_examples_py:
+    ubuntu: ros-rolling-rosbag2-examples-py
+rosbag2_interfaces:
+    ubuntu: ros-rolling-rosbag2-interfaces
+rosbag2_performance_benchmarking:
+    ubuntu: ros-rolling-rosbag2-performance-benchmarking
+rosbag2_performance_benchmarking_msgs:
+    ubuntu: ros-rolling-rosbag2-performance-benchmarking-msgs
+rosbag2_py:
+    ubuntu: ros-rolling-rosbag2-py
+rosbag2_storage:
+    ubuntu: ros-rolling-rosbag2-storage
+rosbag2_storage_default_plugins:
+    ubuntu: ros-rolling-rosbag2-storage-default-plugins
+rosbag2_storage_mcap:
+    ubuntu: ros-rolling-rosbag2-storage-mcap
+rosbag2_storage_sqlite3:
+    ubuntu: ros-rolling-rosbag2-storage-sqlite3
+rosbag2_test_common:
+    ubuntu: ros-rolling-rosbag2-test-common
+rosbag2_test_msgdefs:
+    ubuntu: ros-rolling-rosbag2-test-msgdefs
+rosbag2_tests:
+    ubuntu: ros-rolling-rosbag2-tests
+rosbag2_transport:
+    ubuntu: ros-rolling-rosbag2-transport
+shared_queues_vendor:
+    ubuntu: ros-rolling-shared-queues-vendor
+sqlite3_vendor:
+    ubuntu: ros-rolling-sqlite3-vendor
+zstd_vendor:
+    ubuntu: ros-rolling-zstd-vendor
+rosbag2_bag_v2:
+    ubuntu: ros-rolling-rosbag2-bag-v2
+rosbag2_to_video:
+    ubuntu: ros-rolling-rosbag2-to-video
+rosapi:
+    ubuntu: ros-rolling-rosapi
+rosapi_msgs:
+    ubuntu: ros-rolling-rosapi-msgs
+rosbridge_library:
+    ubuntu: ros-rolling-rosbridge-library
+rosbridge_msgs:
+    ubuntu: ros-rolling-rosbridge-msgs
+rosbridge_server:
+    ubuntu: ros-rolling-rosbridge-server
+rosbridge_suite:
+    ubuntu: ros-rolling-rosbridge-suite
+rosbridge_test_msgs:
+    ubuntu: ros-rolling-rosbridge-test-msgs
+rosidl_adapter:
+    ubuntu: ros-rolling-rosidl-adapter
+rosidl_cli:
+    ubuntu: ros-rolling-rosidl-cli
+rosidl_cmake:
+    ubuntu: ros-rolling-rosidl-cmake
+rosidl_generator_c:
+    ubuntu: ros-rolling-rosidl-generator-c
+rosidl_generator_cpp:
+    ubuntu: ros-rolling-rosidl-generator-cpp
+rosidl_generator_type_description:
+    ubuntu: ros-rolling-rosidl-generator-type-description
+rosidl_parser:
+    ubuntu: ros-rolling-rosidl-parser
+rosidl_pycommon:
+    ubuntu: ros-rolling-rosidl-pycommon
+rosidl_runtime_c:
+    ubuntu: ros-rolling-rosidl-runtime-c
+rosidl_runtime_cpp:
+    ubuntu: ros-rolling-rosidl-runtime-cpp
+rosidl_typesupport_interface:
+    ubuntu: ros-rolling-rosidl-typesupport-interface
+rosidl_typesupport_introspection_c:
+    ubuntu: ros-rolling-rosidl-typesupport-introspection-c
+rosidl_typesupport_introspection_cpp:
+    ubuntu: ros-rolling-rosidl-typesupport-introspection-cpp
+rosidl_core_generators:
+    ubuntu: ros-rolling-rosidl-core-generators
+rosidl_core_runtime:
+    ubuntu: ros-rolling-rosidl-core-runtime
+rosidl_generator_dds_idl:
+    ubuntu: ros-rolling-rosidl-generator-dds-idl
+rosidl_default_generators:
+    ubuntu: ros-rolling-rosidl-default-generators
+rosidl_default_runtime:
+    ubuntu: ros-rolling-rosidl-default-runtime
+rosidl_dynamic_typesupport:
+    ubuntu: ros-rolling-rosidl-dynamic-typesupport
+rosidl_dynamic_typesupport_fastrtps:
+    ubuntu: ros-rolling-rosidl-dynamic-typesupport-fastrtps
+rosidl_generator_py:
+    ubuntu: ros-rolling-rosidl-generator-py
+rosidl_runtime_py:
+    ubuntu: ros-rolling-rosidl-runtime-py
+rosidl_typesupport_c:
+    ubuntu: ros-rolling-rosidl-typesupport-c
+rosidl_typesupport_cpp:
+    ubuntu: ros-rolling-rosidl-typesupport-cpp
+fastrtps_cmake_module:
+    ubuntu: ros-rolling-fastrtps-cmake-module
+rosidl_typesupport_fastrtps_c:
+    ubuntu: ros-rolling-rosidl-typesupport-fastrtps-c
+rosidl_typesupport_fastrtps_cpp:
+    ubuntu: ros-rolling-rosidl-typesupport-fastrtps-cpp
+rclpy_message_converter:
+    ubuntu: ros-rolling-rclpy-message-converter
+rclpy_message_converter_msgs:
+    ubuntu: ros-rolling-rclpy-message-converter-msgs
+rosx_introspection:
+    ubuntu: ros-rolling-rosx-introspection
+rot_conv:
+    ubuntu: ros-rolling-rot-conv
+rplidar_ros:
+    ubuntu: ros-rolling-rplidar-ros
+rpyutils:
+    ubuntu: ros-rolling-rpyutils
+rqt:
+    ubuntu: ros-rolling-rqt
+rqt_gui:
+    ubuntu: ros-rolling-rqt-gui
+rqt_gui_cpp:
+    ubuntu: ros-rolling-rqt-gui-cpp
+rqt_gui_py:
+    ubuntu: ros-rolling-rqt-gui-py
+rqt_py_common:
+    ubuntu: ros-rolling-rqt-py-common
+rqt_action:
+    ubuntu: ros-rolling-rqt-action
+rqt_bag:
+    ubuntu: ros-rolling-rqt-bag
+rqt_bag_plugins:
+    ubuntu: ros-rolling-rqt-bag-plugins
+rqt_common_plugins:
+    ubuntu: ros-rolling-rqt-common-plugins
+rqt_console:
+    ubuntu: ros-rolling-rqt-console
+rqt_dotgraph:
+    ubuntu: ros-rolling-rqt-dotgraph
+rqt_gauges:
+    ubuntu: ros-rolling-rqt-gauges
+rqt_graph:
+    ubuntu: ros-rolling-rqt-graph
+rqt_image_overlay:
+    ubuntu: ros-rolling-rqt-image-overlay
+rqt_image_overlay_layer:
+    ubuntu: ros-rolling-rqt-image-overlay-layer
+rqt_image_view:
+    ubuntu: ros-rolling-rqt-image-view
+rqt_moveit:
+    ubuntu: ros-rolling-rqt-moveit
+rqt_msg:
+    ubuntu: ros-rolling-rqt-msg
+rqt_plot:
+    ubuntu: ros-rolling-rqt-plot
+rqt_publisher:
+    ubuntu: ros-rolling-rqt-publisher
+rqt_py_console:
+    ubuntu: ros-rolling-rqt-py-console
+rqt_reconfigure:
+    ubuntu: ros-rolling-rqt-reconfigure
+rqt_robot_dashboard:
+    ubuntu: ros-rolling-rqt-robot-dashboard
+rqt_robot_monitor:
+    ubuntu: ros-rolling-rqt-robot-monitor
+rqt_robot_steering:
+    ubuntu: ros-rolling-rqt-robot-steering
+rqt_runtime_monitor:
+    ubuntu: ros-rolling-rqt-runtime-monitor
+rqt_service_caller:
+    ubuntu: ros-rolling-rqt-service-caller
+rqt_shell:
+    ubuntu: ros-rolling-rqt-shell
+rqt_srv:
+    ubuntu: ros-rolling-rqt-srv
+rqt_tf_tree:
+    ubuntu: ros-rolling-rqt-tf-tree
+rqt_topic:
+    ubuntu: ros-rolling-rqt-topic
+rsl:
+    ubuntu: ros-rolling-rsl
+rt_manipulators_cpp:
+    ubuntu: ros-rolling-rt-manipulators-cpp
+rt_manipulators_examples:
+    ubuntu: ros-rolling-rt-manipulators-examples
+rt_usb_9axisimu_driver:
+    ubuntu: ros-rolling-rt-usb-9axisimu-driver
+rtabmap:
+    ubuntu: ros-rolling-rtabmap
+rtcm_msgs:
+    ubuntu: ros-rolling-rtcm-msgs
+ruckig:
+    ubuntu: ros-rolling-ruckig
+rviz2:
+    ubuntu: ros-rolling-rviz2
+rviz_assimp_vendor:
+    ubuntu: ros-rolling-rviz-assimp-vendor
+rviz_common:
+    ubuntu: ros-rolling-rviz-common
+rviz_default_plugins:
+    ubuntu: ros-rolling-rviz-default-plugins
+rviz_ogre_vendor:
+    ubuntu: ros-rolling-rviz-ogre-vendor
+rviz_rendering:
+    ubuntu: ros-rolling-rviz-rendering
+rviz_rendering_tests:
+    ubuntu: ros-rolling-rviz-rendering-tests
+rviz_visual_testing_framework:
+    ubuntu: ros-rolling-rviz-visual-testing-framework
+rviz_2d_overlay_msgs:
+    ubuntu: ros-rolling-rviz-2d-overlay-msgs
+rviz_2d_overlay_plugins:
+    ubuntu: ros-rolling-rviz-2d-overlay-plugins
+rviz_visual_tools:
+    ubuntu: ros-rolling-rviz-visual-tools
+sdformat_test_files:
+    ubuntu: ros-rolling-sdformat-test-files
+sdformat_urdf:
+    ubuntu: ros-rolling-sdformat-urdf
+sdformat_vendor:
+    ubuntu: ros-rolling-sdformat-vendor
+septentrio_gnss_driver:
+    ubuntu: ros-rolling-septentrio-gnss-driver
+service_load_balancing:
+    ubuntu: ros-rolling-service-load-balancing
+sick_safetyscanners2:
+    ubuntu: ros-rolling-sick-safetyscanners2
+sick_safetyscanners2_interfaces:
+    ubuntu: ros-rolling-sick-safetyscanners2-interfaces
+sick_safetyscanners_base:
+    ubuntu: ros-rolling-sick-safetyscanners-base
+sick_safevisionary_base:
+    ubuntu: ros-rolling-sick-safevisionary-base
+sick_safevisionary_driver:
+    ubuntu: ros-rolling-sick-safevisionary-driver
+sick_safevisionary_interfaces:
+    ubuntu: ros-rolling-sick-safevisionary-interfaces
+sick_safevisionary_tests:
+    ubuntu: ros-rolling-sick-safevisionary-tests
+simple_actions:
+    ubuntu: ros-rolling-simple-actions
+simple_grasping:
+    ubuntu: ros-rolling-simple-grasping
+simple_launch:
+    ubuntu: ros-rolling-simple-launch
+slg_msgs:
+    ubuntu: ros-rolling-slg-msgs
+slider_publisher:
+    ubuntu: ros-rolling-slider-publisher
+executive_smach:
+    ubuntu: ros-rolling-executive-smach
+smach:
+    ubuntu: ros-rolling-smach
+smach_msgs:
+    ubuntu: ros-rolling-smach-msgs
+smach_ros:
+    ubuntu: ros-rolling-smach-ros
+snowbot_operating_system:
+    ubuntu: ros-rolling-snowbot-operating-system
+soar_ros:
+    ubuntu: ros-rolling-soar-ros
+soccer_geometry_msgs:
+    ubuntu: ros-rolling-soccer-geometry-msgs
+soccer_interfaces:
+    ubuntu: ros-rolling-soccer-interfaces
+soccer_model_msgs:
+    ubuntu: ros-rolling-soccer-model-msgs
+soccer_vision_2d_msgs:
+    ubuntu: ros-rolling-soccer-vision-2d-msgs
+soccer_vision_3d_msgs:
+    ubuntu: ros-rolling-soccer-vision-3d-msgs
+soccer_vision_attribute_msgs:
+    ubuntu: ros-rolling-soccer-vision-attribute-msgs
+soccer_vision_3d_rviz_markers:
+    ubuntu: ros-rolling-soccer-vision-3d-rviz-markers
+sol_vendor:
+    ubuntu: ros-rolling-sol-vendor
+sophus:
+    ubuntu: ros-rolling-sophus
+spdlog_vendor:
+    ubuntu: ros-rolling-spdlog-vendor
+srdfdom:
+    ubuntu: ros-rolling-srdfdom
+sros2:
+    ubuntu: ros-rolling-sros2
+sros2_cmake:
+    ubuntu: ros-rolling-sros2-cmake
+steering_functions:
+    ubuntu: ros-rolling-steering-functions
+stomp:
+    ubuntu: ros-rolling-stomp
+swri_console:
+    ubuntu: ros-rolling-swri-console
+system_fingerprint:
+    ubuntu: ros-rolling-system-fingerprint
+launch_system_modes:
+    ubuntu: ros-rolling-launch-system-modes
+system_modes:
+    ubuntu: ros-rolling-system-modes
+system_modes_examples:
+    ubuntu: ros-rolling-system-modes-examples
+system_modes_msgs:
+    ubuntu: ros-rolling-system-modes-msgs
+system_tests:
+    ubuntu: ros-rolling-system-tests
+tango_icons_vendor:
+    ubuntu: ros-rolling-tango-icons-vendor
+joy_teleop:
+    ubuntu: ros-rolling-joy-teleop
+key_teleop:
+    ubuntu: ros-rolling-key-teleop
+mouse_teleop:
+    ubuntu: ros-rolling-mouse-teleop
+teleop_tools:
+    ubuntu: ros-rolling-teleop-tools
+teleop_tools_msgs:
+    ubuntu: ros-rolling-teleop-tools-msgs
+teleop_twist_joy:
+    ubuntu: ros-rolling-teleop-twist-joy
+teleop_twist_keyboard:
+    ubuntu: ros-rolling-teleop-twist-keyboard
+tensorrt_cmake_module:
+    ubuntu: ros-rolling-tensorrt-cmake-module
+test_interface_files:
+    ubuntu: ros-rolling-test-interface-files
+tf2_2d:
+    ubuntu: ros-rolling-tf2-2d
+tf_transformations:
+    ubuntu: ros-rolling-tf-transformations
+tinyspline_vendor:
+    ubuntu: ros-rolling-tinyspline-vendor
+tinyxml2_vendor:
+    ubuntu: ros-rolling-tinyxml2-vendor
+tinyxml_vendor:
+    ubuntu: ros-rolling-tinyxml-vendor
+tlsf:
+    ubuntu: ros-rolling-tlsf
+topic_based_ros2_control:
+    ubuntu: ros-rolling-topic-based-ros2-control
+topic_tools:
+    ubuntu: ros-rolling-topic-tools
+topic_tools_interfaces:
+    ubuntu: ros-rolling-topic-tools-interfaces
+trac_ik:
+    ubuntu: ros-rolling-trac-ik
+trac_ik_kinematics_plugin:
+    ubuntu: ros-rolling-trac-ik-kinematics-plugin
+trac_ik_lib:
+    ubuntu: ros-rolling-trac-ik-lib
+tracetools_acceleration:
+    ubuntu: ros-rolling-tracetools-acceleration
+ros2trace_analysis:
+    ubuntu: ros-rolling-ros2trace-analysis
+tracetools_analysis:
+    ubuntu: ros-rolling-tracetools-analysis
+asio_cmake_module:
+    ubuntu: ros-rolling-asio-cmake-module
+io_context:
+    ubuntu: ros-rolling-io-context
+serial_driver:
+    ubuntu: ros-rolling-serial-driver
+udp_driver:
+    ubuntu: ros-rolling-udp-driver
+turbojpeg_compressed_image_transport:
+    ubuntu: ros-rolling-turbojpeg-compressed-image-transport
+turtle_nest:
+    ubuntu: ros-rolling-turtle-nest
+turtlebot3_msgs:
+    ubuntu: ros-rolling-turtlebot3-msgs
+turtlebot3_fake_node:
+    ubuntu: ros-rolling-turtlebot3-fake-node
+turtlebot3_gazebo:
+    ubuntu: ros-rolling-turtlebot3-gazebo
+turtlebot3_simulations:
+    ubuntu: ros-rolling-turtlebot3-simulations
+tuw_geometry:
+    ubuntu: ros-rolling-tuw-geometry
+tuw_airskin_msgs:
+    ubuntu: ros-rolling-tuw-airskin-msgs
+tuw_geo_msgs:
+    ubuntu: ros-rolling-tuw-geo-msgs
+tuw_geometry_msgs:
+    ubuntu: ros-rolling-tuw-geometry-msgs
+tuw_graph_msgs:
+    ubuntu: ros-rolling-tuw-graph-msgs
+tuw_msgs:
+    ubuntu: ros-rolling-tuw-msgs
+tuw_multi_robot_msgs:
+    ubuntu: ros-rolling-tuw-multi-robot-msgs
+tuw_nav_msgs:
+    ubuntu: ros-rolling-tuw-nav-msgs
+tuw_object_map_msgs:
+    ubuntu: ros-rolling-tuw-object-map-msgs
+tuw_object_msgs:
+    ubuntu: ros-rolling-tuw-object-msgs
+tuw_std_msgs:
+    ubuntu: ros-rolling-tuw-std-msgs
+tvm_vendor:
+    ubuntu: ros-rolling-tvm-vendor
+twist_mux:
+    ubuntu: ros-rolling-twist-mux
+twist_mux_msgs:
+    ubuntu: ros-rolling-twist-mux-msgs
+twist_stamper:
+    ubuntu: ros-rolling-twist-stamper
+ublox:
+    ubuntu: ros-rolling-ublox
+ublox_gps:
+    ubuntu: ros-rolling-ublox-gps
+ublox_msgs:
+    ubuntu: ros-rolling-ublox-msgs
+ublox_serialization:
+    ubuntu: ros-rolling-ublox-serialization
+ntrip_client_node:
+    ubuntu: ros-rolling-ntrip-client-node
+ublox_dgnss:
+    ubuntu: ros-rolling-ublox-dgnss
+ublox_dgnss_node:
+    ubuntu: ros-rolling-ublox-dgnss-node
+ublox_nav_sat_fix_hp_node:
+    ubuntu: ros-rolling-ublox-nav-sat-fix-hp-node
+ublox_ubx_interfaces:
+    ubuntu: ros-rolling-ublox-ubx-interfaces
+ublox_ubx_msgs:
+    ubuntu: ros-rolling-ublox-ubx-msgs
+udp_msgs:
+    ubuntu: ros-rolling-udp-msgs
+uncrustify_vendor:
+    ubuntu: ros-rolling-uncrustify-vendor
+unique_identifier_msgs:
+    ubuntu: ros-rolling-unique-identifier-msgs
+ur_client_library:
+    ubuntu: ros-rolling-ur-client-library
+ur_description:
+    ubuntu: ros-rolling-ur-description
+ur_msgs:
+    ubuntu: ros-rolling-ur-msgs
+ur:
+    ubuntu: ros-rolling-ur
+ur_calibration:
+    ubuntu: ros-rolling-ur-calibration
+ur_controllers:
+    ubuntu: ros-rolling-ur-controllers
+ur_dashboard_msgs:
+    ubuntu: ros-rolling-ur-dashboard-msgs
+ur_moveit_config:
+    ubuntu: ros-rolling-ur-moveit-config
+ur_robot_driver:
+    ubuntu: ros-rolling-ur-robot-driver
+ur_simulation_gz:
+    ubuntu: ros-rolling-ur-simulation-gz
+urdf:
+    ubuntu: ros-rolling-urdf
+urdf_parser_plugin:
+    ubuntu: ros-rolling-urdf-parser-plugin
+urdf_launch:
+    ubuntu: ros-rolling-urdf-launch
+urdfdom_py:
+    ubuntu: ros-rolling-urdfdom-py
+urdf_tutorial:
+    ubuntu: ros-rolling-urdf-tutorial
+urdfdom:
+    ubuntu: ros-rolling-urdfdom
+urdfdom_headers:
+    ubuntu: ros-rolling-urdfdom-headers
+urg_c:
+    ubuntu: ros-rolling-urg-c
+urg_node:
+    ubuntu: ros-rolling-urg-node
+urg_node_msgs:
+    ubuntu: ros-rolling-urg-node-msgs
+usb_cam:
+    ubuntu: ros-rolling-usb-cam
+v4l2_camera:
+    ubuntu: ros-rolling-v4l2-camera
+desktop:
+    ubuntu: ros-rolling-desktop
+desktop_full:
+    ubuntu: ros-rolling-desktop-full
+perception:
+    ubuntu: ros-rolling-perception
+ros_base:
+    ubuntu: ros-rolling-ros-base
+ros_core:
+    ubuntu: ros-rolling-ros-core
+simulation:
+    ubuntu: ros-rolling-simulation
+velodyne:
+    ubuntu: ros-rolling-velodyne
+velodyne_driver:
+    ubuntu: ros-rolling-velodyne-driver
+velodyne_laserscan:
+    ubuntu: ros-rolling-velodyne-laserscan
+velodyne_msgs:
+    ubuntu: ros-rolling-velodyne-msgs
+velodyne_pointcloud:
+    ubuntu: ros-rolling-velodyne-pointcloud
+velodyne_description:
+    ubuntu: ros-rolling-velodyne-description
+velodyne_gazebo_plugins:
+    ubuntu: ros-rolling-velodyne-gazebo-plugins
+velodyne_simulator:
+    ubuntu: ros-rolling-velodyne-simulator
+vision_msgs:
+    ubuntu: ros-rolling-vision-msgs
+vision_msgs_rviz_plugins:
+    ubuntu: ros-rolling-vision-msgs-rviz-plugins
+vision_msgs_layers:
+    ubuntu: ros-rolling-vision-msgs-layers
+cv_bridge:
+    ubuntu: ros-rolling-cv-bridge
+image_geometry:
+    ubuntu: ros-rolling-image-geometry
+vision_opencv:
+    ubuntu: ros-rolling-vision-opencv
+visp:
+    ubuntu: ros-rolling-visp
+vitis_common:
+    ubuntu: ros-rolling-vitis-common
+vrpn:
+    ubuntu: ros-rolling-vrpn
+vrpn_mocap:
+    ubuntu: ros-rolling-vrpn-mocap
+warehouse_ros:
+    ubuntu: ros-rolling-warehouse-ros
+warehouse_ros_sqlite:
+    ubuntu: ros-rolling-warehouse-ros-sqlite
+web_video_server:
+    ubuntu: ros-rolling-web-video-server
+webots_ros2:
+    ubuntu: ros-rolling-webots-ros2
+webots_ros2_control:
+    ubuntu: ros-rolling-webots-ros2-control
+webots_ros2_driver:
+    ubuntu: ros-rolling-webots-ros2-driver
+webots_ros2_epuck:
+    ubuntu: ros-rolling-webots-ros2-epuck
+webots_ros2_importer:
+    ubuntu: ros-rolling-webots-ros2-importer
+webots_ros2_mavic:
+    ubuntu: ros-rolling-webots-ros2-mavic
+webots_ros2_msgs:
+    ubuntu: ros-rolling-webots-ros2-msgs
+webots_ros2_tesla:
+    ubuntu: ros-rolling-webots-ros2-tesla
+webots_ros2_tests:
+    ubuntu: ros-rolling-webots-ros2-tests
+webots_ros2_tiago:
+    ubuntu: ros-rolling-webots-ros2-tiago
+webots_ros2_turtlebot:
+    ubuntu: ros-rolling-webots-ros2-turtlebot
+webots_ros2_universal_robot:
+    ubuntu: ros-rolling-webots-ros2-universal-robot
+xacro:
+    ubuntu: ros-rolling-xacro
+yaml_cpp_vendor:
+    ubuntu: ros-rolling-yaml-cpp-vendor
+yasmin:
+    ubuntu: ros-rolling-yasmin
+yasmin_demos:
+    ubuntu: ros-rolling-yasmin-demos
+yasmin_msgs:
+    ubuntu: ros-rolling-yasmin-msgs
+yasmin_ros:
+    ubuntu: ros-rolling-yasmin-ros
+yasmin_viewer:
+    ubuntu: ros-rolling-yasmin-viewer
+zbar_ros:
+    ubuntu: ros-rolling-zbar-ros
+zbar_ros_interfaces:
+    ubuntu: ros-rolling-zbar-ros-interfaces
+zenoh_bridge_dds:
+    ubuntu: ros-rolling-zenoh-bridge-dds
+zmqpp_vendor:
+    ubuntu: ros-rolling-zmqpp-vendor

--- a/ros.osdeps-rolling
+++ b/ros.osdeps-rolling
@@ -2,6 +2,8 @@
 # This file is generated, do not edit!
 # based on https://raw.githubusercontent.com/ros/rosdistro/refs/heads/master/rolling/distribution.yaml
 #
+# If you need a refresh, call autoproj reconfigure or delete just this file and run autoproj update --config
+#
 smacc2:
     ubuntu: ros-rolling-smacc2
 smacc2_msgs:

--- a/ubuntu.osdeps
+++ b/ubuntu.osdeps
@@ -1,0 +1,1 @@
+# dummy file for autoproj to recognize the <THIS_FILE>-<ROSNAME> osdeps files

--- a/ubuntu.osdeps-humble
+++ b/ubuntu.osdeps-humble
@@ -2,6 +2,8 @@
 # This file is generated, do not edit!
 # based on https://github.com/ros/rosdistro tag humble/2024-12-20
 #
+# If you need a refresh, call autoproj reconfigure or delete just this file and run autoproj update --config
+#
 ace:
     ubuntu: ["libace-dev"]
 

--- a/ubuntu.osdeps-humble
+++ b/ubuntu.osdeps-humble
@@ -1,0 +1,7778 @@
+#
+# This file is generated, do not edit!
+# based on https://github.com/ros/rosdistro tag humble/2024-12-20
+#
+ace:
+    ubuntu: ["libace-dev"]
+
+ack:
+    ubuntu:
+        default: ["ack"]
+
+ack-grep:
+    ubuntu: ["ack-grep"]
+
+acl:
+    ubuntu: ["acl", "libacl1-dev"]
+
+acpi:
+    ubuntu: ["acpi"]
+
+alsa-oss:
+    ubuntu: ["alsa-oss"]
+
+alsa-utils:
+    ubuntu: ["alsa-utils"]
+
+ant:
+    ubuntu: ["ant"]
+
+antlr:
+    ubuntu: ["antlr", "libantlr-dev"]
+
+apache2:
+    ubuntu: ["apache2"]
+
+apache2-mpm-prefork:
+    ubuntu: ["apache2-mpm-prefork"]
+
+apparmor:
+    ubuntu: ["apparmor"]
+
+apr:
+    ubuntu: ["libapr1-dev", "libaprutil1-dev"]
+
+apt-transport-https:
+    ubuntu: ["apt-transport-https"]
+
+aravis:
+    ubuntu:
+        default: ["libaravis-0.8-0", "aravis-tools"]
+        bionic: nonexistent
+        focal: ["libaravis-0.6-0", "aravis-tools"]
+
+aravis-dev:
+    ubuntu:
+        default: ["libaravis-dev"]
+        bionic: nonexistent
+
+arduino-core:
+    ubuntu: ["arduino-core"]
+
+arista:
+    ubuntu: ["arista"]
+
+armadillo:
+    ubuntu: ["libarmadillo-dev"]
+
+asio:
+    ubuntu: ["libasio-dev"]
+
+assimp:
+    ubuntu:
+        default: ["libassimp-dev"]
+
+assimp-dev:
+    ubuntu:
+        default: ["libassimp-dev"]
+
+at-spi2-core:
+    ubuntu: ["at-spi2-core"]
+
+atlas:
+    ubuntu: ["libatlas-base-dev"]
+
+autoconf:
+    ubuntu: ["autoconf"]
+
+autoconf-archive:
+    ubuntu: ["autoconf-archive"]
+
+automake:
+    ubuntu: ["automake"]
+
+autopoint:
+    ubuntu: ["autopoint"]
+
+autossh:
+    ubuntu: ["autossh"]
+
+avahi-daemon:
+    ubuntu: ["avahi-daemon"]
+
+avahi-utils:
+    ubuntu: ["avahi-utils"]
+
+avr-libc:
+    ubuntu: ["avr-libc"]
+
+avrdude:
+    ubuntu: ["avrdude"]
+
+awscli:
+    ubuntu: ["awscli"]
+
+babeltrace:
+    ubuntu: ["babeltrace"]
+
+bandit:
+    ubuntu: ["bandit"]
+
+bazaar:
+    ubuntu: ["bzr"]
+
+beep:
+    ubuntu: ["beep"]
+
+benchmark:
+    ubuntu:
+        default: ["libbenchmark-dev"]
+
+binutils:
+    ubuntu: ["binutils-dev"]
+
+bison:
+    ubuntu: ["bison"]
+
+blender:
+    ubuntu: ["blender"]
+
+bluez:
+    ubuntu: ["bluez"]
+
+boost:
+    ubuntu: ["libboost-all-dev"]
+
+box2d-dev:
+    ubuntu: ["libbox2d-dev"]
+
+bullet:
+    ubuntu:
+        default: ["libbullet-dev"]
+
+bullet-extras:
+    ubuntu: ["libbullet-extras-dev"]
+
+bzip2:
+    ubuntu: ["libbz2-dev"]
+
+ca-certificates:
+    ubuntu: ["ca-certificates"]
+
+can-utils:
+    ubuntu: ["can-utils"]
+
+cargo:
+    ubuntu: ["cargo"]
+
+castxml:
+    ubuntu: ["castxml"]
+
+catch2:
+    ubuntu:
+        default: ["catch2"]
+        focal: nonexistent
+
+cccc:
+    ubuntu: ["cccc"]
+
+cdk:
+    ubuntu: ["libcdk5"]
+
+cdk-dev:
+    ubuntu: ["libcdk5-dev"]
+
+cgal:
+    ubuntu: ["libcgal-dev"]
+
+cgal-qt5-dev:
+    ubuntu: ["libcgal-qt5-dev"]
+
+checkinstall:
+    ubuntu: ["checkinstall"]
+
+chromedriver:
+    ubuntu: ["chromium-chromedriver"]
+
+chromium-browser:
+    ubuntu: ["chromium-browser"]
+
+chrony:
+    ubuntu: ["chrony"]
+
+clang:
+    ubuntu: ["clang"]
+
+clang-format:
+    ubuntu: ["clang-format"]
+
+clang-tidy:
+    ubuntu:
+        default: ["clang-tidy"]
+
+clangd:
+    ubuntu: ["clangd"]
+
+cli11:
+    ubuntu:
+        default: ["libcli11-dev"]
+        focal: nonexistent
+
+cmake:
+    ubuntu: ["cmake"]
+
+coinor-libcbc-dev:
+    ubuntu: ["coinor-libcbc-dev"]
+
+coinor-libcbc3:
+    ubuntu: ["coinor-libcbc3"]
+
+coinor-libcgl-dev:
+    ubuntu: ["coinor-libcgl-dev"]
+
+coinor-libclp-dev:
+    ubuntu: ["coinor-libclp-dev"]
+
+coinor-libcoinutils-dev:
+    ubuntu: ["coinor-libcoinutils-dev"]
+
+coinor-libipopt-dev:
+    ubuntu: ["coinor-libipopt-dev"]
+
+coinor-libosi-dev:
+    ubuntu: ["coinor-libosi-dev"]
+
+collada-dom:
+    ubuntu:
+        default: ["libcollada-dom2.4-dp-dev"]
+
+collectd:
+    ubuntu: ["collectd"]
+
+collectd-utils:
+    ubuntu: ["collectd-utils"]
+
+comedi:
+    ubuntu: ["libcomedi-dev"]
+
+coreutils:
+    ubuntu: ["coreutils"]
+
+couchdb:
+    ubuntu: ["couchdb"]
+
+cppad:
+    ubuntu: ["cppad"]
+
+cppcheck:
+    ubuntu: ["cppcheck"]
+
+cppunit:
+    ubuntu: ["libcppunit-dev"]
+
+cpuburn:
+    ubuntu: ["cpuburn"]
+
+crypto++:
+    ubuntu: ["libcrypto++-dev"]
+
+curl:
+    ubuntu: ["libcurl4-openssl-dev", "curl"]
+
+curlpp-dev:
+    ubuntu: ["libcurlpp-dev"]
+
+cvs:
+    ubuntu: ["cvs"]
+
+cwiid:
+    ubuntu: ["libcwiid1"]
+
+cwiid-dev:
+    ubuntu: ["libcwiid-dev"]
+
+daemontools:
+    ubuntu: ["daemontools"]
+
+darknet:
+    ubuntu: ["darknet"]
+
+dcraw:
+    ubuntu: ["dcraw"]
+
+debhelper:
+    ubuntu: ["debhelper"]
+
+debtree:
+    ubuntu: ["debtree"]
+
+devilspie2:
+    ubuntu: ["devilspie2"]
+
+devscripts:
+    ubuntu: ["devscripts"]
+
+dfu-util:
+    ubuntu: ["dfu-util"]
+
+dh-python:
+    ubuntu: ["dh-python"]
+
+disper:
+    ubuntu: ["disper"]
+
+dkms:
+    ubuntu: ["dkms"]
+
+dnsmasq:
+    ubuntu: ["dnsmasq"]
+
+docker-compose:
+    ubuntu: ["docker-compose"]
+
+docker.io:
+    ubuntu: ["docker.io"]
+
+doxygen:
+    ubuntu: ["doxygen"]
+
+dpkg:
+    ubuntu: ["dpkg"]
+
+dpkg-dev:
+    ubuntu: ["dpkg-dev"]
+
+dvipng:
+    ubuntu: ["dvipng"]
+
+e2fsprogs:
+    ubuntu: ["e2fsprogs"]
+
+eclipse:
+    ubuntu:
+        karmic: ["eclipse", "eclipse-platform", "eclipse-rcp", "eclipse-pde"]
+
+ed:
+    ubuntu: ["ed"]
+
+eigen:
+    ubuntu: ["libeigen3-dev"]
+
+eigen2:
+    ubuntu: ["libeigen2-dev"]
+
+emacs:
+    ubuntu: ["emacs"]
+
+embree:
+    ubuntu:
+        default: ["libembree-dev"]
+        bionic: nonexistent
+
+enblend:
+    ubuntu: ["enblend"]
+
+enet:
+    ubuntu: ["libenet-dev"]
+
+espeak:
+    ubuntu: ["espeak"]
+
+ethtool:
+    ubuntu: ["ethtool"]
+
+exfat-fuse:
+    ubuntu: ["exfat-fuse"]
+
+exfat-utils:
+    ubuntu: ["exfat-utils"]
+
+exiv2:
+    ubuntu: ["exiv2"]
+
+f2c:
+    ubuntu: ["f2c", "libf2c2", "libf2c2-dev"]
+
+fakeroot:
+    ubuntu: ["fakeroot"]
+
+fcgi:
+    ubuntu: ["libfcgi-dev", "libapache2-mod-fastcgi", "spawn-fcgi"]
+
+festival:
+    ubuntu: ["festival", "festvox-kallpc16k"]
+
+festival-dev:
+    ubuntu: ["festival-dev"]
+
+ffmpeg:
+    ubuntu:
+        default: ["ffmpeg", "libavcodec-dev", "libavformat-dev", "libavutil-dev", "libswscale-dev"]
+
+ffmpeg-dev:
+    ubuntu: ["libavcodec-dev", "libavdevice-dev", "libavfilter-dev", "libavformat-dev", "libavutil-dev", "libpostproc-dev", "libswresample-dev", "libswscale-dev"]
+
+ffmpeg2theora:
+    ubuntu: ["ffmpeg2theora"]
+
+file:
+    ubuntu: ["file"]
+
+filezilla:
+    ubuntu: ["filezilla"]
+
+flac:
+    ubuntu: ["flac"]
+
+flawfinder:
+    ubuntu: ["flawfinder"]
+
+flex:
+    ubuntu: ["flex"]
+
+flite:
+    ubuntu: ["flite"]
+
+fltk:
+    ubuntu:
+        bionic: ["fluid", "libfltk1.3-dev"]
+        focal: ["fluid", "libfltk1.3-dev"]
+
+fluid:
+    ubuntu: ["fluid"]
+
+fluidsynth:
+    ubuntu: ["fluidsynth"]
+
+fmt:
+    ubuntu: ["libfmt-dev"]
+
+fonts-noto:
+    ubuntu: ["fonts-noto"]
+
+fonts-roboto:
+    ubuntu: ["fonts-roboto-hinted", "fonts-roboto-unhinted"]
+
+fping:
+    ubuntu: ["fping"]
+
+freeimage:
+    ubuntu: ["libfreeimage-dev"]
+
+freetype:
+    ubuntu: ["libfreetype6"]
+
+fsharp:
+    ubuntu: ["fsharp"]
+
+fswebcam:
+    ubuntu: ["fswebcam"]
+
+ftdi-eeprom:
+    ubuntu: ["ftdi-eeprom"]
+
+fxload:
+    ubuntu: ["fxload"]
+
+g++-10:
+    ubuntu:
+        focal: ["g++-10"]
+        jammy: ["g++-10"]
+
+g++-5-arm-linux-gnueabihf:
+    ubuntu: ["g++-5-arm-linux-gnueabihf"]
+
+g++-5-multilib:
+    ubuntu: ["g++-5-multilib"]
+
+g++-multilib:
+    ubuntu: ["g++-multilib"]
+
+g++-static:
+    ubuntu: ["g++"]
+
+gamin:
+    ubuntu: ["gamin"]
+
+gawk:
+    ubuntu: ["gawk"]
+
+gazebo:
+    ubuntu:
+        bionic: ["gazebo9"]
+        focal: ["gazebo11"]
+        jammy: ["gazebo"]
+
+gazebo11:
+    ubuntu:
+        focal: ["gazebo11"]
+        jammy: ["gazebo"]
+
+gazebo5:
+    ubuntu: ["gazebo5"]
+
+gazebo7:
+    ubuntu: ["gazebo7"]
+
+gazebo9:
+    ubuntu:
+        bionic: ["gazebo9"]
+
+gcc-arm-none-eabi:
+    ubuntu: ["gcc-arm-none-eabi"]
+
+gcc-avr:
+    ubuntu: ["gcc-avr"]
+
+gcc-multilib:
+    ubuntu: ["gcc-multilib"]
+
+gcc-static:
+    ubuntu: ["gcc"]
+
+gccxml:
+    ubuntu: ["gccxml"]
+
+gcovr:
+    ubuntu: ["gcovr"]
+
+gdal-bin:
+    ubuntu: ["gdal-bin"]
+
+geographiclib:
+    ubuntu:
+        default: ["libgeographiclib-dev"]
+        focal: ["libgeographic-dev"]
+        jammy: ["libgeographic-dev"]
+
+geographiclib-tools:
+    ubuntu: ["geographiclib-tools"]
+
+geos:
+    ubuntu: ["libgeos-dev"]
+
+gettext-base:
+    ubuntu: ["gettext-base"]
+
+gforth:
+    ubuntu: ["gforth"]
+
+gfortran:
+    ubuntu: ["gfortran"]
+
+ghc:
+    ubuntu: ["ghc"]
+
+gifsicle:
+    ubuntu: ["gifsicle"]
+
+gimp:
+    ubuntu: ["gimp"]
+
+git:
+    ubuntu: ["git"]
+
+git-lfs:
+    ubuntu: ["git-lfs"]
+
+gitg:
+    ubuntu: ["gitg"]
+
+gitk:
+    ubuntu: ["gitk"]
+
+gksu:
+    ubuntu: ["gksu"]
+
+glpk:
+    ubuntu: ["libglpk-dev"]
+
+glslang-dev:
+    ubuntu: ["glslang-dev"]
+
+glslc:
+    ubuntu:
+        default: ["glslc"]
+        focal: nonexistent
+        jammy: nonexistent
+
+glut:
+    ubuntu: ["freeglut3-dev"]
+
+gnat:
+    ubuntu: ["gnat"]
+
+gnome-terminal:
+    ubuntu: ["gnome-terminal"]
+
+gnuplot:
+    ubuntu: ["gnuplot"]
+
+gnuplot-iostream:
+    ubuntu: ["libgnuplot-iostream-dev"]
+
+gnuplot-x11:
+    ubuntu: ["gnuplot-x11"]
+
+golang-go:
+    ubuntu: ["golang-go"]
+
+google-mock:
+    ubuntu: ["google-mock"]
+
+gpac:
+    ubuntu: ["gpac"]
+
+gperf:
+    ubuntu: ["gperf"]
+
+gperftools:
+    ubuntu: ["google-perftools", "libgoogle-perftools-dev"]
+
+gpg-agent:
+    ubuntu:
+        default: ["gpg-agent"]
+
+gphoto2:
+    ubuntu: ["gphoto2"]
+
+gprbuild:
+    ubuntu: ["gprbuild"]
+
+gpsd:
+    ubuntu: ["gpsd"]
+
+gradle:
+    ubuntu: ["gradle"]
+
+graphicsmagick:
+    ubuntu: ["libgraphicsmagick++1-dev", "graphicsmagick-libmagick-dev-compat"]
+
+graphviz:
+    ubuntu: ["graphviz"]
+
+graphviz-dev:
+    ubuntu: ["libgraphviz-dev"]
+
+gringo:
+    ubuntu: ["gringo"]
+
+gstreamer0.10-plugins-good:
+    ubuntu: ["gstreamer0.10-plugins-good"]
+
+gstreamer0.10-pocketsphinx:
+    ubuntu: ["gstreamer0.10-pocketsphinx"]
+
+gstreamer1.0:
+    ubuntu: ["gstreamer1.0-tools", "libgstreamer1.0-0", "gir1.2-gstreamer-1.0"]
+
+gstreamer1.0-alsa:
+    ubuntu: ["gstreamer1.0-alsa"]
+
+gstreamer1.0-gl:
+    ubuntu:
+        default: ["gstreamer1.0-gl"]
+
+gstreamer1.0-libav:
+    ubuntu: ["gstreamer1.0-libav"]
+
+gstreamer1.0-plugins-bad:
+    ubuntu: ["gstreamer1.0-plugins-bad"]
+
+gstreamer1.0-plugins-base:
+    ubuntu: ["gstreamer1.0-plugins-base", "libgstreamer-plugins-base1.0-0", "gir1.2-gst-plugins-base-1.0"]
+
+gstreamer1.0-plugins-good:
+    ubuntu: ["gstreamer1.0-plugins-good", "libgstreamer-plugins-good1.0-0"]
+
+gstreamer1.0-plugins-ugly:
+    ubuntu: ["gstreamer1.0-plugins-ugly"]
+
+gstreamer1.0-rtsp:
+    ubuntu: ["gstreamer1.0-rtsp"]
+
+gstreamer1.0-tools:
+    ubuntu: ["gstreamer1.0-tools"]
+
+gstreamer1.0-x:
+    ubuntu: ["gstreamer1.0-x"]
+
+gtest:
+    ubuntu: ["libgtest-dev"]
+
+gtk-doc-tools:
+    ubuntu: ["gtk-doc-tools"]
+
+gtk2:
+    ubuntu: ["libgtk2.0-dev"]
+
+gtk3:
+    ubuntu: ["libgtk-3-dev"]
+
+gurumdds-2.6:
+    ubuntu:
+        bionic: ["gurumdds-2.6"]
+        focal: ["gurumdds-2.6"]
+
+gurumdds-2.7:
+    ubuntu:
+        bionic: ["gurumdds-2.7"]
+        focal: ["gurumdds-2.7"]
+
+gurumdds-2.8:
+    ubuntu:
+        bionic: ["gurumdds-2.8"]
+        focal: ["gurumdds-2.8"]
+        jammy: ["gurumdds-2.8"]
+
+gurumdds-3.0:
+    ubuntu:
+        jammy: ["gurumdds-3.0"]
+
+gv:
+    ubuntu: ["gv"]
+
+gz-citadel:
+    ubuntu:
+        focal: ["gz-citadel"]
+
+gz-cmake2:
+    ubuntu:
+        focal: ["libgz-cmake2-dev"]
+        jammy: ["libgz-cmake2-dev"]
+
+gz-common3:
+    ubuntu:
+        focal: ["libgz-common3-dev"]
+
+gz-common4:
+    ubuntu:
+        focal: ["libgz-common4-dev"]
+        jammy: ["libgz-common4-dev"]
+
+gz-fortress:
+    ubuntu:
+        focal: ["gz-fortress"]
+        jammy: ["gz-fortress"]
+
+gz-fuel-tools4:
+    ubuntu:
+        focal: ["libgz-fuel-tools4-dev"]
+
+gz-fuel-tools7:
+    ubuntu:
+        focal: ["libgz-fuel-tools7-dev"]
+        jammy: ["libgz-fuel-tools7-dev"]
+
+gz-gui3:
+    ubuntu:
+        focal: ["libgz-gui3-dev"]
+
+gz-gui6:
+    ubuntu:
+        focal: ["libgz-gui6-dev"]
+        jammy: ["libgz-gui6-dev"]
+
+gz-launch2:
+    ubuntu:
+        focal: ["libgz-launch2-dev"]
+
+gz-launch5:
+    ubuntu:
+        focal: ["libgz-launch5-dev"]
+        jammy: ["libgz-launch5-dev"]
+
+gz-math6:
+    ubuntu:
+        focal: ["libgz-math6-dev"]
+        jammy: ["libgz-math6-dev"]
+
+gz-math6-eigen3:
+    ubuntu:
+        focal: ["libgz-math6-eigen3-dev"]
+        jammy: ["libgz-math6-eigen3-dev"]
+
+gz-msgs5:
+    ubuntu:
+        focal: ["libgz-msgs5-dev"]
+
+gz-msgs8:
+    ubuntu:
+        focal: ["libgz-msgs8-dev"]
+        jammy: ["libgz-msgs8-dev"]
+
+gz-physics2:
+    ubuntu:
+        focal: ["libgz-physics2-dev"]
+
+gz-physics5:
+    ubuntu:
+        focal: ["libgz-physics5-dev"]
+        jammy: ["libgz-physics5-dev"]
+
+gz-plugin:
+    ubuntu:
+        focal: ["libgz-plugin-dev"]
+        jammy: ["libgz-plugin-dev"]
+
+gz-rendering3:
+    ubuntu:
+        focal: ["libgz-rendering3-dev"]
+
+gz-rendering6:
+    ubuntu:
+        focal: ["libgz-rendering6-dev"]
+        jammy: ["libgz-rendering6-dev"]
+
+gz-sensors3:
+    ubuntu:
+        focal: ["libgz-sensors3-dev"]
+
+gz-sensors6:
+    ubuntu:
+        focal: ["libgz-sensors6-dev"]
+        jammy: ["libgz-sensors6-dev"]
+
+gz-sim3:
+    ubuntu:
+        focal: ["libgz-sim3-dev"]
+
+gz-sim6:
+    ubuntu:
+        focal: ["libgz-sim6-dev"]
+        jammy: ["libgz-sim6-dev"]
+
+gz-sim6-plugins:
+    ubuntu:
+        focal: ["libgz-sim6-plugins"]
+        jammy: ["libgz-sim6-plugins"]
+
+gz-tools:
+    ubuntu:
+        focal: ["libgz-tools-dev"]
+        jammy: ["libgz-tools-dev"]
+
+gz-transport11:
+    ubuntu:
+        focal: ["libgz-transport11-dev"]
+        jammy: ["libgz-transport11-dev"]
+
+gz-transport8:
+    ubuntu:
+        focal: ["libgz-transport8-dev"]
+
+gz-utils1:
+    ubuntu:
+        focal: ["libgz-utils1-dev"]
+        jammy: ["libgz-utils1-dev"]
+
+gz-utils1-cli:
+    ubuntu:
+        focal: ["libgz-utils1-cli-dev"]
+        jammy: ["libgz-utils1-cli-dev"]
+
+haproxy:
+    ubuntu: ["haproxy"]
+
+hddtemp:
+    ubuntu:
+        default: nonexistent
+        bionic: ["hddtemp"]
+        focal: ["hddtemp"]
+
+hdf5:
+    ubuntu: ["libhdf5-dev"]
+
+hdf5-tools:
+    ubuntu: ["hdf5-tools"]
+
+hostapd:
+    ubuntu: ["hostapd"]
+
+hostname:
+    ubuntu: ["hostname"]
+
+htop:
+    ubuntu: ["htop"]
+
+hugin-tools:
+    ubuntu: ["hugin-tools"]
+
+i2c-tools:
+    ubuntu: ["i2c-tools"]
+
+ifstat:
+    ubuntu: ["ifstat"]
+
+ignition-citadel:
+    ubuntu:
+        focal: ["ignition-citadel"]
+
+ignition-cmake2:
+    ubuntu:
+        focal: ["libignition-cmake2-dev"]
+        jammy: ["libignition-cmake2-dev"]
+
+ignition-common3:
+    ubuntu:
+        focal: ["libignition-common3-dev"]
+
+ignition-common4:
+    ubuntu:
+        focal: ["libignition-common4-dev"]
+        jammy: ["libignition-common4-dev"]
+
+ignition-edifice:
+    ubuntu:
+        focal: ["ignition-edifice"]
+
+ignition-fortress:
+    ubuntu:
+        focal: ["ignition-fortress"]
+        jammy: ["ignition-fortress"]
+
+ignition-fuel-tools4:
+    ubuntu:
+        focal: ["libignition-fuel-tools4-dev"]
+
+ignition-fuel-tools6:
+    ubuntu:
+        focal: ["libignition-fuel-tools6-dev"]
+
+ignition-fuel-tools7:
+    ubuntu:
+        focal: ["libignition-fuel-tools7-dev"]
+        jammy: ["libignition-fuel-tools7-dev"]
+
+ignition-gazebo3:
+    ubuntu:
+        focal: ["libignition-gazebo3-dev"]
+
+ignition-gazebo5:
+    ubuntu:
+        focal: ["libignition-gazebo5-dev"]
+
+ignition-gazebo5-plugins:
+    ubuntu:
+        focal: ["libignition-gazebo5-plugins"]
+
+ignition-gazebo6:
+    ubuntu:
+        focal: ["libignition-gazebo6-dev"]
+        jammy: ["libignition-gazebo6-dev"]
+
+ignition-gazebo6-plugins:
+    ubuntu:
+        focal: ["libignition-gazebo6-plugins"]
+        jammy: ["libignition-gazebo6-plugins"]
+
+ignition-gui3:
+    ubuntu:
+        focal: ["libignition-gui3-dev"]
+
+ignition-gui5:
+    ubuntu:
+        focal: ["libignition-gui5-dev"]
+
+ignition-gui6:
+    ubuntu:
+        focal: ["libignition-gui6-dev"]
+        jammy: ["libignition-gui6-dev"]
+
+ignition-launch2:
+    ubuntu:
+        focal: ["libignition-launch2-dev"]
+
+ignition-launch4:
+    ubuntu:
+        focal: ["libignition-launch4-dev"]
+
+ignition-launch5:
+    ubuntu:
+        focal: ["libignition-launch5-dev"]
+        jammy: ["libignition-launch5-dev"]
+
+ignition-math6:
+    ubuntu:
+        focal: ["libignition-math6-dev"]
+        jammy: ["libignition-math6-dev"]
+
+ignition-math6-eigen3:
+    ubuntu:
+        focal: ["libignition-math6-eigen3-dev"]
+        jammy: ["libignition-math6-eigen3-dev"]
+
+ignition-msgs5:
+    ubuntu:
+        focal: ["libignition-msgs5-dev"]
+
+ignition-msgs7:
+    ubuntu:
+        focal: ["libignition-msgs7-dev"]
+
+ignition-msgs8:
+    ubuntu:
+        focal: ["libignition-msgs8-dev"]
+        jammy: ["libignition-msgs8-dev"]
+
+ignition-physics2:
+    ubuntu:
+        focal: ["libignition-physics2-dev"]
+
+ignition-physics4:
+    ubuntu:
+        focal: ["libignition-physics4-dev"]
+
+ignition-physics5:
+    ubuntu:
+        focal: ["libignition-physics5-dev"]
+        jammy: ["libignition-physics5-dev"]
+
+ignition-plugin:
+    ubuntu:
+        focal: ["libignition-plugin-dev"]
+        jammy: ["libignition-plugin-dev"]
+
+ignition-rendering3:
+    ubuntu:
+        focal: ["libignition-rendering3-dev"]
+
+ignition-rendering5:
+    ubuntu:
+        focal: ["libignition-rendering5-dev"]
+
+ignition-rendering6:
+    ubuntu:
+        focal: ["libignition-rendering6-dev"]
+        jammy: ["libignition-rendering6-dev"]
+
+ignition-sensors3:
+    ubuntu:
+        focal: ["libignition-sensors3-dev"]
+
+ignition-sensors5:
+    ubuntu:
+        focal: ["libignition-sensors5-dev"]
+
+ignition-sensors6:
+    ubuntu:
+        focal: ["libignition-sensors6-dev"]
+        jammy: ["libignition-sensors6-dev"]
+
+ignition-tools:
+    ubuntu:
+        focal: ["libignition-tools-dev"]
+        jammy: ["libignition-tools-dev"]
+
+ignition-transport10:
+    ubuntu:
+        focal: ["libignition-transport10-dev"]
+
+ignition-transport11:
+    ubuntu:
+        focal: ["libignition-transport11-dev"]
+        jammy: ["libignition-transport11-dev"]
+
+ignition-transport8:
+    ubuntu:
+        focal: ["libignition-transport8-dev"]
+
+ignition-utils1:
+    ubuntu:
+        focal: ["libignition-utils1-dev"]
+        jammy: ["libignition-utils1-dev"]
+
+ignition-utils1-cli:
+    ubuntu:
+        focal: ["libignition-utils1-cli-dev"]
+        jammy: ["libignition-utils1-cli-dev"]
+
+imagemagick:
+    ubuntu: ["imagemagick"]
+
+intel-opencl-icd:
+    ubuntu:
+        default: ["intel-opencl-icd"]
+        bionic: nonexistent
+
+intltool:
+    ubuntu: ["intltool"]
+
+inxi:
+    ubuntu: ["inxi"]
+
+iperf:
+    ubuntu: ["iperf"]
+
+ipmitool:
+    ubuntu: ["ipmitool"]
+
+iproute2:
+    ubuntu: ["iproute2"]
+
+iputils-ping:
+    ubuntu: ["iputils-ping"]
+
+iwyu:
+    ubuntu: ["iwyu"]
+
+jack:
+    ubuntu: ["libjack-jackd2-dev"]
+
+java:
+    ubuntu: ["default-jdk"]
+
+joystick:
+    ubuntu: ["joystick"]
+
+jq:
+    ubuntu: ["jq"]
+
+julius-voxforge:
+    ubuntu: ["julius-voxforge"]
+
+jython:
+    ubuntu: ["jython"]
+
+kakasi:
+    ubuntu: ["kakasi"]
+
+kate:
+    ubuntu: ["kate"]
+
+kgraphviewer:
+    ubuntu: ["kgraphviewer"]
+
+konsole:
+    ubuntu: ["konsole"]
+
+language-pack-de:
+    ubuntu: ["language-pack-de"]
+
+language-pack-en:
+    ubuntu: ["language-pack-en"]
+
+lcov:
+    ubuntu: ["lcov"]
+
+lensfun:
+    ubuntu: ["liblensfun1"]
+
+lensfun-dev:
+    ubuntu: ["liblensfun-dev"]
+
+leveldb:
+    ubuntu: ["libleveldb-dev"]
+
+lib32asound2:
+    ubuntu: ["lib32asound2"]
+
+libabsl-dev:
+    ubuntu:
+        default: ["libabsl-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libadolc-dev:
+    ubuntu: ["libadolc-dev"]
+
+libalglib-dev:
+    ubuntu: ["libalglib-dev"]
+
+libann-dev:
+    ubuntu: ["libann-dev"]
+
+libao-dev:
+    ubuntu: ["libao-dev"]
+
+libapache2-mod-python:
+    ubuntu: ["libapache2-mod-python"]
+
+libargtable2-dev:
+    ubuntu: ["libargtable2-dev"]
+
+libaria:
+    ubuntu:
+        default: ["libaria-dev"]
+
+libasound2-dev:
+    ubuntu: ["libasound2-dev"]
+
+libatomic:
+    ubuntu: ["libatomic1"]
+
+libav:
+    ubuntu:
+        default: nonexistent
+
+libavahi-client-dev:
+    ubuntu: ["libavahi-client-dev"]
+
+libavahi-core-dev:
+    ubuntu: ["libavahi-core-dev"]
+
+libavdevice-dev:
+    ubuntu: ["libavdevice-dev"]
+
+libb64-dev:
+    ubuntu: ["libb64-dev"]
+
+libbackward-cpp-dev:
+    ubuntu:
+        default: ["libbackward-cpp-dev"]
+        bionic: nonexistent
+
+libbdd-dev:
+    ubuntu: ["libbdd-dev"]
+
+libblas-dev:
+    ubuntu: ["libblas-dev"]
+
+libblosc-dev:
+    ubuntu: ["libblosc-dev"]
+
+libbluetooth:
+    ubuntu: ["libbluetooth3"]
+
+libbluetooth-dev:
+    ubuntu: ["libbluetooth-dev"]
+
+libboost-atomic:
+    ubuntu:
+        bionic: ["libboost-atomic1.65.1"]
+        focal: ["libboost-atomic1.71.0"]
+        jammy: ["libboost-atomic1.74.0"]
+        noble: ["libboost-atomic1.83.0"]
+
+libboost-atomic-dev:
+    ubuntu: ["libboost-atomic-dev"]
+
+libboost-chrono:
+    ubuntu:
+        bionic: ["libboost-chrono1.65.1"]
+        focal: ["libboost-chrono1.71.0"]
+        jammy: ["libboost-chrono1.74.0"]
+        noble: ["libboost-chrono1.83.0"]
+
+libboost-chrono-dev:
+    ubuntu: ["libboost-chrono-dev"]
+
+libboost-coroutine:
+    ubuntu:
+        bionic: ["libboost-coroutine1.65.1"]
+        focal: ["libboost-coroutine1.71.0"]
+        jammy: ["libboost-coroutine1.74.0"]
+        noble: ["libboost-coroutine1.83.0"]
+
+libboost-coroutine-dev:
+    ubuntu: ["libboost-coroutine-dev"]
+
+libboost-date-time:
+    ubuntu:
+        bionic: ["libboost-date-time1.65.1"]
+        focal: ["libboost-date-time1.71.0"]
+        jammy: ["libboost-date-time1.74.0"]
+        noble: ["libboost-date-time1.83.0"]
+
+libboost-date-time-dev:
+    ubuntu: ["libboost-date-time-dev"]
+
+libboost-dev:
+    ubuntu: ["libboost-dev"]
+
+libboost-filesystem:
+    ubuntu:
+        bionic: ["libboost-filesystem1.65.1"]
+        focal: ["libboost-filesystem1.71.0"]
+        jammy: ["libboost-filesystem1.74.0"]
+        noble: ["libboost-filesystem1.83.0"]
+
+libboost-filesystem-dev:
+    ubuntu: ["libboost-filesystem-dev"]
+
+libboost-iostreams:
+    ubuntu:
+        bionic: ["libboost-iostreams1.65.1"]
+        focal: ["libboost-iostreams1.71.0"]
+        jammy: ["libboost-iostreams1.74.0"]
+        noble: ["libboost-iostreams1.83.0"]
+
+libboost-iostreams-dev:
+    ubuntu: ["libboost-iostreams-dev"]
+
+libboost-math:
+    ubuntu:
+        bionic: ["libboost-math1.65.1"]
+        focal: ["libboost-math1.71.0"]
+        jammy: ["libboost-math1.74.0"]
+        noble: ["libboost-math1.83.0"]
+
+libboost-math-dev:
+    ubuntu: ["libboost-math-dev"]
+
+libboost-numpy-dev:
+    ubuntu: ["libboost-numpy-dev"]
+
+libboost-program-options:
+    ubuntu:
+        bionic: ["libboost-program-options1.65.1"]
+        focal: ["libboost-program-options1.71.0"]
+        jammy: ["libboost-program-options1.74.0"]
+        noble: ["libboost-program-options1.83.0"]
+
+libboost-program-options-dev:
+    ubuntu: ["libboost-program-options-dev"]
+
+libboost-python:
+    ubuntu:
+        bionic: ["libboost-python1.65.1"]
+        focal: ["libboost-python1.71.0"]
+        jammy: ["libboost-python1.74.0"]
+        noble: ["libboost-python1.83.0"]
+
+libboost-python-dev:
+    ubuntu: ["libboost-python-dev"]
+
+libboost-random:
+    ubuntu:
+        bionic: ["libboost-random1.65.1"]
+        focal: ["libboost-random1.71.0"]
+        jammy: ["libboost-random1.74.0"]
+        noble: ["libboost-random1.83.0"]
+
+libboost-random-dev:
+    ubuntu: ["libboost-random-dev"]
+
+libboost-regex:
+    ubuntu:
+        bionic: ["libboost-regex1.65.1"]
+        focal: ["libboost-regex1.71.0"]
+        jammy: ["libboost-regex1.74.0"]
+        noble: ["libboost-regex1.83.0"]
+
+libboost-regex-dev:
+    ubuntu: ["libboost-regex-dev"]
+
+libboost-serialization:
+    ubuntu:
+        bionic: ["libboost-serialization1.65.1"]
+        focal: ["libboost-serialization1.71.0"]
+        jammy: ["libboost-serialization1.74.0"]
+        noble: ["libboost-serialization1.83.0"]
+
+libboost-serialization-dev:
+    ubuntu: ["libboost-serialization-dev"]
+
+libboost-system:
+    ubuntu:
+        bionic: ["libboost-system1.65.1"]
+        focal: ["libboost-system1.71.0"]
+        jammy: ["libboost-system1.74.0"]
+        noble: ["libboost-system1.83.0"]
+
+libboost-system-dev:
+    ubuntu: ["libboost-system-dev"]
+
+libboost-thread:
+    ubuntu:
+        bionic: ["libboost-thread1.65.1"]
+        focal: ["libboost-thread1.71.0"]
+        jammy: ["libboost-thread1.74.0"]
+        noble: ["libboost-thread1.83.0"]
+
+libboost-thread-dev:
+    ubuntu: ["libboost-thread-dev"]
+
+libboost-timer:
+    ubuntu:
+        bionic: ["libboost-timer1.65.1"]
+        focal: ["libboost-timer1.71.0"]
+        jammy: ["libboost-timer1.74.0"]
+        noble: ["libboost-timer1.83.0"]
+
+libboost-timer-dev:
+    ubuntu: ["libboost-timer-dev"]
+
+libbsd-dev:
+    ubuntu: ["libbsd-dev"]
+
+libcairo2-dev:
+    ubuntu: ["libcairo2-dev"]
+
+libcap-dev:
+    ubuntu: ["libcap-dev"]
+
+libcap-ng-dev:
+    ubuntu: ["libcap-ng-dev"]
+
+libcap-ng0:
+    ubuntu: ["libcap-ng0"]
+
+libcap2:
+    ubuntu: ["libcap2"]
+
+libcap2-bin:
+    ubuntu: ["libcap2-bin"]
+
+libccd-dev:
+    ubuntu: ["libccd-dev"]
+
+libccid:
+    ubuntu: ["libccid"]
+
+libcdd-dev:
+    ubuntu: ["libcdd-dev"]
+
+libcegui-mk2-dev:
+    ubuntu: ["libcegui-mk2-dev"]
+
+libcereal-dev:
+    ubuntu: ["libcereal-dev"]
+
+libceres-dev:
+    ubuntu: ["libceres-dev"]
+
+libcgroup-dev:
+    ubuntu: ["libcgroup-dev"]
+
+libclang-dev:
+    ubuntu: ["libclang-dev"]
+
+libcoin60-dev:
+    ubuntu: ["libcoin60-dev"]
+
+libcoin80-dev:
+    ubuntu:
+        default: ["libcoin-dev"]
+        bionic: ["libcoin80-dev"]
+
+libconfig++-dev:
+    ubuntu: ["libconfig++-dev"]
+
+libconfig-dev:
+    ubuntu: ["libconfig-dev"]
+
+libconsole-bridge-dev:
+    ubuntu: ["libconsole-bridge-dev"]
+
+libcos4-dev:
+    ubuntu: ["libcos4-dev"]
+
+libcpp-httplib-dev:
+    ubuntu:
+        default: ["libcpp-httplib-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libcpprest-dev:
+    ubuntu: ["libcpprest-dev"]
+
+libcunit-dev:
+    ubuntu: ["libcunit1-dev"]
+
+libcurl:
+    ubuntu: ["libcurl4"]
+
+libcurl-dev:
+    ubuntu: ["libcurl4-openssl-dev"]
+
+libdbus-dev:
+    ubuntu: ["libdbus-1-dev"]
+
+libdc1394-dev:
+    ubuntu:
+        default: ["libdc1394-dev"]
+        bionic: ["libdc1394-22-dev"]
+        focal: ["libdc1394-22-dev"]
+
+libdevil-dev:
+    ubuntu: ["libdevil-dev"]
+
+libdlib-dev:
+    ubuntu:
+        default: ["libdlib-dev"]
+
+libdmtx-dev:
+    ubuntu: ["libdmtx-dev"]
+
+libdpkg-dev:
+    ubuntu: ["libdpkg-dev"]
+
+libdraco-dev:
+    ubuntu:
+        default: ["libdraco-dev"]
+        focal: nonexistent
+
+libdrm-dev:
+    ubuntu: ["libdrm-dev"]
+
+libdw-dev:
+    ubuntu: ["libdw-dev"]
+
+libdxflib-dev:
+    ubuntu: ["libdxflib-dev"]
+
+libedit:
+    ubuntu: ["libedit2"]
+
+libedit-dev:
+    ubuntu: ["libedit-dev"]
+
+libepoxy-dev:
+    ubuntu: ["libepoxy-dev"]
+
+libesd0-dev:
+    ubuntu: ["libesd0-dev"]
+
+libespeak-dev:
+    ubuntu: ["libespeak-dev"]
+
+libespeak-ng1:
+    ubuntu: ["libespeak-ng1"]
+
+libestools-dev:
+    ubuntu:
+        default: ["libestools-dev"]
+
+libev-dev:
+    ubuntu: ["libev-dev"]
+
+libevdev-dev:
+    ubuntu: ["libevdev-dev"]
+
+libevent-dev:
+    ubuntu: ["libevent-dev"]
+
+libexif:
+    ubuntu: ["libexif12"]
+
+libexif-dev:
+    ubuntu: ["libexif-dev"]
+
+libexiv2-dev:
+    ubuntu: ["libexiv2-dev"]
+
+libexpat1-dev:
+    ubuntu: ["libexpat1-dev"]
+
+libext2fs-dev:
+    ubuntu: ["libext2fs-dev"]
+
+libfcl:
+    ubuntu:
+        default: ["libfcl0.7"]
+        focal: ["libfcl0.5"]
+
+libfcl-dev:
+    ubuntu:
+        default: ["libfcl-dev"]
+
+libffi-dev:
+    ubuntu: ["libffi-dev"]
+
+libfftw3:
+    ubuntu: ["libfftw3-3", "libfftw3-dev"]
+
+libfl-dev:
+    ubuntu: ["libfl-dev"]
+
+libflann:
+    ubuntu:
+        default: ["libflann1.9"]
+
+libflann-dev:
+    ubuntu: ["libflann-dev"]
+
+libflatbuffers-dev:
+    ubuntu: ["libflatbuffers-dev"]
+
+libfltk-dev:
+    ubuntu: ["libfltk1.3-dev"]
+
+libfontconfig1-dev:
+    ubuntu: ["libfontconfig1-dev"]
+
+libfreeimage:
+    ubuntu: ["libfreeimage3"]
+
+libfreeimage-dev:
+    ubuntu: ["libfreeimage-dev"]
+
+libfreenect-dev:
+    ubuntu: ["libfreenect-dev"]
+
+libfreetype-dev:
+    ubuntu:
+        default: ["libfreetype-dev"]
+        bionic: ["libfreetype6-dev"]
+
+libfreetype6:
+    ubuntu: ["libfreetype6"]
+
+libfreetype6-dev:
+    ubuntu: ["libfreetype6-dev"]
+
+libftdi-dev:
+    ubuntu: ["libftdi-dev"]
+
+libftdi1-dev:
+    ubuntu: ["libftdi1-dev"]
+
+libftdipp-dev:
+    ubuntu:
+        bionic: ["libftdipp1-dev"]
+
+libftgl-dev:
+    ubuntu: ["libftgl-dev"]
+
+libfyaml-dev:
+    ubuntu:
+        default: ["libfyaml-dev"]
+        focal: nonexistent
+
+libgazebo-dev:
+    ubuntu:
+        focal: ["libgazebo11-dev"]
+        jammy: ["libgazebo-dev"]
+
+libgazebo11-dev:
+    ubuntu:
+        focal: ["libgazebo11-dev"]
+        jammy: ["libgazebo-dev"]
+
+libgazebo5-dev:
+    ubuntu: ["libgazebo5-dev"]
+
+libgazebo7-dev:
+    ubuntu: ["libgazebo7-dev"]
+
+libgazebo9-dev:
+    ubuntu:
+        bionic: ["libgazebo9-dev"]
+
+libgconf2:
+    ubuntu: ["libgconf-2-4"]
+
+libgdal-dev:
+    ubuntu: ["libgdal-dev"]
+
+libgeographiclib-dev:
+    ubuntu: ["libgeographiclib-dev"]
+
+libgeos++-dev:
+    ubuntu: ["libgeos++-dev"]
+
+libgeotiff-dev:
+    ubuntu: ["libgeotiff-dev"]
+
+libgflags-dev:
+    ubuntu: ["libgflags-dev"]
+
+libgfortran3:
+    ubuntu: ["libgfortran3"]
+
+libgif-dev:
+    ubuntu: ["libgif-dev"]
+
+libglew-dev:
+    ubuntu: ["libglew-dev"]
+
+libglfw3-dev:
+    ubuntu:
+        default: ["libglfw3-dev"]
+
+libglib-dev:
+    ubuntu: ["libglib2.0-dev"]
+
+libglm-dev:
+    ubuntu: ["libglm-dev"]
+
+libglui-dev:
+    ubuntu: ["libglui-dev"]
+
+libglw1-mesa:
+    ubuntu: ["libglw1-mesa"]
+
+libgmock-dev:
+    ubuntu:
+        default: ["libgmock-dev"]
+        bionic: nonexistent
+
+libgmp:
+    ubuntu: ["libgmp-dev"]
+
+libgnutls28-dev:
+    ubuntu: ["libgnutls28-dev"]
+
+libgomp1:
+    ubuntu: ["libgomp1"]
+
+libgoogle-glog-dev:
+    ubuntu: ["libgoogle-glog-dev"]
+
+libgpgme-dev:
+    ubuntu:
+        default: ["libgpgme-dev"]
+
+libgphoto-dev:
+    ubuntu:
+        default: ["libgphoto2-dev"]
+
+libgpiod-dev:
+    ubuntu: ["libgpiod-dev"]
+
+libgps:
+    ubuntu: ["libgps-dev"]
+
+libgrpc:
+    ubuntu: ["libgrpc++-dev"]
+
+libgsl:
+    ubuntu:
+        default: ["libgsl-dev"]
+
+libgstreamer-plugins-bad1.0-dev:
+    ubuntu: ["libgstreamer-plugins-bad1.0-dev"]
+
+libgstreamer-plugins-base0.10-0:
+    ubuntu: ["libgstreamer-plugins-base0.10-0"]
+
+libgstreamer-plugins-base0.10-dev:
+    ubuntu: ["libgstreamer-plugins-base0.10-dev"]
+
+libgstreamer-plugins-base1.0-dev:
+    ubuntu: ["libgstreamer-plugins-base1.0-dev"]
+
+libgstreamer0.10-0:
+    ubuntu: ["libgstreamer0.10-0"]
+
+libgstreamer0.10-dev:
+    ubuntu: ["libgstreamer0.10-dev"]
+
+libgstreamer1.0-dev:
+    ubuntu: ["libgstreamer1.0-dev"]
+
+libgstrtspserver-1.0-0:
+    ubuntu: ["libgstrtspserver-1.0-0"]
+
+libgstrtspserver-1.0-dev:
+    ubuntu: ["libgstrtspserver-1.0-dev"]
+
+libgtkmm:
+    ubuntu: ["libgtkmm-2.4-dev"]
+
+libgtkmm3.0-dev:
+    ubuntu: ["libgtkmm-3.0-dev"]
+
+libgts:
+    ubuntu: ["libgts-dev"]
+
+libhal-dev:
+    ubuntu: ["libhal-dev"]
+
+libhdf5-dev:
+    ubuntu: ["libhdf5-dev"]
+
+libhidapi-dev:
+    ubuntu: ["libhidapi-dev"]
+
+libhpptools-dev:
+    ubuntu: ["libhpptools-dev"]
+
+libi2c-dev:
+    ubuntu: ["libi2c-dev"]
+
+libicu-dev:
+    ubuntu: ["libicu-dev"]
+
+libignition-common3:
+    ubuntu:
+        focal: ["libignition-common3"]
+
+libignition-common4:
+    ubuntu:
+        focal: ["libignition-common4"]
+
+libignition-fuel-tools4:
+    ubuntu:
+        focal: ["libignition-fuel-tools4"]
+
+libignition-fuel-tools6:
+    ubuntu:
+        focal: ["libignition-fuel-tools6"]
+
+libignition-gazebo3:
+    ubuntu:
+        focal: ["libignition-gazebo3"]
+
+libignition-gazebo5:
+    ubuntu:
+        focal: ["libignition-gazebo5"]
+
+libignition-gui3:
+    ubuntu:
+        focal: ["libignition-gui3"]
+
+libignition-gui5:
+    ubuntu:
+        focal: ["libignition-gui5"]
+
+libignition-launch2:
+    ubuntu:
+        focal: ["libignition-launch2"]
+
+libignition-launch4:
+    ubuntu:
+        focal: ["libignition-launch4"]
+
+libignition-math6:
+    ubuntu:
+        focal: ["libignition-math6"]
+
+libignition-msgs5:
+    ubuntu:
+        focal: ["libignition-msgs5"]
+
+libignition-msgs7:
+    ubuntu:
+        focal: ["libignition-msgs7"]
+
+libignition-physics2:
+    ubuntu:
+        focal: ["libignition-physics2"]
+
+libignition-physics4:
+    ubuntu:
+        focal: ["libignition-physics4"]
+
+libignition-rendering3:
+    ubuntu:
+        focal: ["libignition-rendering3"]
+
+libignition-rendering5:
+    ubuntu:
+        focal: ["libignition-rendering5"]
+
+libignition-sensors3:
+    ubuntu:
+        focal: ["libignition-sensors3"]
+
+libignition-sensors5:
+    ubuntu:
+        focal: ["libignition-sensors5"]
+
+libignition-transport10:
+    ubuntu:
+        focal: ["libignition-transport10"]
+
+libignition-transport8:
+    ubuntu:
+        focal: ["libignition-transport8"]
+
+libignition-utils1:
+    ubuntu:
+        focal: ["libignition-utils1"]
+
+libiio-dev:
+    ubuntu: ["libiio-dev"]
+
+libimage-exiftool-perl:
+    ubuntu: ["libimage-exiftool-perl"]
+
+libirrlicht-dev:
+    ubuntu: ["libirrlicht-dev"]
+
+libiw-dev:
+    ubuntu: ["libiw-dev"]
+
+libjack-dev:
+    ubuntu: ["libjack-dev"]
+
+libjackson-json-java:
+    ubuntu: ["libjackson-json-java"]
+
+libjansson-dev:
+    ubuntu: ["libjansson-dev"]
+
+libjchart2d-java:
+    ubuntu: ["libjchart2d-java"]
+
+libjpeg:
+    ubuntu: ["libjpeg-dev"]
+
+libjson-glib:
+    ubuntu: ["libjson-glib-dev"]
+
+libjson-java:
+    ubuntu: ["libjson-java"]
+
+libjson0-dev:
+    ubuntu: ["libjson0-dev"]
+
+libjsoncpp:
+    ubuntu:
+        default: ["libjsoncpp25"]
+        bionic: ["libjsoncpp1"]
+        focal: ["libjsoncpp1"]
+
+libjsoncpp-dev:
+    ubuntu: ["libjsoncpp-dev"]
+
+libjsonrpccpp-client0:
+    ubuntu: ["libjsonrpccpp-client0"]
+
+libjsonrpccpp-common0:
+    ubuntu: ["libjsonrpccpp-common0"]
+
+libjsonrpccpp-dev:
+    ubuntu: ["libjsonrpccpp-dev"]
+
+libjsonrpccpp-server0:
+    ubuntu: ["libjsonrpccpp-server0"]
+
+libjsonrpccpp-stub0:
+    ubuntu: ["libjsonrpccpp-stub0"]
+
+libjsonrpccpp-tools:
+    ubuntu: ["libjsonrpccpp-tools"]
+
+libkdtree++-dev:
+    ubuntu: ["libkdtree++-dev"]
+
+libkml-dev:
+    ubuntu: ["libkml-dev"]
+
+liblapack-dev:
+    ubuntu: ["liblapack-dev"]
+
+liblapacke-dev:
+    ubuntu: ["liblapacke-dev"]
+
+liblcm:
+    ubuntu:
+        default: ["liblcm1"]
+
+liblcm-dev:
+    ubuntu:
+        default: ["liblcm-dev"]
+
+libleptonica-dev:
+    ubuntu: ["libleptonica-dev"]
+
+liblinear-dev:
+    ubuntu: ["liblinear-dev"]
+
+liblinphone-dev:
+    ubuntu: ["liblinphone-dev"]
+
+liblmdb-dev:
+    ubuntu: ["liblmdb-dev"]
+
+liblttng-ctl-dev:
+    ubuntu: ["liblttng-ctl-dev"]
+
+liblttng-ust-dev:
+    ubuntu: ["liblttng-ust-dev"]
+
+liblz4:
+    ubuntu: ["liblz4-1"]
+
+liblz4-dev:
+    ubuntu: ["liblz4-dev"]
+
+liblzma-dev:
+    ubuntu: ["liblzma-dev"]
+
+libmagick:
+    ubuntu: ["libmagick++-dev"]
+
+libmarble-dev:
+    ubuntu: ["libmarble-dev"]
+
+libmbedtls-dev:
+    ubuntu: ["libmbedtls-dev"]
+
+libmicrohttpd:
+    ubuntu: ["libmicrohttpd-dev"]
+
+libmlpack-dev:
+    ubuntu: ["libmlpack-dev"]
+
+libmnl-dev:
+    ubuntu: ["libmnl-dev"]
+
+libmockito-java:
+    ubuntu: ["libmockito-java"]
+
+libmodbus-dev:
+    ubuntu: ["libmodbus-dev"]
+
+libmodbus5:
+    ubuntu: ["libmodbus5"]
+
+libmongoc-1.0-0:
+    ubuntu: ["libmongoc-1.0-0"]
+
+libmongoc-dev:
+    ubuntu: ["libmongoc-dev"]
+
+libmongoclient-dev:
+    ubuntu: ["libmongoclient-dev"]
+
+libmotif-dev:
+    ubuntu: ["libmotif-dev"]
+
+libmp3lame-dev:
+    ubuntu: ["libmp3lame-dev"]
+
+libmpg123-dev:
+    ubuntu: ["libmpg123-dev"]
+
+libmpich-dev:
+    ubuntu: ["libmpich-dev"]
+
+libmpich2-dev:
+    ubuntu: ["libmpich2-dev"]
+
+libmsgsl-dev:
+    ubuntu: ["libmsgsl-dev"]
+
+libmysql++-dev:
+    ubuntu: ["libmysql++-dev"]
+
+libmysql++3v5:
+    ubuntu:
+        focal: ["libmysql++3v5"]
+        jammy: ["libmysql++3v5"]
+
+libmysqlclient-dev:
+    ubuntu: ["libmysqlclient-dev"]
+
+libmysqlcppconn-dev:
+    ubuntu: ["libmysqlcppconn-dev"]
+
+libnanoflann-dev:
+    ubuntu:
+        default: ["libnanoflann-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libnanopb-dev:
+    ubuntu:
+        default: ["libnanopb-dev"]
+        bionic: nonexistent
+
+libncurses:
+    ubuntu: ["libncurses6"]
+
+libncurses-dev:
+    ubuntu: ["libncurses-dev"]
+
+libneon27-gnutls-dev:
+    ubuntu: ["libneon27-gnutls-dev"]
+
+libnewmat10-dev:
+    ubuntu: ["libnewmat10-dev"]
+
+libnl-3:
+    ubuntu: ["libnl-3-200", "libnl-genl-3-200", "libnl-route-3-200"]
+
+libnl-3-dev:
+    ubuntu: ["libnl-3-dev", "libnl-genl-3-dev", "libnl-route-3-dev"]
+
+libnl-dev:
+    ubuntu: ["libnl-dev"]
+
+libnlopt-cxx-dev:
+    ubuntu:
+        default: ["libnlopt-cxx-dev"]
+        bionic: nonexistent
+
+libnlopt-dev:
+    ubuntu: ["libnlopt-dev"]
+
+libnlopt0:
+    ubuntu: ["libnlopt0"]
+
+libnotify:
+    ubuntu: ["libnotify-dev"]
+
+libnss3-dev:
+    ubuntu: ["libnss3-dev"]
+
+liboctomap-dev:
+    ubuntu: ["liboctomap-dev"]
+
+libogg:
+    ubuntu: ["libogg-dev"]
+
+libogre:
+    ubuntu: ["libogre-1.9.0v5"]
+
+libogre-1.12-dev:
+    ubuntu:
+        focal: ["libogre-1.12-dev"]
+        jammy: ["libogre-1.12-dev"]
+
+libogre-dev:
+    ubuntu: ["libogre-1.9-dev"]
+
+libogre1.12.10:
+    ubuntu:
+        jammy: ["libogre1.12.10"]
+
+libois-dev:
+    ubuntu: ["libois-dev"]
+
+libomp-dev:
+    ubuntu: ["libomp-dev"]
+
+libopal-dev:
+    ubuntu: ["libopal-dev"]
+
+libopen3d-dev:
+    ubuntu:
+        default: ["libopen3d-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libopenal-dev:
+    ubuntu: ["libopenal-dev"]
+
+libopenblas-dev:
+    ubuntu: ["libopenblas-dev"]
+
+libopencv-contrib-dev:
+    ubuntu: ["libopencv-contrib-dev"]
+
+libopencv-dev:
+    ubuntu: ["libopencv-dev"]
+
+libopencv-imgproc-dev:
+    ubuntu: ["libopencv-imgproc-dev"]
+
+libopenexr-dev:
+    ubuntu: ["libopenexr-dev"]
+
+libopenni-dev:
+    ubuntu: ["libopenni-dev"]
+
+libopenni-sensor-primesense-dev:
+    ubuntu: ["libopenni-sensor-primesense-dev"]
+
+libopenni2-dev:
+    ubuntu: ["libopenni2-dev"]
+
+libopenscenegraph:
+    ubuntu: ["openscenegraph", "libopenscenegraph-dev"]
+
+libopensplice67:
+    ubuntu:
+        bionic: ["libopensplice67"]
+
+libopensplice69:
+    ubuntu:
+        bionic: ["libopensplice69"]
+
+libopenvdb:
+    ubuntu:
+        bionic: ["libopenvdb5.0"]
+        focal: ["libopenvdb6.2"]
+        jammy: ["libopenvdb8.1"]
+
+libopenvdb-dev:
+    ubuntu: ["libopenvdb-dev", "libilmbase-dev"]
+
+libopus-dev:
+    ubuntu: ["libopus-dev"]
+
+liborocos-bfl:
+    ubuntu:
+        default: ["liborocos-bfl0.8"]
+        bionic: nonexistent
+
+liborocos-bfl-dev:
+    ubuntu: ["liborocos-bfl-dev"]
+
+liborocos-kdl:
+    ubuntu:
+        default: ["liborocos-kdl1.5"]
+        bionic: ["liborocos-kdl1.3"]
+        focal: ["liborocos-kdl1.4"]
+
+liborocos-kdl-dev:
+    ubuntu: ["liborocos-kdl-dev"]
+
+libosmesa6-dev:
+    ubuntu: ["libosmesa6-dev"]
+
+libpaho-mqtt:
+    ubuntu:
+        default: ["libpaho-mqtt1.3"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpaho-mqtt-dev:
+    ubuntu:
+        default: ["libpaho-mqtt-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpaho-mqttpp:
+    ubuntu:
+        default: ["libpaho-mqttpp3-1"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpaho-mqttpp-dev:
+    ubuntu:
+        default: ["libpaho-mqttpp-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpcap:
+    ubuntu: ["libpcap0.8-dev"]
+
+libpcl-all:
+    ubuntu:
+        bionic: ["libpcl-apps1.8", "libpcl-common1.8", "libpcl-features1.8", "libpcl-filters1.8", "libpcl-io1.8", "libpcl-kdtree1.8", "libpcl-keypoints1.8", "libpcl-ml1.8", "libpcl-octree1.8", "libpcl-outofcore1.8", "libpcl-people1.8", "libpcl-recognition1.8", "libpcl-registration1.8", "libpcl-sample-consensus1.8", "libpcl-search1.8", "libpcl-segmentation1.8", "libpcl-stereo1.8", "libpcl-surface1.8", "libpcl-tracking1.8", "libpcl-visualization1.8"]
+        focal: ["libpcl-apps1.10", "libpcl-common1.10", "libpcl-features1.10", "libpcl-filters1.10", "libpcl-io1.10", "libpcl-kdtree1.10", "libpcl-keypoints1.10", "libpcl-ml1.10", "libpcl-octree1.10", "libpcl-outofcore1.10", "libpcl-people1.10", "libpcl-recognition1.10", "libpcl-registration1.10", "libpcl-sample-consensus1.10", "libpcl-search1.10", "libpcl-segmentation1.10", "libpcl-stereo1.10", "libpcl-surface1.10", "libpcl-tracking1.10", "libpcl-visualization1.10"]
+        jammy: ["libpcl-apps1.12", "libpcl-common1.12", "libpcl-features1.12", "libpcl-filters1.12", "libpcl-io1.12", "libpcl-kdtree1.12", "libpcl-keypoints1.12", "libpcl-ml1.12", "libpcl-octree1.12", "libpcl-outofcore1.12", "libpcl-people1.12", "libpcl-recognition1.12", "libpcl-registration1.12", "libpcl-sample-consensus1.12", "libpcl-search1.12", "libpcl-segmentation1.12", "libpcl-stereo1.12", "libpcl-surface1.12", "libpcl-tracking1.12", "libpcl-visualization1.12"]
+        noble: ["libpcl-apps1.14", "libpcl-common1.14", "libpcl-features1.14", "libpcl-filters1.14", "libpcl-io1.14", "libpcl-kdtree1.14", "libpcl-keypoints1.14", "libpcl-ml1.14", "libpcl-octree1.14", "libpcl-outofcore1.14", "libpcl-people1.14", "libpcl-recognition1.14", "libpcl-registration1.14", "libpcl-sample-consensus1.14", "libpcl-search1.14", "libpcl-segmentation1.14", "libpcl-stereo1.14", "libpcl-surface1.14", "libpcl-tracking1.14", "libpcl-visualization1.14"]
+
+libpcl-all-dev:
+    ubuntu: ["libpcl-dev"]
+
+libpcl-apps:
+    ubuntu:
+        bionic: ["libpcl-apps1.8"]
+        focal: ["libpcl-apps1.10"]
+        jammy: ["libpcl-apps1.12"]
+        noble: ["libpcl-apps1.14"]
+
+libpcl-common:
+    ubuntu:
+        bionic: ["libpcl-common1.8"]
+        focal: ["libpcl-common1.10"]
+        jammy: ["libpcl-common1.12"]
+        noble: ["libpcl-common1.14"]
+
+libpcl-features:
+    ubuntu:
+        bionic: ["libpcl-features1.8"]
+        focal: ["libpcl-features1.10"]
+        jammy: ["libpcl-features1.12"]
+        noble: ["libpcl-features1.14"]
+
+libpcl-filters:
+    ubuntu:
+        bionic: ["libpcl-filters1.8"]
+        focal: ["libpcl-filters1.10"]
+        jammy: ["libpcl-filters1.12"]
+        noble: ["libpcl-filters1.14"]
+
+libpcl-io:
+    ubuntu:
+        bionic: ["libpcl-io1.8"]
+        focal: ["libpcl-io1.10"]
+        jammy: ["libpcl-io1.12"]
+        noble: ["libpcl-io1.14"]
+
+libpcl-kdtree:
+    ubuntu:
+        bionic: ["libpcl-kdtree1.8"]
+        focal: ["libpcl-kdtree1.10"]
+        jammy: ["libpcl-kdtree1.12"]
+        noble: ["libpcl-kdtree1.14"]
+
+libpcl-keypoints:
+    ubuntu:
+        bionic: ["libpcl-keypoints1.8"]
+        focal: ["libpcl-keypoints1.10"]
+        jammy: ["libpcl-keypoints1.12"]
+        noble: ["libpcl-keypoints1.14"]
+
+libpcl-ml:
+    ubuntu:
+        bionic: ["libpcl-ml1.8"]
+        focal: ["libpcl-ml1.10"]
+        jammy: ["libpcl-ml1.12"]
+        noble: ["libpcl-ml1.14"]
+
+libpcl-octree:
+    ubuntu:
+        bionic: ["libpcl-octree1.8"]
+        focal: ["libpcl-octree1.10"]
+        jammy: ["libpcl-octree1.12"]
+        noble: ["libpcl-octree1.14"]
+
+libpcl-outofcore:
+    ubuntu:
+        bionic: ["libpcl-outofcore1.8"]
+        focal: ["libpcl-outofcore1.10"]
+        jammy: ["libpcl-outofcore1.12"]
+        noble: ["libpcl-outofcore1.14"]
+
+libpcl-people:
+    ubuntu:
+        bionic: ["libpcl-people1.8"]
+        focal: ["libpcl-people1.10"]
+        jammy: ["libpcl-people1.12"]
+        noble: ["libpcl-people1.14"]
+
+libpcl-recognition:
+    ubuntu:
+        bionic: ["libpcl-recognition1.8"]
+        focal: ["libpcl-recognition1.10"]
+        jammy: ["libpcl-recognition1.12"]
+        noble: ["libpcl-recognition1.14"]
+
+libpcl-registration:
+    ubuntu:
+        bionic: ["libpcl-registration1.8"]
+        focal: ["libpcl-registration1.10"]
+        jammy: ["libpcl-registration1.12"]
+        noble: ["libpcl-registration1.14"]
+
+libpcl-sample-consensus:
+    ubuntu:
+        bionic: ["libpcl-sample-consensus1.8"]
+        focal: ["libpcl-sample-consensus1.10"]
+        jammy: ["libpcl-sample-consensus1.12"]
+        noble: ["libpcl-sample-consensus1.14"]
+
+libpcl-search:
+    ubuntu:
+        bionic: ["libpcl-search1.8"]
+        focal: ["libpcl-search1.10"]
+        jammy: ["libpcl-search1.12"]
+        noble: ["libpcl-search1.14"]
+
+libpcl-segmentation:
+    ubuntu:
+        bionic: ["libpcl-segmentation1.8"]
+        focal: ["libpcl-segmentation1.10"]
+        jammy: ["libpcl-segmentation1.12"]
+        noble: ["libpcl-segmentation1.14"]
+
+libpcl-stereo:
+    ubuntu:
+        bionic: ["libpcl-stereo1.8"]
+        focal: ["libpcl-stereo1.10"]
+        jammy: ["libpcl-stereo1.12"]
+        noble: ["libpcl-stereo1.14"]
+
+libpcl-surface:
+    ubuntu:
+        bionic: ["libpcl-surface1.8"]
+        focal: ["libpcl-surface1.10"]
+        jammy: ["libpcl-surface1.12"]
+        noble: ["libpcl-surface1.14"]
+
+libpcl-tracking:
+    ubuntu:
+        bionic: ["libpcl-tracking1.8"]
+        focal: ["libpcl-tracking1.10"]
+        jammy: ["libpcl-tracking1.12"]
+        noble: ["libpcl-tracking1.14"]
+
+libpcl-visualization:
+    ubuntu:
+        bionic: ["libpcl-visualization1.8"]
+        focal: ["libpcl-visualization1.10"]
+        jammy: ["libpcl-visualization1.12"]
+        noble: ["libpcl-visualization1.14"]
+
+libpcsclite-dev:
+    ubuntu: ["libpcsclite-dev"]
+
+libpcsclite1:
+    ubuntu: ["libpcsclite1"]
+
+libphonon:
+    ubuntu: ["libphonon4"]
+
+libphonon-dev:
+    ubuntu: ["libphonon-dev"]
+
+libpng++-dev:
+    ubuntu: ["libpng++-dev"]
+
+libpng-dev:
+    ubuntu:
+        default: ["libpng-dev"]
+
+libpng12-dev:
+    ubuntu: ["libpng12-dev"]
+
+libpoco-dev:
+    ubuntu: ["libpoco-dev"]
+
+libpocofoundation9:
+    ubuntu: ["libpocofoundation9"]
+
+libpopt-dev:
+    ubuntu: ["libpopt-dev"]
+
+libpq-dev:
+    ubuntu: ["libpq-dev"]
+
+libpqxx:
+    ubuntu:
+        bionic: ["libpqxx-4.0v5"]
+        focal: ["libpqxx-6.4"]
+
+libpqxx-dev:
+    ubuntu: ["libpqxx-dev"]
+
+libprocps-dev:
+    ubuntu: ["libprocps-dev"]
+
+libprocps6:
+    ubuntu:
+        bionic: ["libprocps6"]
+
+libpt-dev:
+    ubuntu: ["libpt-dev"]
+
+libpthread-stubs0-dev:
+    ubuntu: ["libpthread-stubs0-dev"]
+
+libpulse-dev:
+    ubuntu: ["libpulse-dev"]
+
+libqcustomplot-dev:
+    ubuntu: ["libqcustomplot-dev"]
+
+libqd-dev:
+    ubuntu: ["libqd-dev"]
+
+libqglviewer-dev-qt5:
+    ubuntu: ["libqglviewer-dev-qt5"]
+
+libqglviewer-qt4:
+    ubuntu:
+        bionic: ["libqglviewer2-qt4"]
+
+libqglviewer-qt4-dev:
+    ubuntu:
+        bionic: ["libqglviewer-dev-qt4"]
+
+libqglviewer2-qt5:
+    ubuntu: ["libqglviewer2-qt5"]
+
+libqhull:
+    ubuntu: ["libqhull-dev"]
+
+libqmi-glib-dev:
+    ubuntu: ["libqmi-glib-dev"]
+
+libqrencode:
+    ubuntu: ["libqrencode3"]
+
+libqrencode-dev:
+    ubuntu: ["libqrencode-dev"]
+
+libqt4:
+    ubuntu: ["libqt4-dbus", "libqt4-network", "libqt4-script", "libqt4-test", "libqt4-xml", "libqtcore4"]
+
+libqt4-dev:
+    ubuntu: ["libqt4-dev"]
+
+libqt4-opengl:
+    ubuntu: ["libqt4-opengl"]
+
+libqt4-opengl-dev:
+    ubuntu: ["libqt4-opengl-dev"]
+
+libqt4-sql-psql:
+    ubuntu: ["libqt4-sql-psql"]
+
+libqt5-charts-dev:
+    ubuntu: ["libqt5charts5-dev"]
+
+libqt5-concurrent:
+    ubuntu: ["libqt5concurrent5"]
+
+libqt5-core:
+    ubuntu: ["libqt5core5a"]
+
+libqt5-gstreamer-dev:
+    ubuntu: ["libqt5gstreamer-dev"]
+
+libqt5-gui:
+    ubuntu: ["libqt5gui5"]
+
+libqt5-multimedia:
+    ubuntu: ["libqt5multimedia5"]
+
+libqt5-network:
+    ubuntu: ["libqt5network5"]
+
+libqt5-opengl:
+    ubuntu: ["libqt5opengl5"]
+
+libqt5-opengl-dev:
+    ubuntu: ["libqt5opengl5-dev"]
+
+libqt5-printsupport:
+    ubuntu: ["libqt5printsupport5"]
+
+libqt5-qml:
+    ubuntu: ["libqt5qml5"]
+
+libqt5-quick:
+    ubuntu: ["libqt5quick5"]
+
+libqt5-serialport:
+    ubuntu: ["libqt5serialport5"]
+
+libqt5-serialport-dev:
+    ubuntu: ["libqt5serialport5-dev"]
+
+libqt5-sql:
+    ubuntu: ["libqt5sql5"]
+
+libqt5-svg:
+    ubuntu: ["libqt5svg5"]
+
+libqt5-svg-dev:
+    ubuntu: ["libqt5svg5-dev"]
+
+libqt5-websockets-dev:
+    ubuntu: ["libqt5websockets5-dev"]
+
+libqt5-widgets:
+    ubuntu: ["libqt5widgets5"]
+
+libqt5-xml:
+    ubuntu: ["libqt5xml5"]
+
+libqt5multimedia5-plugins:
+    ubuntu: ["libqt5multimedia5-plugins"]
+
+libqt5x11extras5-dev:
+    ubuntu: ["libqt5x11extras5-dev"]
+
+libqtgui4:
+    ubuntu: ["libqtgui4"]
+
+libqtwebkit-dev:
+    ubuntu: ["libqtwebkit-dev"]
+
+libqwt-qt5-dev:
+    ubuntu:
+        default: ["libqwt-qt5-dev"]
+
+libqwt5-qt4-dev:
+    ubuntu: ["libqwt5-qt4-dev"]
+
+libqwt6:
+    ubuntu: ["libqwt-dev"]
+
+libqwtplot3d-qt4-dev:
+    ubuntu: ["libqwtplot3d-qt4-dev"]
+
+librabbitmq-dev:
+    ubuntu: ["librabbitmq-dev"]
+
+librapidxml-dev:
+    ubuntu: ["librapidxml-dev"]
+
+libraw1394:
+    ubuntu: ["libraw1394-11"]
+
+libraw1394-dev:
+    ubuntu: ["libraw1394-dev"]
+
+librdkafka-dev:
+    ubuntu: ["librdkafka-dev"]
+
+libreadline:
+    ubuntu: ["libreadline-dev"]
+
+libreadline-dev:
+    ubuntu: ["libreadline-dev"]
+
+libreadline-java:
+    ubuntu: ["libreadline-java"]
+
+librtaudio-dev:
+    ubuntu: ["librtaudio-dev"]
+
+libsecp256k1-dev:
+    ubuntu: ["libsecp256k1-dev"]
+
+libsensors4-dev:
+    ubuntu: ["libsensors4-dev"]
+
+libserial-dev:
+    ubuntu: ["libserial-dev"]
+
+libshaderc-dev:
+    ubuntu:
+        default: ["libshaderc-dev"]
+        focal: nonexistent
+        jammy: nonexistent
+
+libsimage-dev:
+    ubuntu: ["libsimage-dev"]
+
+libsndfile1-dev:
+    ubuntu: ["libsndfile1-dev"]
+
+libsodium-dev:
+    ubuntu: ["libsodium-dev"]
+
+libsoqt4-dev:
+    ubuntu: ["libsoqt4-dev"]
+
+libsoundio-dev:
+    ubuntu: ["libsoundio-dev"]
+
+libsoup2-dev:
+    ubuntu: ["libsoup2.4-dev"]
+
+libspatialindex-dev:
+    ubuntu: ["libspatialindex-dev"]
+
+libspatialite:
+    ubuntu:
+        default: ["libsqlite3-mod-spatialite"]
+
+libspnav-dev:
+    ubuntu: ["libspnav-dev", "libx11-dev"]
+
+libsqlite3-dev:
+    ubuntu: ["libsqlite3-dev"]
+
+libsrtp0-dev:
+    ubuntu: ["libsrtp0-dev"]
+
+libssh-dev:
+    ubuntu: ["libssh-dev"]
+
+libssh2:
+    ubuntu: ["libssh2-1"]
+
+libssh2-dev:
+    ubuntu: ["libssh2-1-dev"]
+
+libssl-dev:
+    ubuntu: ["libssl-dev"]
+
+libstdc++5:
+    ubuntu: ["libstdc++5"]
+
+libstdc++6:
+    ubuntu: ["libstdc++6"]
+
+libsvm-dev:
+    ubuntu: ["libsvm-dev"]
+
+libsvm3:
+    ubuntu: ["libsvm3"]
+
+libsvn-dev:
+    ubuntu: ["libsvn-dev"]
+
+libswscale-dev:
+    ubuntu: ["libswscale-dev"]
+
+libsystemd-dev:
+    ubuntu:
+        default: ["libsystemd-dev"]
+
+libtclap-dev:
+    ubuntu: ["libtclap-dev"]
+
+libtesseract:
+    ubuntu: ["libtesseract-dev"]
+
+libtheora:
+    ubuntu: ["libtheora-dev"]
+
+libtiff-dev:
+    ubuntu: ["libtiff-dev"]
+
+libtiff4-dev:
+    ubuntu: ["libtiff4-dev"]
+
+libtins-dev:
+    ubuntu: ["libtins-dev"]
+
+libtool:
+    ubuntu: ["libtool", "libltdl-dev", "libtool-bin"]
+
+libttspico:
+    ubuntu: ["libttspico-dev", "libttspico-data", "libttspico-utils", "libttspico0"]
+
+libturbojpeg:
+    ubuntu:
+        default: ["libturbojpeg0-dev"]
+
+libudev-dev:
+    ubuntu: ["libudev-dev"]
+
+libunittest++:
+    ubuntu: ["libunittest++-dev"]
+
+libunwind:
+    ubuntu:
+        default: ["libunwind8"]
+
+libunwind-dev:
+    ubuntu:
+        default: ["libunwind-dev"]
+
+liburdfdom-dev:
+    ubuntu: ["liburdfdom-dev"]
+
+liburdfdom-headers-dev:
+    ubuntu: ["liburdfdom-headers-dev"]
+
+liburdfdom-tools:
+    ubuntu: ["liburdfdom-tools"]
+
+libusb:
+    ubuntu: ["libusb-0.1-4"]
+
+libusb-1.0:
+    ubuntu: ["libusb-1.0-0"]
+
+libusb-1.0-dev:
+    ubuntu: ["libusb-1.0-0-dev"]
+
+libusb-dev:
+    ubuntu: ["libusb-dev"]
+
+libuv-dev:
+    ubuntu:
+        bionic: ["libuv0.10-dev"]
+
+libuv1-dev:
+    ubuntu: ["libuv1-dev"]
+
+libuvc-dev:
+    ubuntu:
+        default: ["libuvc-dev"]
+
+libv4l-dev:
+    ubuntu: ["libv4l-dev"]
+
+libvlc:
+    ubuntu:
+        default: ["libvlc5", "vlc-bin"]
+
+libvlc-dev:
+    ubuntu: ["libvlc-dev"]
+
+libvlccore-dev:
+    ubuntu: ["libvlccore-dev"]
+
+libvorbis-dev:
+    ubuntu: ["libvorbis-dev"]
+
+libvpx-dev:
+    ubuntu: ["libvpx-dev"]
+
+libvtk:
+    ubuntu:
+        default: ["libvtk7-dev"]
+        bionic: ["libvtk6-dev"]
+
+libvtk-java:
+    ubuntu:
+        default: ["libvtk7-java"]
+        bionic: ["libvtk6-java"]
+
+libvtk-qt:
+    ubuntu:
+        default: ["libvtk7-qt-dev"]
+        bionic: ["libvtk6-qt-dev"]
+
+libvtk9-dev:
+    ubuntu:
+        default: ["libvtk9-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libvulkan-dev:
+    ubuntu:
+        default: ["libvulkan-dev"]
+
+libwebp-dev:
+    ubuntu: ["libwebp-dev"]
+
+libwebp-tools:
+    ubuntu: ["webp"]
+
+libwebsocketpp-dev:
+    ubuntu: ["libwebsocketpp-dev"]
+
+libwebsockets-dev:
+    ubuntu: ["libwebsockets-dev"]
+
+libx11:
+    ubuntu: ["libx11-dev"]
+
+libx11-dev:
+    ubuntu: ["libx11-dev"]
+
+libx11-xcb-dev:
+    ubuntu: ["libx11-xcb-dev"]
+
+libx264-dev:
+    ubuntu: ["libx264-dev"]
+
+libxaw:
+    ubuntu: ["libxaw7-dev"]
+
+libxcb-randr0-dev:
+    ubuntu: ["libxcb-randr0-dev"]
+
+libxcursor-dev:
+    ubuntu: ["libxcursor-dev"]
+
+libxenomai-dev:
+    ubuntu: ["libxenomai-dev"]
+
+libxext:
+    ubuntu: ["libxext-dev"]
+
+libxft-dev:
+    ubuntu: ["libxft-dev"]
+
+libxi-dev:
+    ubuntu: ["libxi-dev"]
+
+libxinerama-dev:
+    ubuntu: ["libxinerama-dev"]
+
+libxkbcommon-dev:
+    ubuntu: ["libxkbcommon-dev"]
+
+libxml++-2.6:
+    ubuntu: ["libxml++2.6-dev"]
+
+libxml2:
+    ubuntu: ["libxml2-dev"]
+
+libxml2-utils:
+    ubuntu: ["libxml2-utils"]
+
+libxmlrpc-c++:
+    ubuntu: ["libxmlrpc-c++8-dev"]
+
+libxmu-dev:
+    ubuntu: ["libxmu-dev"]
+
+libxrandr:
+    ubuntu: ["libxrandr-dev"]
+
+libxslt:
+    ubuntu: ["libxslt1-dev"]
+
+libxss1:
+    ubuntu: ["libxss1"]
+
+libxt-dev:
+    ubuntu: ["libxt-dev"]
+
+libxtst-dev:
+    ubuntu: ["libxtst-dev"]
+
+libxxf86vm:
+    ubuntu: ["libxxf86vm-dev"]
+
+libyaml:
+    ubuntu: ["libyaml-0-2"]
+
+libyaml-dev:
+    ubuntu: ["libyaml-dev"]
+
+libzip-dev:
+    ubuntu: ["libzip-dev"]
+
+libzmq3-dev:
+    ubuntu:
+        default: ["libzmq3-dev", "cppzmq-dev"]
+        bionic: ["libzmq3-dev"]
+        focal: ["libzmq3-dev"]
+        jammy: ["libzmq3-dev"]
+
+libzmqpp-dev:
+    ubuntu: ["libzmqpp-dev"]
+
+libzmqpp3:
+    ubuntu: ["libzmqpp3"]
+
+libzstd-dev:
+    ubuntu:
+        default: ["libzstd-dev"]
+
+light-locker:
+    ubuntu: ["light-locker"]
+
+lighttpd:
+    ubuntu: ["lighttpd"]
+
+lilypond:
+    ubuntu: ["lilypond"]
+
+linphone:
+    ubuntu: ["linphone"]
+
+linux-headers-generic:
+    ubuntu: ["linux-headers-generic"]
+
+linux-kernel-headers:
+    ubuntu: ["linux-libc-dev"]
+
+llvm:
+    ubuntu: ["llvm"]
+
+llvm-7:
+    ubuntu:
+        bionic: ["llvm-7"]
+        focal: ["llvm-7"]
+
+llvm-7-dev:
+    ubuntu:
+        bionic: ["llvm-7-dev"]
+        focal: ["llvm-7-dev"]
+
+llvm-dev:
+    ubuntu: ["llvm-dev"]
+
+lm-sensors:
+    ubuntu: ["lm-sensors"]
+
+log4cplus:
+    ubuntu: ["liblog4cplus-dev"]
+
+log4cxx:
+    ubuntu:
+        default: ["liblog4cxx-dev"]
+
+lsb-release:
+    ubuntu: ["lsb-release"]
+
+lttng-modules:
+    ubuntu: ["lttng-modules-dkms"]
+
+lttng-tools:
+    ubuntu: ["lttng-tools"]
+
+lua-dev:
+    ubuntu: ["liblua5.1-0-dev"]
+
+lua5.2-dev:
+    ubuntu: ["liblua5.2-dev"]
+
+lz4:
+    ubuntu: ["liblz4-dev"]
+
+m2r:
+    ubuntu:
+        default: ["m2r"]
+        bionic: nonexistent
+
+m4:
+    ubuntu: ["m4"]
+
+mapnik-utils:
+    ubuntu: ["mapnik-utils"]
+
+matio:
+    ubuntu: ["libmatio-dev"]
+
+maven:
+    ubuntu: ["maven"]
+
+mayavi:
+    ubuntu: ["mayavi2"]
+
+meld:
+    ubuntu: ["meld"]
+
+mercurial:
+    ubuntu: ["mercurial"]
+
+mesa-common-dev:
+    ubuntu: ["mesa-common-dev"]
+
+mesa-utils:
+    ubuntu: ["mesa-utils"]
+
+meshlab:
+    ubuntu: ["meshlab"]
+
+mkdocs:
+    ubuntu:
+        bionic: ["mkdocs"]
+
+mkdocs-bootstrap:
+    ubuntu:
+        bionic: ["mkdocs-bootstrap"]
+
+mkdocs-bootswatch:
+    ubuntu:
+        bionic: ["mkdocs-bootswatch"]
+
+mongodb:
+    ubuntu:
+        bionic: ["mongodb"]
+        focal: ["mongodb"]
+
+mongodb-dev:
+    ubuntu: ["libmongoclient-dev"]
+
+mono-complete:
+    ubuntu: ["mono-complete"]
+
+mono-devel:
+    ubuntu: ["mono-devel"]
+
+mosquitto:
+    ubuntu: ["mosquitto"]
+
+mosquitto-clients:
+    ubuntu: ["mosquitto-clients"]
+
+mosquitto-dev:
+    ubuntu: ["libmosquitto-dev"]
+
+mosquittopp-dev:
+    ubuntu: ["libmosquittopp-dev"]
+
+mpfr:
+    ubuntu: ["libmpfr-dev"]
+
+mpg123:
+    ubuntu: ["mpg123"]
+
+mplayer:
+    ubuntu: ["mplayer"]
+
+mrpt:
+    ubuntu: ["libmrpt-dev"]
+
+msgpack:
+    ubuntu: ["libmsgpack-dev"]
+
+msr-tools:
+    ubuntu: ["msr-tools"]
+
+multistrap:
+    ubuntu: ["multistrap"]
+
+muparser:
+    ubuntu: ["libmuparser-dev"]
+
+nanobind-dev:
+    pip: ["nanobind"]
+    pip: ["nanobind"]
+
+nanoflann:
+    ubuntu:
+        default: ["libnanoflann-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+nasm:
+    ubuntu: ["nasm"]
+
+nbtscan:
+    ubuntu: ["nbtscan"]
+
+net-tools:
+    ubuntu: ["net-tools"]
+
+netcdf:
+    ubuntu: ["libnetcdf-dev"]
+
+netpbm:
+    ubuntu: ["libnetpbm10-dev"]
+
+network-manager:
+    ubuntu: ["network-manager"]
+
+ninja-build:
+    ubuntu: ["ninja-build"]
+
+nite-dev:
+    ubuntu: ["nite-dev"]
+
+nkf:
+    ubuntu: ["nkf"]
+
+nlohmann-json-dev:
+    ubuntu:
+        default: ["nlohmann-json3-dev"]
+        bionic: ["nlohmann-json-dev"]
+
+nmap:
+    ubuntu: ["nmap"]
+
+nodejs:
+    ubuntu: ["nodejs"]
+
+nodejs-legacy:
+    ubuntu: ["nodejs-legacy"]
+
+npm:
+    ubuntu: ["npm"]
+
+ntp:
+    ubuntu: ["ntp"]
+
+ntpdate:
+    ubuntu: ["ntpdate"]
+
+nvidia-cg:
+    ubuntu: ["nvidia-cg-toolkit"]
+
+nvidia-cuda:
+    ubuntu: ["nvidia-cuda-toolkit"]
+
+nvidia-cuda-dev:
+    ubuntu: ["nvidia-cuda-dev"]
+
+nvidia-cudnn:
+    ubuntu:
+        default: ["nvidia-cudnn"]
+        focal: nonexistent
+
+ocl-icd-opencl-dev:
+    ubuntu: ["ocl-icd-opencl-dev"]
+
+octave:
+    ubuntu: ["octave"]
+
+odb:
+    ubuntu:
+        default: ["odb"]
+
+omniidl:
+    ubuntu: ["omniidl", "omniorb-idl"]
+
+omniorb:
+    ubuntu: ["omniorb", "omniidl", "omniorb-idl", "omniorb-nameserver", "libomniorb4-dev"]
+
+opencascade:
+    ubuntu:
+        bionic: ["liboce-visualization-dev"]
+        focal: ["libocct-data-exchange-dev", "libocct-draw-dev"]
+
+opencl-headers:
+    ubuntu: ["opencl-headers"]
+
+opende:
+    ubuntu: ["libode-dev"]
+
+opengl:
+    ubuntu: ["libgl1-mesa-dev", "libglu1-mesa-dev"]
+
+openjdk-6-jdk:
+    ubuntu: ["openjdk-6-jdk"]
+
+openmpi:
+    ubuntu: []
+
+openni-dev:
+    ubuntu: ["libopenni-dev"]
+
+openocd:
+    ubuntu: ["openocd"]
+
+openssh-client:
+    ubuntu: ["openssh-client"]
+
+openssh-server:
+    ubuntu: ["openssh-server"]
+
+openssl:
+    ubuntu: ["openssl"]
+
+optipng:
+    ubuntu: ["optipng"]
+
+osm2pgsql:
+    ubuntu: ["osm2pgsql"]
+
+osmium:
+    ubuntu: ["libosmium2-dev"]
+
+pandoc:
+    ubuntu: ["pandoc"]
+
+patchelf:
+    ubuntu: ["patchelf"]
+
+pcre:
+    ubuntu: ["libpcre3-dev"]
+
+pcre-dev:
+    ubuntu: ["libpcre++-dev"]
+
+pcscd:
+    ubuntu: ["pcscd"]
+
+phantomjs:
+    ubuntu: ["phantomjs"]
+
+pigz:
+    ubuntu: ["pigz"]
+
+pkg-config:
+    ubuntu: ["pkg-config"]
+
+pmccabe:
+    ubuntu: ["pmccabe"]
+
+pmount:
+    ubuntu: ["pmount"]
+
+polyclipping-dev:
+    ubuntu: ["libpolyclipping-dev"]
+
+poppler-utils:
+    ubuntu: ["poppler-utils"]
+
+portaudio:
+    ubuntu: ["libportaudio-dev"]
+
+portaudio19-dev:
+    ubuntu: ["portaudio19-dev"]
+
+postfix:
+    ubuntu: ["postfix"]
+
+postgresql:
+    ubuntu: ["postgresql", "postgresql-contrib"]
+
+postgresql-client:
+    ubuntu: ["postgresql-client"]
+
+postgresql-postgis:
+    ubuntu:
+        bionic: ["postgresql-10-postgis-2.4", "postgresql-contrib", "postgresql-server-dev-all"]
+        focal: ["postgresql-12-postgis-3", "postgresql-contrib", "postgresql-server-dev-all"]
+
+potrace:
+    ubuntu: ["potrace"]
+
+powertop:
+    ubuntu: ["powertop"]
+
+procps:
+    ubuntu: ["procps"]
+
+proj:
+    ubuntu: ["libproj-dev"]
+
+protobuf:
+    ubuntu:
+        bionic: ["libprotobuf10"]
+        focal: ["libprotobuf17"]
+        jammy: ["libprotobuf23"]
+        noble: ["libprotobuf32"]
+
+protobuf-compiler-grpc:
+    ubuntu: ["protobuf-compiler-grpc"]
+
+protobuf-dev:
+    ubuntu: ["libprotobuf-dev", "protobuf-compiler", "libprotoc-dev"]
+
+ps-engine:
+    ubuntu: ["ps-engine"]
+
+psmisc:
+    ubuntu: ["psmisc"]
+
+pstoedit:
+    ubuntu: ["pstoedit"]
+
+psutils:
+    ubuntu: ["psutils"]
+
+pugixml-dev:
+    ubuntu: ["libpugixml-dev"]
+
+pybind11-dev:
+    ubuntu: ["pybind11-dev"]
+
+pybind11-json-dev:
+    ubuntu:
+        default: ["pybind11-json-dev"]
+        focal: nonexistent
+
+python-dev:
+    ubuntu:
+        default: ["python-dev"]
+        focal: ["python2-dev"]
+
+qemu-user-static:
+    ubuntu: ["qemu-user-static"]
+
+qhull-bin:
+    ubuntu: ["qhull-bin"]
+
+qml-module-qt-labs-folderlistmodel:
+    ubuntu: ["qml-module-qt-labs-folderlistmodel"]
+
+qml-module-qt-labs-platform:
+    ubuntu: ["qml-module-qt-labs-platform"]
+
+qml-module-qt-labs-settings:
+    ubuntu: ["qml-module-qt-labs-settings"]
+
+qml-module-qtcharts:
+    ubuntu: ["qml-module-qtcharts"]
+
+qml-module-qtgraphicaleffects:
+    ubuntu: ["qml-module-qtgraphicaleffects"]
+
+qml-module-qtlocation:
+    ubuntu: ["qml-module-qtlocation"]
+
+qml-module-qtmultimedia:
+    ubuntu: ["qml-module-qtmultimedia"]
+
+qml-module-qtpositioning:
+    ubuntu: ["qml-module-qtpositioning"]
+
+qml-module-qtquick-controls:
+    ubuntu: ["qml-module-qtquick-controls"]
+
+qml-module-qtquick-controls2:
+    ubuntu: ["qml-module-qtquick-controls2"]
+
+qml-module-qtquick-dialogs:
+    ubuntu: ["qml-module-qtquick-dialogs"]
+
+qml-module-qtquick-extras:
+    ubuntu: ["qml-module-qtquick-extras"]
+
+qml-module-qtquick-layouts:
+    ubuntu: ["qml-module-qtquick-layouts"]
+
+qml-module-qtquick-templates2:
+    ubuntu: ["qml-module-qtquick-templates2"]
+
+qml-module-qtquick-window2:
+    ubuntu: ["qml-module-qtquick-window2"]
+
+qml-module-qtquick2:
+    ubuntu: ["qml-module-qtquick2"]
+
+qrencode:
+    ubuntu: ["qrencode"]
+
+qt4-dev-tools:
+    ubuntu: ["qt4-dev-tools"]
+
+qt4-linguist-tools:
+    ubuntu:
+        default: nonexistent
+        bionic: ["qt4-linguist-tools"]
+
+qt4-qmake:
+    ubuntu: ["qt4-qmake"]
+
+qt5-image-formats-plugins:
+    ubuntu: ["qt5-image-formats-plugins"]
+
+qt5-qmake:
+    ubuntu: ["qt5-qmake"]
+
+qtbase5-dev:
+    ubuntu: ["qtbase5-dev"]
+
+qtbase5-private-dev:
+    ubuntu: ["qtbase5-private-dev"]
+
+qtdeclarative5-dev:
+    ubuntu: ["qtdeclarative5-dev"]
+
+qtmobility-dev:
+    ubuntu: ["qtmobility-dev"]
+
+qtmultimedia5-dev:
+    ubuntu: ["qtmultimedia5-dev"]
+
+qtpositioning5-dev:
+    ubuntu: ["qtpositioning5-dev"]
+
+qtquickcontrols2-5-dev:
+    ubuntu: ["qtquickcontrols2-5-dev"]
+
+qttools5-dev:
+    ubuntu: ["qttools5-dev"]
+
+qttools5-dev-tools:
+    ubuntu: ["qttools5-dev-tools"]
+
+qtwebengine5-dev:
+    ubuntu: ["qtwebengine5-dev"]
+
+r-base:
+    ubuntu: ["r-base"]
+
+r-base-dev:
+    ubuntu: ["r-base-dev"]
+
+range-v3:
+    ubuntu:
+        default: ["librange-v3-dev"]
+
+rapidjson-dev:
+    ubuntu: ["rapidjson-dev"]
+
+readline-dev:
+    ubuntu: ["libreadline-dev"]
+
+recode:
+    ubuntu: ["recode"]
+
+recordmydesktop:
+    ubuntu: ["recordmydesktop"]
+
+redis-server:
+    ubuntu: ["redis-server"]
+
+robin-map-dev:
+    ubuntu: ["robin-map-dev"]
+
+robotino-api2:
+    ubuntu: ["robotino-api2"]
+
+rsync:
+    ubuntu: ["rsync"]
+
+rsyslog:
+    ubuntu: ["rsyslog"]
+
+rt-tests:
+    ubuntu: ["rt-tests"]
+
+rti-connext-dds-5.3.1:
+    ubuntu:
+        bionic: ["rti-connext-dds-5.3.1"]
+        focal: ["rti-connext-dds-5.3.1"]
+
+rti-connext-dds-6.0.1:
+    ubuntu:
+        default: ["rti-connext-dds-6.0.1"]
+        bionic: nonexistent
+
+rtmidi:
+    ubuntu: ["librtmidi-dev"]
+
+rustc:
+    ubuntu: ["rustc"]
+
+sbcl:
+    ubuntu: ["sbcl"]
+
+scons:
+    ubuntu: ["scons"]
+
+screen:
+    ubuntu: ["screen"]
+
+sdformat:
+    ubuntu:
+        bionic: ["libsdformat6-dev"]
+        focal: ["libsdformat9-dev"]
+        jammy: ["libsdformat-dev"]
+
+sdformat11:
+    ubuntu:
+        focal: ["libsdformat11-dev"]
+
+sdformat12:
+    ubuntu:
+        focal: ["libsdformat12-dev"]
+        jammy: ["libsdformat12-dev"]
+
+sdl:
+    ubuntu: ["libsdl1.2-dev"]
+
+sdl-gfx:
+    ubuntu: ["libsdl-gfx1.2-dev"]
+
+sdl-image:
+    ubuntu: ["libsdl-image1.2-dev"]
+
+sdl-mixer:
+    ubuntu: ["libsdl-mixer1.2-dev"]
+
+sdl-ttf:
+    ubuntu: ["libsdl-ttf2.0-dev"]
+
+sdl2:
+    ubuntu: ["libsdl2-dev"]
+
+sdl2-image:
+    ubuntu: ["libsdl2-image-dev"]
+
+sdl2-mixer:
+    ubuntu: ["libsdl2-mixer-dev"]
+
+sdl2-ttf:
+    ubuntu: ["libsdl2-ttf-dev"]
+
+semgrep:
+    pip: ["semgrep"]
+
+setserial:
+    ubuntu: ["setserial"]
+
+sfml-dev:
+    ubuntu: ["libsfml-dev"]
+
+simde:
+    ubuntu:
+        default: ["libsimde-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+sixad:
+    ubuntu: ["sixad"]
+
+slime:
+    ubuntu: ["slime"]
+
+smartmontools:
+    ubuntu: ["smartmontools"]
+
+smbclient:
+    ubuntu: ["smbclient"]
+
+snappy:
+    ubuntu: ["libsnappy-dev"]
+
+socat:
+    ubuntu: ["socat"]
+
+sound-theme-freedesktop:
+    ubuntu: ["sound-theme-freedesktop"]
+
+sox:
+    ubuntu: ["sox"]
+
+spacenavd:
+    ubuntu: ["spacenavd"]
+
+sparsehash:
+    ubuntu: ["libsparsehash-dev"]
+
+spdlog:
+    ubuntu: ["libspdlog-dev"]
+
+speech-dispatcher:
+    ubuntu: ["speech-dispatcher"]
+
+spirv-headers:
+    ubuntu:
+        default: ["spirv-headers"]
+        bionic: nonexistent
+
+spirv-tools:
+    ubuntu:
+        default: ["spirv-tools"]
+        bionic: nonexistent
+
+sqlite3:
+    ubuntu: ["sqlite3"]
+
+ssh-askpass:
+    ubuntu: ["ssh-askpass"]
+
+ssh-askpass-gnome:
+    ubuntu: ["ssh-askpass-gnome"]
+
+sshpass:
+    ubuntu: ["sshpass"]
+
+stress:
+    ubuntu: ["stress"]
+
+stress-ng:
+    ubuntu: ["stress-ng"]
+
+subversion:
+    ubuntu: ["subversion"]
+
+suitesparse:
+    ubuntu: ["libsuitesparse-dev"]
+
+supervisor:
+    ubuntu: ["supervisor"]
+
+swi-prolog:
+    ubuntu: ["swi-prolog"]
+
+swi-prolog-java:
+    ubuntu: ["swi-prolog-java"]
+
+swi-prolog-odbc:
+    ubuntu: ["swi-prolog-odbc"]
+
+swig:
+    ubuntu: ["swig"]
+
+sysbench:
+    ubuntu: ["sysbench"]
+
+sysstat:
+    ubuntu: ["sysstat"]
+
+systemd:
+    ubuntu: ["systemd"]
+
+tango-icon-theme:
+    ubuntu: ["tango-icon-theme"]
+
+tar:
+    ubuntu: ["libtar-dev"]
+
+tbb:
+    ubuntu: ["libtbb-dev"]
+
+tcsh:
+    ubuntu: ["tcsh"]
+
+terminator:
+    ubuntu: ["terminator"]
+
+tesseract-ocr:
+    ubuntu: ["tesseract-ocr"]
+
+tesseract-ocr-jpn:
+    ubuntu: ["tesseract-ocr-jpn"]
+
+texlive-fonts-extra:
+    ubuntu: ["texlive-fonts-extra"]
+
+texlive-fonts-recommended:
+    ubuntu: ["texlive-fonts-recommended"]
+
+texlive-full:
+    ubuntu: ["texlive-full"]
+
+texlive-latex-base:
+    ubuntu: ["texlive-latex-base"]
+
+texlive-latex-extra:
+    ubuntu: ["texlive-latex-extra"]
+
+texlive-latex-recommended:
+    ubuntu: ["texlive-latex-recommended"]
+
+texmaker:
+    ubuntu: ["texmaker"]
+
+tiled:
+    ubuntu: ["tiled"]
+
+time:
+    ubuntu: ["time"]
+
+tinyxml:
+    ubuntu: ["libtinyxml-dev"]
+
+tinyxml2:
+    ubuntu: ["libtinyxml2-dev"]
+
+tix:
+    ubuntu: ["tix"]
+
+tmux:
+    ubuntu: ["tmux"]
+
+touchegg:
+    ubuntu: ["touchegg"]
+
+trang:
+    ubuntu: ["trang"]
+
+tree:
+    ubuntu: ["tree"]
+
+tshark:
+    ubuntu: ["tshark"]
+
+ttf-kochi-gothic:
+    ubuntu: ["ttf-kochi-gothic"]
+
+ttf-kochi-mincho:
+    ubuntu: ["ttf-kochi-mincho"]
+
+ttf-sazanami-gothic:
+    ubuntu: ["ttf-sazanami-gothic"]
+
+ttf-sazanami-mincho:
+    ubuntu: ["ttf-sazanami-mincho"]
+
+udev:
+    ubuntu: ["udev"]
+
+udhcpc:
+    ubuntu: ["udhcpc"]
+
+unclutter:
+    ubuntu: ["unclutter"]
+
+uncrustify:
+    ubuntu: ["uncrustify"]
+
+unison:
+    ubuntu: ["unison"]
+
+unison-gui:
+    ubuntu: ["unison-gtk"]
+
+unoconv:
+    ubuntu: ["unoconv"]
+
+unrar:
+    ubuntu: ["unrar"]
+
+unzip:
+    ubuntu: ["unzip"]
+
+usbutils:
+    ubuntu: ["usbutils"]
+
+util-linux:
+    ubuntu:
+        default: ["util-linux"]
+        bionic: ["setpriv", "util-linux"]
+
+uuid:
+    ubuntu: ["uuid-dev"]
+
+uvcdynctrl:
+    ubuntu: ["uvcdynctrl"]
+
+v4l-utils:
+    ubuntu: ["v4l-utils"]
+
+valgrind:
+    ubuntu: ["valgrind"]
+
+vim:
+    ubuntu: ["vim"]
+
+vlc:
+    ubuntu: ["vlc"]
+
+vorbis-tools:
+    ubuntu: ["vorbis-tools"]
+
+wayland:
+    ubuntu: ["libwayland-client0", "libwayland-cursor0", "libwayland-egl1"]
+
+wayland-dev:
+    ubuntu: ["libwayland-dev", "wayland-protocols"]
+
+wget:
+    ubuntu: ["wget"]
+
+wireguard:
+    ubuntu:
+        default: ["wireguard"]
+        bionic: nonexistent
+
+wireless-tools:
+    ubuntu: ["wireless-tools"]
+
+wireshark:
+    ubuntu: ["wireshark"]
+
+wireshark-common:
+    ubuntu: ["wireshark-common"]
+
+wkhtmltopdf:
+    ubuntu: ["wkhtmltopdf"]
+
+wmctrl:
+    ubuntu: ["wmctrl"]
+
+workrave:
+    ubuntu: ["workrave", "workrave-data"]
+
+wx-common:
+    ubuntu: ["wx-common"]
+
+wxwidgets:
+    ubuntu:
+        default: ["libwxgtk3.2-dev"]
+        bionic: ["libwxgtk3.0-dev"]
+        focal: ["libwxgtk3.0-gtk3-dev"]
+        jammy: ["libwxgtk3.0-gtk3-dev"]
+
+x11proto-dri2-dev:
+    ubuntu: ["x11proto-dri2-dev"]
+
+x11proto-gl-dev:
+    ubuntu: ["x11proto-gl-dev"]
+
+x11proto-print-dev:
+    ubuntu: ["x11proto-print-dev"]
+
+xclip:
+    ubuntu: ["xclip"]
+
+xdg-utils:
+    ubuntu: ["xdg-utils"]
+
+xdotool:
+    ubuntu: ["xdotool"]
+
+xerces:
+    ubuntu: ["libxerces-c-dev"]
+
+xfonts-100dpi:
+    ubuntu: ["xfonts-100dpi"]
+
+xfonts-75dpi:
+    ubuntu: ["xfonts-75dpi"]
+
+xpath-perl:
+    ubuntu: ["libxml-xpath-perl"]
+
+xsimd:
+    ubuntu:
+        default: ["libxsimd-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+xsltproc:
+    ubuntu: ["xsltproc"]
+
+xtensor:
+    ubuntu:
+        default: ["libxtensor-dev"]
+        focal: nonexistent
+
+xterm:
+    ubuntu: ["xterm"]
+
+xulrunner-1.9.2:
+    ubuntu:
+        karmic: ["xulrunner-1.9.2"]
+
+xulrunner-dev:
+    ubuntu: ["libv8-dev"]
+
+xvfb:
+    ubuntu: ["xvfb"]
+
+xz-utils:
+    ubuntu: ["xz-utils"]
+
+yaml:
+    ubuntu: ["libyaml-dev"]
+
+yaml-cpp:
+    ubuntu: ["libyaml-cpp-dev"]
+
+yamllint:
+    ubuntu: ["yamllint"]
+
+yarn:
+    ubuntu:
+        default: ["yarnpkg"]
+        bionic: nonexistent
+
+yasm:
+    ubuntu: ["yasm"]
+
+zbar:
+    ubuntu: ["libzbar-dev"]
+
+zenity:
+    ubuntu: ["zenity"]
+
+zeromq3:
+    ubuntu: ["libzmq5"]
+
+zip:
+    ubuntu: ["zip"]
+
+zlib:
+    ubuntu: ["zlib1g-dev"]
+
+zsh:
+    ubuntu: ["zsh"]
+
+zziplib:
+    ubuntu: ["libzzip-dev"]
+
+adafruit-ads1x15-pip:
+    pip: ["Adafruit-ADS1x15"]
+
+adafruit-gpio-pip:
+    pip: ["Adafruit-GPIO"]
+
+adafruit-mcp3008-pip:
+    pip: ["Adafruit-MCP3008"]
+
+adafruit-pca9685-pip:
+    pip: ["adafruit-pca9685"]
+
+autograd-pip:
+    pip: ["autograd"]
+
+autolab-core-pip:
+    pip: ["autolab-core"]
+
+autolab-perception-pip:
+    pip: ["autolab_perception"]
+
+autolab-visualization-pip:
+    pip: ["visualization"]
+
+awsiotpythonsdk-pip:
+    pip: ["awsiotpythonsdk"]
+
+azure-core-pip:
+    pip: ["azure-core"]
+
+azure-iothub-device-client-pip:
+    pip: ["azure-iothub-device-client"]
+
+azure-mgmt-storage-pip:
+    pip: ["azure-mgmt-storage"]
+
+azure-storage-file-share-pip:
+    pip: ["azure-storage-file-share"]
+
+black:
+    ubuntu:
+        default: ["black"]
+        bionic: nonexistent
+
+canopen-pip:
+    pip: ["canopen"]
+
+carla-pip:
+    pip: ["carla"]
+
+casadi-pip:
+    pip: ["casadi"]
+
+cmakelint-pip:
+    pip: ["cmakelint"]
+
+cppcheck-junit-pip:
+    pip: ["cppcheck-junit"]
+
+cython:
+    ubuntu: ["cython"]
+
+cython3:
+    ubuntu: ["cython3"]
+
+dpath-pip:
+    pip: ["dpath"]
+
+ds4drv-pip:
+    pip: ["ds4drv"]
+
+epydoc:
+    ubuntu: ["python-epydoc"]
+
+exhale-pip:
+    pip: ["exhale"]
+
+gunicorn:
+    ubuntu: ["gunicorn"]
+
+gym-pip:
+    pip: ["gym"]
+
+imgaug-pip:
+    pip: ["imgaug"]
+
+intelhex-pip:
+    pip: ["intelhex"]
+
+ipython:
+    ubuntu: ["ipython"]
+
+ipython3:
+    ubuntu: ["ipython3"]
+
+jupyter-nbconvert:
+    ubuntu:
+        default: ["jupyter-nbconvert"]
+
+jupyter-notebook:
+    ubuntu:
+        default: ["jupyter-notebook"]
+
+libgv-python:
+    ubuntu: ["libgv-python"]
+
+libshiboken2-dev:
+    ubuntu: ["libshiboken2-dev"]
+
+mcap-ros2-support:
+    pip: ["mcap-ros2-support"]
+
+meson:
+    ubuntu: ["meson"]
+
+nuitka:
+    ubuntu: ["nuitka"]
+
+onvif_zeep:
+    pip: ["onvif_zeep"]
+
+opcua-pip:
+    pip: ["opcua"]
+
+paramiko:
+    ubuntu: ["python-paramiko"]
+
+pi-ina219-pip:
+    pip: ["pi-ina219"]
+
+pika:
+    ubuntu: ["python-pika"]
+
+pydocstyle:
+    ubuntu: ["pydocstyle"]
+
+pydrive-pip:
+    pip: ["PyDrive"]
+
+pyflakes3:
+    ubuntu: ["pyflakes3"]
+
+pymap3d-pip:
+    pip: ["pymap3d"]
+    pip: ["pymap3d"]
+
+pymodbustcp-pip:
+    pip: ["pyModbusTCP"]
+
+pynput-pip:
+    pip: ["pynput"]
+
+pyosmium:
+    ubuntu: ["python-pyosmium"]
+
+pyper-pip:
+    pip: ["pyper"]
+
+pyqt4-dev-tools:
+    ubuntu: ["pyqt4-dev-tools"]
+
+pyqt5-dev-tools:
+    ubuntu: ["pyqt5-dev-tools"]
+
+pyqt6-dev-tools:
+    ubuntu:
+        default: ["pyqt6-dev-tools"]
+        focal: nonexistent
+        jammy: nonexistent
+
+pyrebase-pip:
+    pip: ["pyrebase"]
+
+pyro4:
+    ubuntu: ["python2-pyro4"]
+
+pyros-setup-pip:
+    pip: ["pyros-setup"]
+
+pyside-tools:
+    ubuntu: ["pyside-tools"]
+
+python:
+    ubuntu:
+        bionic: ["python-dev"]
+
+python-absl-py-pip:
+    pip: ["absl-py"]
+
+python-adafruit-bno055-pip:
+    pip: ["adafruit_bno055"]
+
+python-alembic:
+    ubuntu:
+        default: ["python-alembic"]
+
+python-amqp:
+    ubuntu: ["python-amqp"]
+
+python-aniso8601:
+    ubuntu:
+        bionic: ["python-aniso8601"]
+
+python-annoy-pip:
+    pip: ["annoy"]
+
+python-anyjson:
+    ubuntu: ["python-anyjson"]
+
+python-apparmor:
+    ubuntu: ["python-apparmor"]
+
+python-argcomplete:
+    ubuntu: ["python-argcomplete"]
+
+python-argh:
+    ubuntu: ["python-argh"]
+
+python-argparse:
+    ubuntu:
+        default: []
+
+python-astor-pip:
+    pip: ["astor"]
+
+python-attrs:
+    ubuntu:
+        bionic: ["python-attr"]
+        focal: ["python-attr"]
+
+python-autobahn:
+    ubuntu:
+        default: ["python-autobahn"]
+
+python-avahi:
+    ubuntu: ["python-avahi"]
+
+python-babel:
+    ubuntu: ["python-babel"]
+
+python-backoff-pip:
+    pip: ["backoff"]
+
+python-backports.ssl-match-hostname:
+    ubuntu:
+        bionic: ["python-backports.ssl-match-hostname"]
+
+python-bcrypt:
+    ubuntu: ["python-bcrypt"]
+
+python-beautifulsoup:
+    ubuntu: ["python-beautifulsoup"]
+
+python-bitarray:
+    ubuntu: ["python-bitarray"]
+
+python-bitstring:
+    ubuntu:
+        bionic: ["python-bitstring"]
+
+python-bitstring-pip:
+    pip: ["bitstring"]
+
+python-blinker:
+    ubuntu: ["python-blinker"]
+
+python-bloom:
+    ubuntu:
+        default: ["python-bloom"]
+
+python-bluez:
+    ubuntu: ["python-bluez"]
+
+python-bokeh-pip:
+    pip: ["bokeh"]
+
+python-boltons:
+    ubuntu:
+        default: ["python-boltons"]
+
+python-boto3:
+    ubuntu:
+        default: ["python-boto3"]
+
+python-bottle:
+    ubuntu: ["python-bottle"]
+
+python-box2d:
+    ubuntu: ["python-box2d"]
+
+python-breathe:
+    ubuntu: ["python-breathe"]
+
+python-bs4:
+    ubuntu: ["python-bs4"]
+
+python-bson:
+    ubuntu: ["python-bson"]
+
+python-cairo:
+    ubuntu: ["python-cairo"]
+
+python-cairosvg:
+    ubuntu: ["python-cairosvg"]
+
+python-can:
+    ubuntu:
+        bionic: ["python-can"]
+
+python-cantools-pip:
+    pip: ["cantools"]
+
+python-catkin-lint:
+    ubuntu: ["python-catkin-lint"]
+
+python-catkin-pkg:
+    ubuntu:
+        bionic: ["python-catkin-pkg"]
+
+python-catkin-pkg-modules:
+    ubuntu: ["python-catkin-pkg-modules"]
+
+python-catkin-sphinx:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-catkin-sphinx"]
+
+python-catkin-tools:
+    ubuntu: ["python-catkin-tools"]
+
+python-cbor:
+    ubuntu: ["python-cbor"]
+
+python-celery:
+    ubuntu: ["python-celery"]
+
+python-certifi:
+    ubuntu:
+        bionic: ["python-certifi"]
+
+python-chainer-mask-rcnn-pip:
+    pip: ["chainer-mask-rcnn"]
+
+python-chainer-pip:
+    pip: ["chainer"]
+
+python-chainercv-pip:
+    pip: ["chainercv"]
+
+python-cheetah:
+    ubuntu: ["python-cheetah"]
+
+python-cherrypy:
+    ubuntu: ["python-cherrypy3"]
+
+python-clearsilver:
+    ubuntu: ["python-clearsilver"]
+
+python-click:
+    ubuntu:
+        bionic: ["python-click"]
+
+python-cobs-pip:
+    pip: ["cobs"]
+
+python-collada:
+    ubuntu: ["python-collada"]
+
+python-colorama:
+    ubuntu: ["python-colorama"]
+
+python-concurrent.futures:
+    ubuntu: ["python-concurrent.futures"]
+
+python-configparser:
+    ubuntu: ["python-configparser"]
+
+python-construct:
+    ubuntu:
+        bionic: ["python-construct"]
+
+python-construct-pip:
+    pip: ["construct"]
+
+python-control-pip:
+    pip: ["control"]
+
+python-cookiecutter:
+    ubuntu: ["python-cookiecutter"]
+
+python-cookiecutter-pip:
+    pip: ["cookiecutter"]
+
+python-couchdb:
+    ubuntu: ["python-couchdb"]
+
+python-coverage:
+    ubuntu:
+        bionic: ["python-coverage"]
+
+python-cpplint:
+    pip: ["cpplint"]
+
+python-crccheck-pip:
+    pip: ["crccheck"]
+
+python-crcmod:
+    ubuntu:
+        bionic: ["python-crcmod"]
+
+python-crypto:
+    ubuntu:
+        bionic: ["python-crypto"]
+
+python-cryptography:
+    ubuntu: ["python-cryptography"]
+
+python-cvxopt:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-cvxopt"]
+
+python-cvxpy-pip:
+    pip: ["cvxpy"]
+
+python-cwiid:
+    ubuntu: ["python-cwiid"]
+
+python-cython-pip:
+    pip: ["cython"]
+
+python-datadog-pip:
+    pip: ["datadog"]
+
+python-dateutil:
+    ubuntu: ["python-dateutil"]
+
+python-deap-pip:
+    pip: ["deap"]
+
+python-debian:
+    ubuntu:
+        bionic: ["python-debian"]
+
+python-decorator:
+    ubuntu: ["python-decorator"]
+
+python-deepdiff-pip:
+    pip: ["deepdiff"]
+
+python-defer-pip:
+    pip: ["defer"]
+
+python-defusedxml:
+    ubuntu: ["python-defusedxml"]
+
+python-dialogflow-pip:
+    pip: ["dialogflow"]
+
+python-django:
+    ubuntu: ["python-django"]
+
+python-django-cors-headers:
+    ubuntu: ["python-django-cors-headers"]
+
+python-django-extensions:
+    ubuntu: ["python-django-extensions"]
+
+python-django-extra-views:
+    ubuntu: ["python-django-extra-views"]
+
+python-djangorestframework:
+    ubuntu: ["python-djangorestframework"]
+
+python-dlib:
+    pip: ["dlib"]
+
+python-docker:
+    ubuntu: ["python-docker"]
+
+python-docopt:
+    ubuntu: ["python-docopt"]
+
+python-docutils:
+    ubuntu:
+        bionic: ["python-docutils"]
+
+python-docx:
+    pip: ["python-docx"]
+
+python-dt-apriltags-pip:
+    pip: ["dt-apriltags"]
+
+python-dxfgrabber-pip:
+    pip: ["dxfgrabber"]
+
+python-easygui:
+    ubuntu: ["python-easygui"]
+
+python-elasticsearch:
+    ubuntu:
+        bionic: ["python-elasticsearch"]
+
+python-empy:
+    ubuntu: ["python-empy"]
+
+python-enum:
+    ubuntu: ["python-enum"]
+
+python-enum34:
+    ubuntu: ["python-enum34"]
+
+python-enum34-pip:
+    pip: ["enum34"]
+
+python-evdev:
+    ubuntu: ["python-evdev"]
+
+python-expiringdict:
+    ubuntu: ["python-expiringdict"]
+
+python-face-alignment-pip:
+    pip: ["face-alignment"]
+
+python-face-recognition-pip:
+    pip: ["face_recognition"]
+
+python-falcon:
+    ubuntu: ["python-falcon"]
+
+python-fastdtw-pip:
+    pip: ["python-fastdtw"]
+
+python-fcl-pip:
+    pip: ["python-fcl"]
+
+python-fcn-pip:
+    pip: ["fcn"]
+
+python-filterpy-pip:
+    pip: ["filterpy"]
+
+python-fixtures:
+    ubuntu: ["python-fixtures"]
+
+python-flake8:
+    ubuntu:
+        bionic: ["python-flake8"]
+
+python-flask:
+    ubuntu:
+        default: ["python-flask"]
+
+python-flask-appbuilder-pip:
+    pip: ["flask-appbuilder"]
+
+python-flask-cors-pip:
+    pip: ["flask-cors"]
+
+python-flatdict-pip:
+    pip: ["flatdict"]
+
+python-freezegun-pip:
+    pip: ["freezegun"]
+
+python-frozendict:
+    ubuntu: ["python-frozendict"]
+
+python-ftdi1:
+    ubuntu: ["python-ftdi1"]
+
+python-funcsigs:
+    ubuntu: ["python-funcsigs"]
+
+python-future:
+    ubuntu:
+        bionic: ["python-future"]
+
+python-fuzzywuzzy-pip:
+    pip: ["fuzzywuzzy"]
+
+python-fysom:
+    pip: ["fysom"]
+
+python-gTTS-pip:
+    pip: ["gTTS"]
+
+python-gcloud-pip:
+    pip: ["gcloud"]
+
+python-gdal:
+    ubuntu:
+        bionic: ["python-gdal"]
+
+python-gdown-pip:
+    pip: ["gdown"]
+
+python-genshi:
+    ubuntu: ["python-genshi"]
+
+python-geocoder-pip:
+    pip: ["geocoder"]
+
+python-geographiclib:
+    ubuntu: ["python-geographiclib"]
+
+python-geopy:
+    ubuntu: ["python-geopy"]
+
+python-gevent:
+    ubuntu: ["python-gevent"]
+
+python-gi:
+    ubuntu: ["python-gi"]
+
+python-gi-cairo:
+    ubuntu: ["python-gi-cairo"]
+
+python-git:
+    ubuntu: ["python-git"]
+
+python-github-pip:
+    pip: ["PyGithub"]
+
+python-gitlab:
+    ubuntu:
+        bionic: ["python-gitlab"]
+
+python-gitpython-pip:
+    pip: ["gitpython"]
+
+python-glpk-pip:
+    pip: ["glpk"]
+
+python-gnupg:
+    ubuntu: ["python-gnupg"]
+
+python-gobject:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-gobject"]
+        focal: ["python-gobject"]
+
+python-google-cloud-bigquery-pip:
+    pip: ["google-cloud-bigquery"]
+
+python-google-cloud-speech-pip:
+    pip: ["google-cloud-speech"]
+
+python-google-cloud-storage-pip:
+    pip: ["google-cloud-storage"]
+
+python-google-cloud-texttospeech-pip:
+    pip: ["google-cloud-texttospeech"]
+
+python-google-cloud-vision-pip:
+    pip: ["google-cloud-vision"]
+
+python-googleapi:
+    ubuntu:
+        bionic: ["python-googleapi"]
+
+python-gpiozero:
+    ubuntu:
+        bionic: ["python-gpiozero"]
+
+python-gputil-pip:
+    pip: ["gputil"]
+
+python-gpxpy:
+    ubuntu:
+        bionic: ["python-gpxpy"]
+
+python-graphitesend-pip:
+    pip: ["graphitesend"]
+
+python-graphviz-pip:
+    pip: ["graphviz"]
+
+python-grpc-tools:
+    pip: ["grpcio-tools"]
+
+python-grpcio:
+    pip: ["grpcio"]
+
+python-gst-1.0:
+    ubuntu: ["python-gst-1.0"]
+
+python-gtk2:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-gtk2"]
+
+python-gurobipy-pip:
+    pip: ["gurobipy"]
+
+python-h5py:
+    ubuntu:
+        default: ["python-h5py"]
+
+python-httplib2:
+    ubuntu:
+        default: ["python-httplib2"]
+
+python-hypothesis:
+    ubuntu:
+        default: ["python-hypothesis"]
+
+python-imageio:
+    ubuntu:
+        bionic: ["python-imageio"]
+
+python-imaging:
+    ubuntu:
+        default: ["python-pil"]
+
+python-imaging-imagetk:
+    ubuntu: ["python-pil.imagetk"]
+
+python-impacket:
+    ubuntu: ["python-impacket"]
+
+python-influxdb:
+    ubuntu:
+        bionic: ["python-influxdb"]
+
+python-inject-pip:
+    pip: ["inject"]
+
+python-inotify-simple-pip:
+    pip: ["inotify-simple"]
+
+python-inputs-pip:
+    pip: ["inputs"]
+
+python-ipdb:
+    ubuntu: ["python-ipdb"]
+
+python-is-python3:
+    ubuntu:
+        default: ["python-is-python3"]
+        bionic: nonexistent
+
+python-itsdangerous:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-itsdangerous"]
+
+python-j1939-pip:
+    pip: ["j1939"]
+
+python-jasmine-pip:
+    pip: ["jasmine"]
+
+python-jetson-gpio-pip:
+    pip: ["Jetson.GPIO"]
+
+python-jetson-stats-pip:
+    pip: ["jetson-stats"]
+
+python-jinja2:
+    ubuntu: ["python-jinja2"]
+
+python-jira-pip:
+    pip: ["jira"]
+
+python-jmespath:
+    ubuntu: ["python-jmespath"]
+
+python-joblib:
+    ubuntu: ["python-joblib"]
+
+python-jsonpickle:
+    ubuntu: ["python-jsonpickle"]
+
+python-jsonpyes-pip:
+    pip: ["jsonpyes"]
+
+python-jsonref-pip:
+    pip: ["jsonref"]
+
+python-jsonschema:
+    ubuntu: ["python-jsonschema"]
+
+python-jsonschema-pip:
+    pip: ["jsonschema"]
+
+python-jwt:
+    ubuntu: ["python-jwt"]
+
+python-kdtree:
+    pip: ["kdtree"]
+
+python-keras-pip:
+    pip: ["keras"]
+
+python-keras-rl-pip:
+    pip: ["keras-rl"]
+
+python-kitchen:
+    ubuntu: ["python-kitchen"]
+
+python-kml:
+    ubuntu: ["python-kml"]
+
+python-kombu:
+    ubuntu: ["python-kombu"]
+
+python-kombu-pip:
+    pip: ["kombu"]
+
+python-levenshtein:
+    ubuntu: ["python-levenshtein"]
+
+python-libpcap:
+    ubuntu: ["python-libpcap"]
+
+python-libpgm-pip:
+    pip: ["libpgm"]
+
+python-librabbitmq-pip:
+    pip: ["librabbitmq"]
+
+python-lindypy-pip:
+    pip: ["lindypy"]
+
+python-lttngust:
+    pip: ["python-lttngust"]
+
+python-luis-pip:
+    pip: ["luis"]
+
+python-lxml:
+    ubuntu:
+        bionic: ["python-lxml"]
+        focal: ["python-lxml"]
+
+python-lzf-pip:
+    pip: ["python-lzf"]
+
+python-mahotas:
+    pip: ["mahotas"]
+
+python-mako:
+    ubuntu: ["python-mako"]
+
+python-mapnik:
+    ubuntu: ["python-mapnik"]
+
+python-marisa:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-marisa"]
+
+python-markdown:
+    ubuntu: ["python-markdown"]
+
+python-marshmallow:
+    pip: ["marshmallow"]
+
+python-math3d-pip:
+    pip: ["math3d"]
+
+python-matplotlib:
+    ubuntu:
+        bionic: ["python-matplotlib"]
+
+python-mechanize:
+    ubuntu: ["python-mechanize"]
+
+python-mistune:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-mistune"]
+
+python-mock:
+    ubuntu:
+        bionic: ["python-mock"]
+
+python-monotonic:
+    ubuntu: ["python-monotonic"]
+
+python-more-itertools:
+    ubuntu:
+        default: ["python-more-itertools"]
+
+python-msgpack:
+    ubuntu: ["python-msgpack"]
+
+python-multicast:
+    pip: ["py-multicast"]
+
+python-multiprocess-pip:
+    pip: ["multiprocess"]
+
+python-mysqldb:
+    ubuntu: ["python-mysqldb"]
+
+python-namedlist-pip:
+    pip: ["namedlist"]
+
+python-nclib-pip:
+    pip: ["nclib"]
+
+python-netaddr:
+    ubuntu:
+        bionic: ["python-netaddr"]
+
+python-netcdf4:
+    ubuntu: ["python-netcdf4"]
+
+python-netifaces:
+    ubuntu:
+        bionic: ["python-netifaces"]
+
+python-networkmanager:
+    ubuntu: ["python-networkmanager"]
+
+python-networkx:
+    ubuntu:
+        default: ["python-networkx"]
+
+python-nose:
+    ubuntu:
+        default: ["python-nose"]
+
+python-ntplib:
+    ubuntu: ["python-ntplib"]
+
+python-numpy:
+    ubuntu:
+        bionic: ["python-numpy"]
+        focal: ["python-numpy"]
+
+python-numpy-quaternion-pip:
+    pip: ["numpy-quaternion"]
+
+python-numpy-stl-pip:
+    pip: ["numpy-stl"]
+
+python-numpydoc:
+    ubuntu: ["python-numpydoc"]
+
+python-oauth2client:
+    ubuntu: ["python-oauth2client"]
+
+python-objectpath-pip:
+    pip: ["objectpath"]
+
+python-omniorb:
+    ubuntu:
+        focal: ["python-omniorb", "python-omniorb-omg", "omniidl-python"]
+
+python-open3d-pip:
+    pip: ["open3d-python"]
+
+python-opencv:
+    ubuntu: ["python-opencv"]
+
+python-opencv-contrib-pip:
+    pip: ["opencv-contrib-python"]
+
+python-opengl:
+    ubuntu:
+        bionic: ["python-opengl"]
+
+python-openssl:
+    ubuntu: ["python-openssl"]
+
+python-oyaml-pip:
+    pip: ["oyaml"]
+
+python-packaging:
+    ubuntu: ["python-packaging"]
+
+python-paho-mqtt:
+    ubuntu:
+        bionic: ["python-paho-mqtt"]
+
+python-paho-mqtt-pip:
+    pip: ["paho-mqtt"]
+
+python-pandacan-pip:
+    pip: ["pandacan"]
+
+python-pandas:
+    ubuntu: ["python-pandas"]
+
+python-parameterized:
+    ubuntu:
+        bionic: ["python-parameterized"]
+
+python-paramiko:
+    ubuntu: ["python-paramiko"]
+
+python-parse:
+    ubuntu: ["python-parse"]
+
+python-parso:
+    ubuntu:
+        bionic: ["python-parso"]
+
+python-passlib:
+    ubuntu: ["python-passlib"]
+
+python-pastedeploy:
+    ubuntu: ["python-pastedeploy"]
+
+python-path.py:
+    pip: ["path.py"]
+
+python-pathlib:
+    ubuntu: ["python-pathlib"]
+
+python-pathlib2:
+    ubuntu:
+        default: ["python-pathlib2"]
+
+python-pathos-pip:
+    pip: ["pathos"]
+
+python-pbr:
+    ubuntu: ["python-pbr"]
+
+python-pcapy:
+    ubuntu: ["python-pcapy"]
+
+python-pcg-gazebo-pip:
+    pip: ["pcg-gazebo"]
+
+python-pep8:
+    ubuntu:
+        default: ["python-pep8"]
+
+python-percol:
+    pip: ["percol"]
+
+python-periphery-pip:
+    pip: ["python-periphery"]
+
+python-persist-queue-pip:
+    pip: ["persist-queue"]
+
+python-pexpect:
+    ubuntu: ["python-pexpect"]
+
+python-pip:
+    ubuntu: ["python-pip"]
+
+python-pixel-ring-pip:
+    pip: ["pixel-ring"]
+
+python-pkg-resources:
+    ubuntu: ["python-pkg-resources"]
+
+python-planar-pip:
+    pip: ["planar"]
+
+python-plyfile-pip:
+    pip: ["plyfile"]
+
+python-poster:
+    ubuntu: ["python-poster"]
+
+python-pqdict-pip:
+    pip: ["pqdict"]
+
+python-prettytable:
+    ubuntu: ["python-prettytable"]
+
+python-progressbar:
+    ubuntu:
+        bionic: ["python-progressbar"]
+
+python-progressbar2-pip:
+    pip: ["progressbar2"]
+
+python-protobuf:
+    ubuntu: ["python-protobuf"]
+
+python-psutil:
+    ubuntu:
+        default: ["python-psutil"]
+
+python-pulsectl-pip:
+    pip: ["pulsectl"]
+
+python-pyassimp:
+    ubuntu:
+        bionic: ["python-pyassimp"]
+
+python-pyaudio:
+    ubuntu: ["python-pyaudio"]
+
+python-pycodestyle:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-pycodestyle"]
+
+python-pycpd-pip:
+    pip: ["pycpd"]
+
+python-pycryptodome:
+    ubuntu: ["python-pycryptodome"]
+
+python-pycurl:
+    ubuntu: ["python-pycurl"]
+
+python-pydbus:
+    ubuntu:
+        bionic: ["python-pydbus"]
+
+python-pydot:
+    ubuntu: ["python-pydot"]
+
+python-pyexiv2:
+    ubuntu: ["python-pyexiv2"]
+
+python-pyftpdlib:
+    ubuntu: ["python-pyftpdlib"]
+
+python-pygame:
+    ubuntu: ["python-pygame"]
+
+python-pygithub3:
+    pip: ["pygithub3"]
+
+python-pygps-pip:
+    pip: ["pyGPs"]
+
+python-pygraph:
+    ubuntu: ["python-pygraph"]
+
+python-pygraphviz:
+    ubuntu: ["python-pygraphviz"]
+
+python-pyinotify:
+    ubuntu: ["python-pyinotify"]
+
+python-pykalman:
+    pip: ["pykalman"]
+
+python-pylibftdi-pip:
+    pip: ["pylibftdi"]
+
+python-pylint:
+    ubuntu: ["pylint"]
+
+python-pylint3:
+    ubuntu:
+        default: ["pylint"]
+        bionic: ["pylint3"]
+
+python-pymavlink:
+    pip: ["pymavlink"]
+
+python-pymodbus:
+    ubuntu:
+        bionic: ["python-pymodbus"]
+
+python-pymodbus-pip:
+    pip: ["pymodbus"]
+
+python-pymongo:
+    ubuntu:
+        default: ["python-pymongo"]
+
+python-pymouse:
+    pip: ["pymouse"]
+
+python-pynfft:
+    ubuntu: ["python-pynfft"]
+
+python-pynmea2:
+    pip: ["pynmea2"]
+
+python-pypcd-pip:
+    pip: ["pypcd"]
+
+python-pypng:
+    ubuntu:
+        bionic: ["python-png"]
+
+python-pypozyx-pip:
+    pip: ["pypozyx"]
+
+python-pyproj:
+    ubuntu: ["python-pyproj"]
+
+python-pyqrcode:
+    ubuntu:
+        bionic: ["python-pyqrcode"]
+
+python-pyqtgraph:
+    ubuntu:
+        bionic: ["python-pyqtgraph"]
+
+python-pyquery:
+    ubuntu: ["python-pyquery"]
+
+python-pyramid:
+    ubuntu: ["python-pyramid"]
+
+python-pyrealsense2-pip:
+    pip: ["pyrealsense2"]
+
+python-pysimplegui27-pip:
+    pip: ["pysimplegui27"]
+
+python-pysnmp:
+    ubuntu: ["python-pysnmp4"]
+
+python-pytesseract-pip:
+    pip: ["pytesseract"]
+
+python-pytest:
+    ubuntu: ["python-pytest"]
+
+python-pytest-cov:
+    ubuntu: ["python-pytest-cov"]
+
+python-pytest-dependency-pip:
+    pip: ["pytest-dependency"]
+
+python-pytest-mock:
+    ubuntu: ["python-pytest-mock"]
+
+python-pytest-qt-pip:
+    pip: ["pytest-qt"]
+
+python-pytides-pip:
+    pip: ["pytides"]
+
+python-pytorch-pip:
+    pip: ["torch", "torchvision"]
+
+python-pytz-pip:
+    pip: ["pytz"]
+
+python-pyudev:
+    ubuntu:
+        default: ["python-pyudev"]
+
+python-pyusb-pip:
+    pip: ["pyusb"]
+
+python-pyuserinput:
+    pip: ["PyUserInput"]
+
+python-pyvirtualdisplay-pip:
+    pip: ["pyvirtualdisplay"]
+
+python-pyxhook-pip:
+    pip: ["pyxhook"]
+
+python-pyzbar-pip:
+    pip: ["pyzbar"]
+
+python-qrencode:
+    ubuntu: ["python-qrencode"]
+
+python-qt-bindings:
+    ubuntu:
+        default: ["python-pyside", "libpyside-dev", "libshiboken-dev", "shiboken", "python-qt4", "python-qt4-dev", "python-sip-dev"]
+
+python-qt-bindings-gl:
+    ubuntu: ["python-qt4-gl"]
+
+python-qt-bindings-qwt5:
+    ubuntu: ["python-qwt5-qt4"]
+
+python-qt-bindings-webkit:
+    ubuntu: ["python-qt4"]
+
+python-qt4-gl:
+    ubuntu: ["python-qt4-gl"]
+
+python-qt5-bindings:
+    ubuntu:
+        bionic: ["pyqt5-dev", "python-pyqt5", "python-pyqt5.qtsvg", "python-sip-dev"]
+
+python-qt5-bindings-gl:
+    ubuntu:
+        bionic: ["python-pyqt5.qtopengl"]
+
+python-qt5-bindings-qsci:
+    ubuntu: ["python-pyqt5.qsci"]
+
+python-qt5-bindings-quick:
+    ubuntu: ["python-pyqt5.qtquick"]
+
+python-qt5-bindings-webkit:
+    ubuntu:
+        bionic: ["python-pyqt5.qtwebkit"]
+
+python-qtpy:
+    ubuntu: ["python-qtpy"]
+
+python-qwt5-qt4:
+    ubuntu: ["python-qwt5-qt4"]
+
+python-rdflib:
+    ubuntu: ["python-rdflib"]
+
+python-readchar-pip:
+    pip: ["readchar"]
+
+python-redis:
+    ubuntu: ["python-redis"]
+
+python-redis-pip:
+    pip: ["redis"]
+
+python-requests:
+    ubuntu:
+        default: ["python-requests"]
+
+python-requests-oauthlib:
+    ubuntu: ["python-requests-oauthlib"]
+
+python-responses-pip:
+    pip: ["responses"]
+
+python-rosdep:
+    ubuntu:
+        bionic: ["python-rosdep"]
+
+python-rosdep-modules:
+    ubuntu: ["python-rosdep-modules"]
+
+python-rosinstall:
+    ubuntu:
+        default: ["python-rosinstall"]
+
+python-rosinstall-generator:
+    ubuntu: ["python-rosinstall-generator"]
+
+python-rospkg:
+    ubuntu:
+        default: ["python-rospkg"]
+
+python-rospkg-modules:
+    ubuntu: ["python-rospkg-modules"]
+
+python-rpi.gpio:
+    ubuntu:
+        bionic: ["python-rpi.gpio"]
+
+python-rpi.gpio-pip:
+    pip: ["RPi.GPIO"]
+
+python-rtree:
+    ubuntu: ["python-rtree"]
+
+python-ruamel.yaml:
+    ubuntu:
+        bionic: ["python-ruamel.yaml"]
+
+python-rx-pip:
+    pip: ["rx"]
+
+python-sbp-pip:
+    pip: ["sbp"]
+
+python-scapy:
+    ubuntu: ["python-scapy"]
+
+python-schedule:
+    ubuntu: ["python-schedule"]
+
+python-scipy:
+    ubuntu:
+        default: ["python-scipy"]
+
+python-scp:
+    ubuntu: ["python-scp"]
+
+python-seaborn:
+    ubuntu:
+        bionic: ["python-seaborn"]
+
+python-selectors2-pip:
+    pip: ["selectors2"]
+
+python-selenium-pip:
+    pip: ["selenium"]
+
+python-semantic-version:
+    ubuntu:
+        bionic: ["python-semantic-version"]
+
+python-semver:
+    ubuntu: ["python-semver"]
+
+python-serial:
+    ubuntu:
+        bionic: ["python-serial"]
+
+python-setproctitle:
+    ubuntu: ["python-setproctitle"]
+
+python-setuptools:
+    ubuntu:
+        bionic: ["python-setuptools"]
+
+python-sexpdata:
+    pip: ["sexpdata"]
+
+python-sh:
+    ubuntu:
+        bionic: ["python-sh"]
+
+python-shapely:
+    ubuntu:
+        default: ["python-shapely"]
+
+python-simplejson:
+    ubuntu: ["python-simplejson"]
+
+python-singledispatch:
+    ubuntu: ["python-singledispatch"]
+
+python-sip:
+    ubuntu:
+        default: ["python-sip-dev"]
+
+python-six:
+    ubuntu: ["python-six"]
+
+python-skimage:
+    ubuntu:
+        bionic: ["python-skimage"]
+
+python-skimage-pip:
+    pip: ["scikit-image"]
+
+python-sklearn:
+    ubuntu:
+        default: ["python-sklearn"]
+
+python-slackclient-pip:
+    pip: ["slackclient"]
+
+python-slacker-cli:
+    pip: ["slacker-cli"]
+
+python-slycot-pip:
+    pip: ["slycot"]
+
+python-smbus:
+    ubuntu: ["python-smbus"]
+
+python-sortedcontainers-pip:
+    pip: ["sortedcontainers"]
+
+python-sparqlwrapper:
+    ubuntu: ["python-sparqlwrapper"]
+
+python-speechrecognition-pip:
+    pip: ["speechrecognition"]
+
+python-sphinx:
+    ubuntu:
+        default: ["python-sphinx"]
+
+python-sphinx-argparse:
+    ubuntu:
+        bionic: ["python-sphinx-argparse"]
+
+python-sphinx-rtd-theme:
+    ubuntu:
+        bionic: ["python-sphinx-rtd-theme"]
+
+python-spidev-pip:
+    pip: ["spidev"]
+
+python-sqlalchemy:
+    ubuntu:
+        bionic: ["python-sqlalchemy"]
+
+python-sqlite:
+    ubuntu: ["python-sqlite"]
+
+python-statistics-pip:
+    pip: ["statistics"]
+
+python-statsd:
+    ubuntu: ["python-statsd"]
+
+python-subprocess32:
+    ubuntu:
+        default: ["python-subprocess32"]
+
+python-support:
+    ubuntu: ["python-support"]
+
+python-svg.path:
+    ubuntu:
+        bionic: ["python-svg.path"]
+
+python-svn:
+    ubuntu: ["python-svn"]
+
+python-sympy:
+    ubuntu:
+        bionic: ["python-sympy"]
+
+python-systemd:
+    ubuntu:
+        bionic: ["python-systemd"]
+
+python-sysv-ipc:
+    ubuntu: ["python-sysv-ipc"]
+
+python-tablib:
+    ubuntu: ["python-tablib"]
+
+python-tablib-pip:
+    pip: ["tablib"]
+
+python-tabulate:
+    ubuntu:
+        bionic: ["python-tabulate"]
+
+python-tabulate-pip:
+    pip: ["tabulate"]
+
+python-tblib:
+    ubuntu: ["python-tblib"]
+
+python-telegram-bot:
+    pip: ["python-telegram-bot"]
+
+python-tensorboard-pip:
+    pip: ["tensorboard"]
+
+python-tensorboardX-pip:
+    pip: ["tensorboardX"]
+
+python-tensorflow-gpu-pip:
+    pip: ["tensorflow-gpu"]
+
+python-tensorflow-hub-pip:
+    pip: ["tensorflow-hub"]
+
+python-tensorflow-pip:
+    pip: ["tensorflow"]
+
+python-tensorflow-serving-api-pip:
+    pip: ["tensorflow-serving-api"]
+
+python-termcolor:
+    ubuntu:
+        default: ["python-termcolor"]
+
+python-testscenarios:
+    ubuntu: ["python-testscenarios"]
+
+python-testtools:
+    ubuntu: ["python-testtools"]
+
+python-texttable:
+    ubuntu:
+        bionic: ["python-texttable"]
+
+python-tftpy:
+    ubuntu: ["python-tftpy"]
+
+python-tilestache:
+    ubuntu: ["tilestache"]
+
+python-tk:
+    ubuntu:
+        default: ["python-tk"]
+
+python-toml:
+    ubuntu: ["python-toml"]
+
+python-tornado:
+    ubuntu: ["python-tornado"]
+
+python-tornado-couchdb-pip:
+    pip: ["tornado-couchdb"]
+
+python-tornado-pip:
+    pip: ["tornado"]
+
+python-tqdm:
+    ubuntu:
+        bionic: ["python-tqdm"]
+
+python-transforms3d-pip:
+    pip: ["transforms3d"]
+
+python-transitions:
+    ubuntu:
+        bionic: ["python-transitions"]
+
+python-trep:
+    pip: ["trep"]
+
+python-triangle-pip:
+    pip: ["triangle"]
+
+python-trimesh-pip:
+    pip: ["trimesh"]
+
+python-twilio-pip:
+    pip: ["twilio"]
+
+python-twisted-bin:
+    ubuntu: ["python-twisted-bin"]
+
+python-twisted-core:
+    ubuntu: ["python-twisted-core"]
+
+python-twisted-web:
+    ubuntu: ["python-twisted-web"]
+
+python-twitter:
+    ubuntu: ["python-twitter"]
+
+python-typing:
+    ubuntu:
+        default: ["python-typing"]
+
+python-typing-pip:
+    pip: ["typing"]
+
+python-tz:
+    ubuntu: ["python-tz"]
+
+python-tzlocal-pip:
+    pip: ["tzlocal"]
+
+python-ubjson:
+    ubuntu:
+        bionic: ["python-ubjson"]
+
+python-ujson:
+    ubuntu:
+        bionic: ["python-ujson"]
+
+python-unittest2:
+    ubuntu: ["python-unittest2"]
+
+python-urlgrabber:
+    ubuntu: ["python-urlgrabber"]
+
+python-urllib3:
+    ubuntu: ["python-urllib3"]
+
+python-usb:
+    ubuntu: ["python-usb"]
+
+python-utm-pip:
+    pip: ["utm"]
+
+python-validictory-pip:
+    pip: ["validictory"]
+
+python-vcstool:
+    ubuntu: ["python-vcstool"]
+
+python-vedo-pip:
+    pip: ["vedo"]
+
+python-vine-pip:
+    pip: ["vine"]
+
+python-virtualenv:
+    ubuntu: ["python-virtualenv"]
+
+python-visual:
+    ubuntu: ["python-visual"]
+
+python-vlc-pip:
+    pip: ["python-vlc"]
+
+python-voluptuous:
+    ubuntu: ["python-voluptuous"]
+
+python-vtk:
+    ubuntu:
+        bionic: ["python-vtk6"]
+
+python-w1thermsensor-pip:
+    pip: ["w1thermsensor"]
+
+python-waitress:
+    ubuntu: ["python-waitress"]
+
+python-walrus-pip:
+    pip: ["walrus"]
+
+python-watchdog:
+    ubuntu:
+        bionic: ["python-watchdog"]
+
+python-webob:
+    ubuntu: ["python-webob"]
+
+python-webpy:
+    ubuntu: ["python-webpy"]
+
+python-webrtcvad-pip:
+    pip: ["webrtcvad"]
+
+python-websocket:
+    ubuntu:
+        bionic: ["python-websocket"]
+
+python-webtest:
+    ubuntu: ["python-webtest"]
+
+python-werkzeug:
+    ubuntu: ["python-werkzeug"]
+
+python-wheel:
+    ubuntu: ["python-wheel"]
+
+python-whichcraft:
+    ubuntu: ["python-whichcraft"]
+
+python-wrapt:
+    ubuntu: ["python-wrapt"]
+
+python-ws4py:
+    ubuntu: ["python-ws4py"]
+
+python-ws4py-pip:
+    pip: ["ws4py"]
+
+python-wstool:
+    ubuntu: ["python-wstool"]
+
+python-wtforms:
+    ubuntu: ["python-wtforms"]
+
+python-wxtools:
+    ubuntu: ["python-wxtools"]
+
+python-xdot:
+    ubuntu: ["xdot"]
+
+python-xlib:
+    ubuntu: ["python-xlib"]
+
+python-xlrd:
+    ubuntu: ["python-xlrd"]
+
+python-xmlplain-pip:
+    pip: ["xmlplain"]
+
+python-xmltodict:
+    ubuntu:
+        bionic: ["python-xmltodict"]
+
+python-yamale-pip:
+    pip: ["yamale"]
+
+python-yaml:
+    ubuntu:
+        bionic: ["python-yaml"]
+        focal: ["python-yaml"]
+
+python-zbar:
+    ubuntu: ["python-zbar"]
+
+python-zmq:
+    ubuntu:
+        default: ["python-zmq"]
+
+python3:
+    ubuntu: ["python3-dev"]
+
+python3-adafruit-blinka-pip:
+    pip: ["Adafruit-Blinka"]
+
+python3-adafruit-circuitpython-ads1x15-pip:
+    pip: ["adafruit-circuitpython-ads1x15"]
+
+python3-adafruit-circuitpython-bno055-pip:
+    pip: ["adafruit-circuitpython-bno055"]
+
+python3-adafruit-circuitpython-bno08x-pip:
+    pip: ["adafruit-circuitpython-bno08x"]
+
+python3-adafruit-circuitpython-lsm9ds0-pip:
+    pip: ["adafruit-circuitpython-lsm9ds0"]
+
+python3-adafruit-circuitpython-mcp230xx-pip:
+    pip: ["adafruit-circuitpython-mcp230xx"]
+
+python3-adafruit-circuitpython-mpu6050-pip:
+    pip: ["adafruit-circuitpython-mpu6050"]
+
+python3-adapt-parser-pip:
+    pip: ["adapt-parser"]
+
+python3-ahrs-pip:
+    pip: ["ahrs"]
+
+python3-aio-pika-pip:
+    pip: ["aio-pika"]
+
+python3-aiohttp:
+    ubuntu: ["python3-aiohttp"]
+
+python3-aiohttp-cors:
+    ubuntu: ["python3-aiohttp-cors"]
+
+python3-aiortc:
+    ubuntu:
+        jammy: ["python3-aiortc"]
+
+python3-albumentations-pip:
+    pip: ["albumentations"]
+
+python3-alembic:
+    ubuntu: ["python3-alembic"]
+
+python3-ansible-runner-pip:
+    pip: ["ansible-runner"]
+
+python3-antlr4:
+    ubuntu:
+        default: ["python3-antlr4"]
+        focal: nonexistent
+
+python3-anytree-pip:
+    pip: ["anytree"]
+
+python3-apa102-pi-pip:
+    pip: ["apa102-pi"]
+
+python3-argcomplete:
+    ubuntu: ["python3-argcomplete"]
+
+python3-astropy-pip:
+    pip: ["astropy"]
+
+python3-asyncssh:
+    ubuntu: ["python3-asyncssh"]
+
+python3-attrs:
+    ubuntu: ["python3-attr"]
+
+python3-autobahn:
+    ubuntu: ["python3-autobahn"]
+
+python3-awsiotsdk-pip:
+    pip: ["awsiotsdk"]
+
+python3-babel:
+    ubuntu: ["python3-babel"]
+
+python3-babeltrace:
+    ubuntu: ["python3-babeltrace"]
+
+python3-backoff-pip:
+    pip: ["backoff"]
+
+python3-bcrypt:
+    ubuntu: ["python3-bcrypt"]
+
+python3-bidict:
+    ubuntu:
+        default: ["python3-bidict"]
+        bionic: nonexistent
+
+python3-bitarray:
+    ubuntu: ["python3-bitarray"]
+
+python3-bitstring:
+    ubuntu: ["python3-bitstring"]
+
+python3-bloom:
+    ubuntu: ["python3-bloom"]
+
+python3-bluerobotics-ping-pip:
+    pip: ["bluerobotics-ping"]
+
+python3-bluez:
+    ubuntu:
+        default: ["python3-bluez"]
+        bionic: nonexistent
+
+python3-bokeh-pip:
+    pip: ["bokeh"]
+
+python3-bosdyn-api-pip:
+    pip: ["bosdyn-api", "bosdyn-choreography-protos"]
+
+python3-bosdyn-client-pip:
+    pip: ["bosdyn-client", "bosdyn-choreography-client"]
+
+python3-bosdyn-core-pip:
+    pip: ["bosdyn-core"]
+
+python3-bosdyn-mission-pip:
+    pip: ["bosdyn-mission"]
+
+python3-boto3:
+    ubuntu: ["python3-boto3"]
+
+python3-bottle:
+    ubuntu: ["python3-bottle"]
+
+python3-box:
+    pip: ["python-box"]
+    pip: ["python-box"]
+
+python3-breathe:
+    ubuntu: ["python3-breathe"]
+
+python3-bs4:
+    ubuntu: ["python3-bs4"]
+
+python3-bson:
+    ubuntu: ["python3-bson"]
+
+python3-build:
+    ubuntu:
+        default: ["python3-build"]
+        focal: nonexistent
+
+python3-cairo:
+    ubuntu: ["python3-cairo"]
+
+python3-cairosvg:
+    ubuntu: ["python3-cairosvg"]
+
+python3-can:
+    ubuntu:
+        default: ["python3-can"]
+
+python3-can-j1939-pip:
+    pip: ["can-j1939"]
+
+python3-cantools-pip:
+    pip: ["cantools"]
+
+python3-catkin-lint:
+    ubuntu:
+        default: ["catkin-lint"]
+        bionic: nonexistent
+
+python3-catkin-pkg:
+    ubuntu: ["python3-catkin-pkg"]
+
+python3-catkin-pkg-modules:
+    ubuntu: ["python3-catkin-pkg-modules"]
+
+python3-catkin-sphinx:
+    ubuntu:
+        default: nonexistent
+        focal: ["python3-catkin-sphinx"]
+
+python3-catkin-tools:
+    ubuntu: ["python3-catkin-tools"]
+
+python3-cbor2:
+    pip: ["cbor2"]
+    pip: ["cbor2"]
+
+python3-certifi:
+    ubuntu: ["python3-certifi"]
+
+python3-cffi:
+    ubuntu: ["python3-cffi"]
+
+python3-chainer-pip:
+    pip: ["chainer"]
+
+python3-charisma-sdk-pip:
+    pip: ["charisma-sdk"]
+
+python3-cherrypy3:
+    ubuntu: ["python3-cherrypy3"]
+
+python3-click:
+    ubuntu: ["python3-click"]
+
+python3-colcon-common-extensions:
+    ubuntu: ["python3-colcon-common-extensions"]
+
+python3-colcon-meson:
+    ubuntu:
+        jammy: ["python3-colcon-meson"]
+
+python3-collada:
+    ubuntu:
+        default: ["python3-collada"]
+        bionic: nonexistent
+
+python3-collada-pip:
+    pip: ["pycollada"]
+
+python3-colorama:
+    ubuntu: ["python3-colorama"]
+
+python3-colorcet:
+    pip: ["colorcet"]
+    pip: ["colorcet"]
+
+python3-conan-pip:
+    pip: ["conan"]
+
+python3-connexion-pip:
+    pip: ["connexion"]
+
+python3-construct:
+    ubuntu: ["python3-construct"]
+
+python3-cookiecutter:
+    ubuntu:
+        default: ["python3-cookiecutter"]
+        focal: nonexistent
+
+python3-coverage:
+    ubuntu: ["python3-coverage"]
+
+python3-crc16-pip:
+    pip: ["crc16"]
+
+python3-crcmod:
+    ubuntu: ["python3-crcmod"]
+
+python3-cryptography:
+    ubuntu: ["python3-cryptography"]
+
+python3-cvxopt:
+    ubuntu: ["python3-cvxopt"]
+
+python3-cvxpy-pip:
+    pip: ["cvxpy"]
+
+python3-cycler:
+    ubuntu: ["python3-cycler"]
+
+python3-dataclasses-json:
+    ubuntu:
+        default: ["python3-dataclasses-json"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-datadog-pip:
+    pip: ["datadog"]
+
+python3-dateutil:
+    ubuntu: ["python3-dateutil"]
+
+python3-dbus:
+    ubuntu: ["python3-dbus"]
+
+python3-decorator:
+    ubuntu: ["python3-decorator"]
+
+python3-deepdiff:
+    pip: ["deepdiff"]
+
+python3-defusedxml:
+    ubuntu: ["python3-defusedxml"]
+
+python3-deprecated:
+    ubuntu:
+        default: ["python3-deprecated"]
+        bionic: nonexistent
+
+python3-depthai-pip:
+    pip: ["depthai"]
+
+python3-dev:
+    ubuntu: ["python3-dev"]
+
+python3-dill:
+    ubuntu: ["python3-dill"]
+
+python3-distro:
+    ubuntu: ["python3-distro"]
+
+python3-distutils:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python3-distutils"]
+        focal: ["python3-distutils"]
+        jammy: ["python3-distutils"]
+
+python3-django:
+    ubuntu: ["python3-django"]
+
+python3-django-cors-headers:
+    ubuntu: ["python3-django-cors-headers"]
+
+python3-django-extensions:
+    ubuntu: ["python3-django-extensions"]
+
+python3-django-extra-views:
+    ubuntu: ["python3-django-extra-views"]
+
+python3-djangorestframework:
+    ubuntu: ["python3-djangorestframework"]
+
+python3-dlib-pip:
+    pip: ["dlib"]
+
+python3-do-mpc-pip:
+    pip: ["do-mpc"]
+
+python3-docker:
+    ubuntu: ["python3-docker"]
+
+python3-docopt:
+    ubuntu: ["python3-docopt"]
+
+python3-docutils:
+    ubuntu: ["python3-docutils"]
+
+python3-dubins-pip:
+    pip: ["dubins"]
+
+python3-easydict:
+    pip: ["easydict"]
+    pip: ["easydict"]
+
+python3-elasticsearch:
+    ubuntu: ["python3-elasticsearch"]
+
+python3-emoji:
+    pip: ["emoji"]
+    pip: ["emoji"]
+
+python3-empy:
+    ubuntu: ["python3-empy"]
+
+python3-environs-pip:
+    pip: ["environs"]
+
+python3-evdev:
+    ubuntu: ["python3-evdev"]
+
+python3-events-pip:
+    pip: ["Events"]
+
+python3-expiringdict:
+    ubuntu: ["python3-expiringdict"]
+
+python3-ezdxf:
+    pip: ["ezdxf"]
+    pip: ["ezdxf"]
+
+python3-fabric:
+    ubuntu: ["python3-fabric"]
+
+python3-falcon:
+    ubuntu: ["python3-falcon"]
+
+python3-fann2:
+    ubuntu: ["python3-fann2"]
+
+python3-fastapi:
+    pip: ["fastapi"]
+    pip: ["fastapi"]
+
+python3-fasteners-pip:
+    pip: ["fasteners"]
+
+python3-fastjsonschema:
+    ubuntu:
+        default: ["python3-fastjsonschema"]
+        focal: nonexistent
+
+python3-fastkml:
+    ubuntu: ["python3-fastkml"]
+
+python3-fastnumbers-pip:
+    pip: ["fastnumbers"]
+
+python3-fcn-pip:
+    pip: ["fcn"]
+
+python3-filetype-pip:
+    pip: ["filetype"]
+
+python3-filfinder-pip:
+    pip: ["fil_finder"]
+
+python3-fiona:
+    ubuntu: ["python3-fiona"]
+
+python3-flake8:
+    ubuntu: ["python3-flake8"]
+
+python3-flake8-black:
+    pip: ["flake8-black"]
+
+python3-flake8-blind-except:
+    ubuntu:
+        default: ["python3-flake8-blind-except"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-blind-except-pip:
+    pip: ["flake8-blind-except"]
+
+python3-flake8-builtins:
+    ubuntu:
+        default: ["python3-flake8-builtins"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-builtins-pip:
+    pip: ["flake8-builtins"]
+
+python3-flake8-class-newline:
+    ubuntu:
+        default: ["python3-flake8-class-newline"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-class-newline-pip:
+    pip: ["flake8-class-newline"]
+
+python3-flake8-comprehensions:
+    ubuntu:
+        default: ["python3-flake8-comprehensions"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-comprehensions-pip:
+    pip: ["flake8-comprehensions"]
+
+python3-flake8-deprecated:
+    ubuntu:
+        default: ["python3-flake8-deprecated"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-deprecated-pip:
+    pip: ["flake8-deprecated"]
+
+python3-flake8-docstrings:
+    ubuntu: ["python3-flake8-docstrings"]
+
+python3-flake8-docstrings-pip:
+    pip: ["flake8-docstrings"]
+
+python3-flake8-import-order:
+    ubuntu:
+        default: ["python3-flake8-import-order"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-import-order-pip:
+    pip: ["flake8-import-order"]
+
+python3-flake8-isort:
+    pip: ["flake8-isort"]
+
+python3-flake8-quotes:
+    ubuntu:
+        default: ["python3-flake8-quotes"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-quotes-pip:
+    pip: ["flake8-quotes"]
+
+python3-flaky:
+    ubuntu: ["python3-flaky"]
+
+python3-flask:
+    ubuntu: ["python3-flask"]
+
+python3-flask-bcrypt:
+    ubuntu: ["python3-flask-bcrypt"]
+
+python3-flask-cors:
+    ubuntu:
+        default: ["python3-flask-cors"]
+        bionic: nonexistent
+
+python3-flask-jwt-extended:
+    pip: ["flask-jwt-extended"]
+
+python3-flask-migrate:
+    ubuntu: ["python3-flask-migrate"]
+
+python3-flask-restplus-pip:
+    pip: ["flask-restplus"]
+
+python3-flask-socketio:
+    ubuntu: ["python3-flask-socketio"]
+
+python3-flask-sqlalchemy:
+    ubuntu: ["python3-flask-sqlalchemy"]
+
+python3-flatbuffers:
+    pip: ["flatbuffers"]
+    pip: ["flatbuffers"]
+
+python3-fonttools:
+    ubuntu: ["python3-fonttools"]
+
+python3-formant-pip:
+    pip: ["formant"]
+
+python3-fpdf2-pip:
+    pip: ["fpdf2"]
+
+python3-ftdi1:
+    ubuntu: ["python3-ftdi1"]
+
+python3-funcsigs:
+    ubuntu: ["python3-funcsigs"]
+
+python3-future:
+    ubuntu: ["python3-future"]
+
+python3-gdal:
+    ubuntu: ["python3-gdal"]
+
+python3-gdown-pip:
+    pip: ["gdown"]
+
+python3-geographiclib:
+    ubuntu: ["python3-geographiclib"]
+
+python3-geojson:
+    ubuntu: ["python3-geojson"]
+
+python3-geomag-pip:
+    pip: ["geomag"]
+
+python3-geopandas:
+    ubuntu: ["python3-geopandas"]
+
+python3-geopy:
+    ubuntu: ["python3-geopy"]
+
+python3-gi:
+    ubuntu: ["python3-gi"]
+
+python3-gi-cairo:
+    ubuntu: ["python3-gi-cairo"]
+
+python3-git:
+    ubuntu: ["python3-git"]
+
+python3-github:
+    ubuntu: ["python3-github"]
+
+python3-gitlab:
+    ubuntu: ["python3-gitlab"]
+
+python3-glpk-pip:
+    pip: ["glpk"]
+
+python3-gnupg:
+    ubuntu: ["python3-gnupg"]
+
+python3-google-auth:
+    ubuntu: ["python3-google-auth"]
+
+python3-google-auth-httplib2:
+    ubuntu:
+        default: ["python3-google-auth-httplib2"]
+        bionic: nonexistent
+
+python3-google-auth-oauthlib:
+    ubuntu:
+        default: ["python3-google-auth-oauthlib"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-google-cloud-pubsub-pip:
+    pip: ["google-cloud-pubsub"]
+
+python3-google-cloud-secret-manager-pip:
+    pip: ["google-cloud-secret-manager"]
+
+python3-google-cloud-storage-pip:
+    pip: ["google-cloud-storage"]
+
+python3-google-cloud-texttospeech-pip:
+    pip: ["google-cloud-texttospeech"]
+
+python3-googleapi:
+    ubuntu: ["python3-googleapi"]
+
+python3-gpiozero:
+    ubuntu:
+        default: ["python3-gpiozero"]
+        bionic: nonexistent
+
+python3-gpxpy:
+    ubuntu: ["python3-gpxpy"]
+
+python3-gql-pip:
+    pip: ["gql"]
+
+python3-graphviz:
+    ubuntu: ["python3-graphviz"]
+
+python3-grip:
+    ubuntu: ["grip"]
+
+python3-grpc-tools:
+    ubuntu:
+        default: ["python3-grpc-tools"]
+        bionic: nonexistent
+
+python3-grpcio:
+    ubuntu:
+        default: ["python3-grpcio"]
+        bionic: nonexistent
+
+python3-gurobipy-pip:
+    pip: ["gurobipy"]
+
+python3-gymnasium-pip:
+    pip: ["gymnasium"]
+
+python3-gymnasium-robotics-pip:
+    pip: ["gymnasium-robotics"]
+
+python3-gz-math6:
+    ubuntu:
+        focal: ["python3-gz-math6"]
+        jammy: ["python3-gz-math6"]
+
+python3-gz-sim6:
+    ubuntu:
+        focal: ["python3-gz-sim6"]
+        jammy: ["python3-gz-sim6"]
+
+python3-h5py:
+    ubuntu: ["python3-h5py"]
+
+python3-hidapi:
+    ubuntu: ["python3-hid"]
+
+python3-hidapi-cffi:
+    ubuntu: ["python3-hidapi"]
+
+python3-httplib2:
+    ubuntu: ["python3-httplib2"]
+
+python3-hypothesis:
+    ubuntu: ["python3-hypothesis"]
+
+python3-icecream:
+    ubuntu:
+        default: ["python3-icecream"]
+        focal: nonexistent
+
+python3-ifcfg:
+    ubuntu:
+        bionic: ["python3-ifcfg"]
+        focal: ["python3-ifcfg"]
+
+python3-ignition-gazebo6:
+    ubuntu:
+        focal: ["python3-ignition-gazebo6"]
+        jammy: ["python3-ignition-gazebo6"]
+
+python3-ignition-math6:
+    ubuntu:
+        focal: ["python3-ignition-math6"]
+        jammy: ["python3-ignition-math6"]
+
+python3-imageio:
+    ubuntu: ["python3-imageio"]
+
+python3-img2pdf:
+    ubuntu: ["python3-img2pdf"]
+
+python3-importlib-metadata:
+    pip: ["importlib-metadata"]
+
+python3-importlib-resources:
+    pip: ["importlib-resources"]
+
+python3-inflection:
+    ubuntu: ["python3-inflection"]
+
+python3-inflection-pip:
+    pip: ["inflection"]
+
+python3-influxdb:
+    ubuntu: ["python3-influxdb"]
+
+python3-influxdb-client-pip:
+    pip: ["influxdb-client"]
+
+python3-inject-pip:
+    pip: ["inject"]
+
+python3-inputimeout-pip:
+    pip: ["inputimeout"]
+
+python3-insightface-pip:
+    pip: ["insightface"]
+
+python3-interpreter:
+    ubuntu: ["python3-minimal"]
+
+python3-j1939-pip:
+    pip: ["j1939"]
+
+python3-jinja2:
+    ubuntu: ["python3-jinja2"]
+
+python3-jmespath:
+    ubuntu: ["python3-jmespath"]
+
+python3-joblib:
+    ubuntu: ["python3-joblib"]
+
+python3-jsonpickle:
+    ubuntu: ["python3-jsonpickle"]
+
+python3-jsonschema:
+    ubuntu: ["python3-jsonschema"]
+
+python3-junitparser:
+    ubuntu:
+        default: ["python3-junitparser"]
+        bionic: nonexistent
+
+python3-jupyros-pip:
+    pip: ["jupyros"]
+
+python3-jwt:
+    ubuntu: ["python3-jwt"]
+
+python3-kitchen:
+    ubuntu:
+        default: ["python3-kitchen"]
+
+python3-kivy:
+    ubuntu: ["python3-kivy"]
+
+python3-kiwisolver:
+    pip: ["kiwisolver"]
+
+python3-kml2geojson-pip:
+    pip: ["kml2geojson"]
+
+python3-lark-parser:
+    ubuntu:
+        default: ["python3-lark"]
+        bionic: ["python3-lark-parser"]
+
+python3-lensfun:
+    ubuntu: ["python3-lensfun"]
+
+python3-lgpio:
+    pip: ["lgpio"]
+
+python3-libgpiod:
+    ubuntu:
+        default: ["python3-libgpiod"]
+        bionic: nonexistent
+
+python3-libtmux:
+    ubuntu: ["python3-libtmux"]
+
+python3-lingua-franca-pip:
+    pip: ["lingua-franca"]
+
+python3-lockfile:
+    ubuntu: ["python3-lockfile"]
+
+python3-lttng:
+    ubuntu: ["python3-lttng"]
+
+python3-lxml:
+    ubuntu: ["python3-lxml"]
+
+python3-magic:
+    ubuntu: ["python3-magic"]
+
+python3-mako:
+    ubuntu: ["python3-mako"]
+
+python3-mapbox-earcut-pip:
+    pip: ["mapbox-earcut"]
+
+python3-mapnik:
+    ubuntu: ["python3-mapnik"]
+
+python3-marisa:
+    ubuntu: ["python3-marisa"]
+
+python3-markdown:
+    ubuntu: ["python3-markdown"]
+
+python3-marshmallow:
+    ubuntu: ["python3-marshmallow"]
+
+python3-marshmallow-dataclass-pip:
+    pip: ["marshmallow-dataclass"]
+
+python3-matplotlib:
+    ubuntu: ["python3-matplotlib"]
+
+python3-mavproxy-pip:
+    pip: ["MAVProxy"]
+
+python3-mccabe:
+    ubuntu: ["python3-mccabe"]
+
+python3-mechanize:
+    ubuntu:
+        default: ["python3-mechanize"]
+        bionic: nonexistent
+
+python3-mediapipe-pip:
+    pip: ["mediapipe"]
+
+python3-meshio:
+    ubuntu: ["python3-meshio"]
+
+python3-meson-pip:
+    pip: ["meson"]
+
+python3-minijinja:
+    pip: ["minijinja"]
+    pip: ["minijinja"]
+    pip: ["minijinja"]
+
+python3-minimalmodbus-pip:
+    pip: ["minimalmodbus"]
+
+python3-mistune:
+    ubuntu: ["python3-mistune"]
+
+python3-mlflow:
+    pip: ["mlflow"]
+
+python3-mock:
+    ubuntu: ["python3-mock"]
+
+python3-moonraker-api-pip:
+    pip: ["moonraker-api"]
+
+python3-more-itertools:
+    ubuntu: ["python3-more-itertools"]
+
+python3-moteus-pi3hat-pip:
+    pip: ["moteus-pi3hat"]
+
+python3-moteus-pip:
+    pip: ["moteus"]
+
+python3-motor-pip:
+    pip: ["motor"]
+
+python3-msgpack:
+    ubuntu: ["python3-msgpack"]
+
+python3-msk-pip:
+    pip: ["msk"]
+
+python3-msm-pip:
+    pip: ["msm"]
+
+python3-multimethod-pip:
+    pip: ["multimethod"]
+
+python3-multipledispatch:
+    ubuntu:
+        default: ["python3-multipledispatch"]
+        focal: nonexistent
+
+python3-munkres:
+    ubuntu: ["python3-munkres"]
+
+python3-mycroft-messagebus-client-pip:
+    pip: ["mycroft-messagebus-client"]
+
+python3-mypy:
+    ubuntu: ["python3-mypy"]
+
+python3-mysqldb:
+    ubuntu: ["python3-mysqldb"]
+
+python3-myst-parser-pip:
+    pip: ["myst-parser"]
+
+python3-natsort:
+    ubuntu: ["python3-natsort"]
+
+python3-nclib-pip:
+    pip: ["nclib"]
+
+python3-nep-pip:
+    pip: ["nep"]
+
+python3-nest-asyncio:
+    ubuntu:
+        default: ["python3-nest-asyncio"]
+        focal: nonexistent
+
+python3-netcdf4:
+    ubuntu: ["python3-netcdf4"]
+
+python3-netifaces:
+    ubuntu: ["python3-netifaces"]
+
+python3-networkmanager:
+    ubuntu: ["python3-networkmanager"]
+
+python3-networkx:
+    ubuntu: ["python3-networkx"]
+
+python3-nlopt:
+    ubuntu:
+        default: ["python3-nlopt"]
+        bionic: nonexistent
+
+python3-nmcli-pip:
+    pip: ["nmcli"]
+
+python3-nose:
+    ubuntu: ["python3-nose"]
+
+python3-nose-parameterized:
+    ubuntu: ["python3-nose-parameterized"]
+
+python3-nose-yanc:
+    ubuntu: ["python3-nose-yanc"]
+
+python3-ntplib:
+    ubuntu: ["python3-ntplib"]
+
+python3-numba:
+    ubuntu: ["python3-numba"]
+
+python3-numpy:
+    ubuntu: ["python3-numpy"]
+
+python3-numpy-stl:
+    ubuntu:
+        default: ["python3-numpy-stl"]
+
+python3-nuscenes-devkit-pip:
+    pip: ["nuscenes-devkit"]
+
+python3-nxt-python-pip:
+    pip: ["nxt-python"]
+
+python3-oauth2client:
+    ubuntu: ["python3-oauth2client"]
+
+python3-oct2py-pip:
+    pip: ["oct2py"]
+
+python3-odrive-pip:
+    pip: ["odrive"]
+
+python3-ollama-pip:
+    pip: ["ollama"]
+
+python3-onnxruntime-gpu-pip:
+    pip: ["onnxruntime-gpu"]
+
+python3-onnxruntime-openvino-pip:
+    pip: ["onnxruntime-openvino"]
+
+python3-onnxruntime-pip:
+    pip: ["onnxruntime"]
+
+python3-open3d:
+    ubuntu:
+        default: ["python3-open3d"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-open3d-pip:
+    pip: ["open3d"]
+
+python3-openai-pip:
+    pip: ["openai"]
+
+python3-opencv:
+    ubuntu: ["python3-opencv"]
+
+python3-opengl:
+    ubuntu: ["python3-opengl"]
+
+python3-openhsi-pip:
+    pip: ["openhsi"]
+
+python3-openpyxl:
+    ubuntu: ["python3-openpyxl"]
+
+python3-orjson:
+    pip: ["orjson"]
+
+python3-osrf-pycommon:
+    ubuntu: ["python3-osrf-pycommon"]
+
+python3-overrides:
+    pip: ["overrides"]
+
+python3-owlready2-pip:
+    pip: ["owlready2"]
+
+python3-owslib:
+    ubuntu: ["python3-owslib"]
+
+python3-packaging:
+    ubuntu: ["python3-packaging"]
+
+python3-padaos-pip:
+    pip: ["padaos"]
+
+python3-padatious-pip:
+    pip: ["padatious"]
+
+python3-paho-mqtt:
+    ubuntu:
+        default: ["python3-paho-mqtt"]
+
+python3-pandas:
+    ubuntu: ["python3-pandas"]
+
+python3-papermill-pip:
+    pip: ["papermill"]
+
+python3-parameterized:
+    ubuntu: ["python3-parameterized"]
+
+python3-paramiko:
+    ubuntu: ["python3-paramiko"]
+
+python3-parse:
+    ubuntu: ["python3-parse"]
+
+python3-pcg-gazebo-pip:
+    pip: ["pcg-gazebo"]
+
+python3-pep8:
+    ubuntu: ["python3-pep8"]
+
+python3-pep8-naming:
+    ubuntu: ["python3-pep8-naming"]
+
+python3-petact-pip:
+    pip: ["petact"]
+
+python3-pexpect:
+    ubuntu: ["python3-pexpect"]
+
+python3-pickleDB-pip:
+    pip: ["pickleDB"]
+
+python3-piexif:
+    ubuntu: ["python3-piexif"]
+
+python3-pigpio:
+    ubuntu: ["python3-pigpio"]
+
+python3-pika:
+    ubuntu: ["python3-pika"]
+
+python3-pil:
+    ubuntu: ["python3-pil"]
+
+python3-pil-imagetk:
+    ubuntu: ["python3-pil.imagetk"]
+
+python3-pip:
+    ubuntu: ["python3-pip"]
+
+python3-pkg-resources:
+    ubuntu: ["python3-pkg-resources"]
+
+python3-playsound-pip:
+    pip: ["playsound"]
+
+python3-ply:
+    ubuntu: ["python3-ply"]
+
+python3-pocketsphinx-pip:
+    pip: ["pocketsphinx"]
+
+python3-polling2-pip:
+    pip: ["polling2"]
+
+python3-pqdict-pip:
+    pip: ["pqdict"]
+
+python3-pre-commit:
+    pip: ["pre-commit"]
+    pip: ["pre-commit"]
+
+python3-precise-runner-pip:
+    pip: ["precise-runner"]
+
+python3-prettytable:
+    ubuntu: ["python3-prettytable"]
+
+python3-progressbar:
+    ubuntu: ["python3-progressbar"]
+
+python3-prometheus-client:
+    ubuntu: ["python3-prometheus-client"]
+
+python3-prompt-toolkit:
+    ubuntu: ["python3-prompt-toolkit"]
+
+python3-protobuf:
+    ubuntu: ["python3-protobuf"]
+
+python3-psutil:
+    ubuntu: ["python3-psutil"]
+
+python3-psycopg2:
+    ubuntu: ["python3-psycopg2"]
+
+python3-py3exiv2-pip:
+    pip: ["py3exiv2"]
+
+python3-pyads-pip:
+    pip: ["pyads"]
+
+python3-pyassimp:
+    ubuntu:
+        default: ["python3-pyassimp"]
+
+python3-pyaudio:
+    ubuntu: ["python3-pyaudio"]
+
+python3-pybullet-pip:
+    pip: ["pybullet"]
+
+python3-pyclipper:
+    ubuntu: ["python3-pyclipper"]
+
+python3-pycodestyle:
+    ubuntu: ["python3-pycodestyle"]
+
+python3-pycryptodome:
+    ubuntu: ["python3-pycryptodome"]
+
+python3-pydantic:
+    pip: ["pydantic"]
+
+python3-pydbus:
+    ubuntu: ["python3-pydbus"]
+
+python3-pydot:
+    ubuntu: ["python3-pydot"]
+
+python3-pyee:
+    ubuntu: ["python3-pyee"]
+
+python3-pyftdi-pip:
+    pip: ["pyftdi"]
+
+python3-pyftpdlib:
+    ubuntu: ["python3-pyftpdlib"]
+
+python3-pygame:
+    pip: ["pygame"]
+
+python3-pygit2:
+    ubuntu: ["python3-pygit2"]
+
+python3-pygments:
+    ubuntu: ["python3-pygments"]
+
+python3-pygraphviz:
+    ubuntu: ["python3-pygraphviz"]
+
+python3-pyinotify:
+    ubuntu: ["python3-pyinotify"]
+
+python3-pykdl:
+    ubuntu:
+        default: ["python3-pykdl"]
+        bionic: nonexistent
+
+python3-pylatexenc:
+    pip: ["pylatexenc"]
+    pip: ["pylatexenc"]
+
+python3-pylibdmtx:
+    pip: ["pylibdmtx"]
+    pip: ["pylibdmtx"]
+
+python3-pymap3d:
+    ubuntu:
+        default: ["python3-pymap3d"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-pymesh2-pip:
+    pip: ["pymesh2"]
+
+python3-pymodbus:
+    ubuntu:
+        default: ["python3-pymodbus"]
+
+python3-pymodbus-pip:
+    pip: ["pymodbus"]
+
+python3-pymongo:
+    ubuntu: ["python3-pymongo"]
+
+python3-pymongo-pip:
+    pip: ["pymongo"]
+
+python3-pynmea2:
+    ubuntu: ["python3-nmea2"]
+
+python3-pynmeagps-pip:
+    pip: ["pynmeagps"]
+
+python3-pynput:
+    ubuntu:
+        default: ["python3-pynput"]
+        focal: nonexistent
+
+python3-pyosmium:
+    ubuntu: ["python3-pyosmium"]
+
+python3-pyotp:
+    ubuntu: ["python3-pyotp"]
+
+python3-pyparsing:
+    ubuntu: ["python3-pyparsing"]
+
+python3-pypdf:
+    pip: ["pypdf"]
+    pip: ["pypdf"]
+    pip: ["pypdf"]
+
+python3-pypng:
+    ubuntu:
+        default: ["python3-png"]
+
+python3-pyproj:
+    ubuntu: ["python3-pyproj"]
+
+python3-pyqrcode:
+    ubuntu: ["python3-pyqrcode"]
+
+python3-pyqt5:
+    ubuntu: ["pyqt5-dev", "python3-pyqt5", "python3-pyqt5.qtsvg", "python3-sip-dev"]
+
+python3-pyqt5.qtquick:
+    ubuntu: ["python3-pyqt5.qtquick"]
+
+python3-pyqt5.qtwebengine:
+    ubuntu: ["python3-pyqt5.qtwebengine"]
+
+python3-pyqt6.qtmultimedia:
+    ubuntu:
+        default: ["python3-pyqt6.qtmultimedia"]
+        focal: nonexistent
+        jammy: nonexistent
+
+python3-pyqtdarktheme-pip:
+    pip: ["pyqtdarktheme"]
+
+python3-pyqtgraph:
+    ubuntu: ["python3-pyqtgraph"]
+
+python3-pyro-ppl-pip:
+    pip: ["pyro-ppl"]
+
+python3-pyrr-pip:
+    pip: ["pyrr"]
+
+python3-pyside2:
+    ubuntu:
+        default: ["libpyside2-dev", "libshiboken2-dev", "python3-pyside2.qtcore", "python3-pyside2.qtgui", "python3-pyside2.qthelp", "python3-pyside2.qtnetwork", "python3-pyside2.qtprintsupport", "python3-pyside2.qtsvg", "python3-pyside2.qttest", "python3-pyside2.qtwidgets", "python3-pyside2.qtxml", "shiboken2"]
+        bionic: nonexistent
+
+python3-pyside2.qtcore:
+    ubuntu: ["python3-pyside2.qtcore"]
+
+python3-pyside2.qtgui:
+    ubuntu: ["python3-pyside2.qtgui"]
+
+python3-pyside2.qtopengl:
+    ubuntu:
+        default: ["python3-pyside2.qtopengl"]
+        bionic: nonexistent
+
+python3-pyside2.qtqml:
+    ubuntu: ["python3-pyside2.qtqml"]
+
+python3-pyside2.qtquick:
+    ubuntu:
+        default: ["python3-pyside2.qtquick"]
+        bionic: nonexistent
+
+python3-pyside2.qtuitools:
+    ubuntu:
+        default: ["python3-pyside2.qtuitools"]
+        bionic: nonexistent
+
+python3-pyside2.qtwidgets:
+    ubuntu: ["python3-pyside2.qtwidgets"]
+
+python3-pyside6:
+    pip: ["PySide6"]
+    pip: ["PySide6"]
+    pip: ["PySide6"]
+
+python3-pyside6.qtasyncio:
+    ubuntu:
+        default: ["python3-pyside6.qtasyncio"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtcharts:
+    ubuntu:
+        default: ["python3-pyside6.qtcharts"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtconcurrent:
+    ubuntu:
+        default: ["python3-pyside6.qtconcurrent"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtcore:
+    ubuntu:
+        default: ["python3-pyside6.qtcore"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtdatavisualization:
+    ubuntu:
+        default: ["python3-pyside6.qtdatavisualization"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtgui:
+    ubuntu:
+        default: ["python3-pyside6.qtgui"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtqml:
+    ubuntu:
+        default: ["python3-pyside6.qtqml"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qttest:
+    ubuntu:
+        default: ["python3-pyside6.qttest"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtwidgets:
+    ubuntu:
+        default: ["python3-pyside6.qtwidgets"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pysnmp:
+    ubuntu: ["python3-pysnmp4"]
+
+python3-pysnmp-mibs:
+    ubuntu: ["python3-pysnmp4-mibs"]
+
+python3-pystemd:
+    pip: ["pystemd"]
+
+python3-pyswarms-pip:
+    pip: ["pyswarms"]
+
+python3-pytest:
+    ubuntu: ["python3-pytest"]
+
+python3-pytest-asyncio:
+    ubuntu:
+        default: ["python3-pytest-asyncio"]
+        bionic: nonexistent
+
+python3-pytest-benchmark:
+    ubuntu: ["python3-pytest-benchmark"]
+
+python3-pytest-cov:
+    ubuntu: ["python3-pytest-cov"]
+
+python3-pytest-mock:
+    ubuntu: ["python3-pytest-mock"]
+
+python3-pytest-order:
+    ubuntu:
+        default: ["python3-pytest-order"]
+        focal: nonexistent
+
+python3-pytest-pylint:
+    ubuntu: ["python3-pytest-pylint"]
+
+python3-pytest-ruff-pip:
+    pip: ["pytest-ruff"]
+
+python3-pytest-timeout:
+    ubuntu: ["python3-pytest-timeout"]
+
+python3-pytest-xdist:
+    ubuntu: ["python3-pytest-xdist"]
+
+python3-pytest-xvfb:
+    ubuntu: ["python3-pytest-xvfb"]
+
+python3-pytorch-pip:
+    pip: ["torch", "torchvision"]
+
+python3-pytrinamic-pip:
+    pip: ["pytrinamic"]
+
+python3-pyudev:
+    ubuntu: ["python3-pyudev"]
+
+python3-pyvista-pip:
+    pip: ["pyvista"]
+
+python3-pyxdg-pip:
+    pip: ["pyxdg"]
+
+python3-qpsolvers-pip:
+    pip: ["qpsolvers"]
+
+python3-qrcode:
+    ubuntu: ["python3-qrcode"]
+
+python3-qt5-bindings:
+    ubuntu:
+        default: ["libpyside2-dev", "libshiboken2-dev", "pyqt5-dev", "python3-pyqt5", "python3-pyqt5.qtsvg", "python3-pyside2.qtsvg", "python3-sip-dev", "shiboken2"]
+        bionic: ["pyqt5-dev", "python3-pyqt5", "python3-pyqt5.qtsvg", "python3-sip-dev"]
+
+python3-qt5-bindings-gl:
+    ubuntu: ["python3-pyqt5.qtopengl"]
+
+python3-qt5-bindings-webkit:
+    ubuntu: ["python3-pyqt5.qtwebkit"]
+
+python3-qtpy:
+    ubuntu: ["python3-qtpy"]
+
+python3-qwt:
+    ubuntu: ["python3-qwt"]
+
+python3-qwt-pip:
+    pip: ["PythonQwt"]
+
+python3-rafcon-pip:
+    pip: ["rafcon"]
+
+python3-rapidfuzz-pip:
+    pip: ["rapidfuzz"]
+
+python3-rasterio:
+    ubuntu: ["python3-rasterio"]
+
+python3-rdflib:
+    ubuntu: ["python3-rdflib"]
+
+python3-reportlab:
+    ubuntu: ["python3-reportlab"]
+
+python3-requests:
+    ubuntu: ["python3-requests"]
+
+python3-requests-futures:
+    ubuntu: ["python3-requests-futures"]
+
+python3-requests-oauthlib:
+    ubuntu: ["python3-requests-oauthlib"]
+
+python3-requests-toolbelt:
+    ubuntu: ["python3-requests-toolbelt"]
+
+python3-retrying:
+    ubuntu: ["python3-retrying"]
+
+python3-rich:
+    pip: ["rich"]
+
+python3-river-pip:
+    pip: ["river"]
+
+python3-rmsd-pip:
+    pip: ["rmsd"]
+
+python3-robodk-pip:
+    pip: ["robodk"]
+
+python3-rocker:
+    ubuntu: ["python3-rocker"]
+
+python3-rosbags-pip:
+    pip: ["rosbags"]
+
+python3-rosdep:
+    ubuntu: ["python3-rosdep"]
+
+python3-rosdep-modules:
+    ubuntu: ["python3-rosdep-modules"]
+
+python3-rosdistro-modules:
+    ubuntu: ["python3-rosdistro-modules"]
+
+python3-rosinstall-generator:
+    ubuntu: ["python3-rosinstall-generator"]
+
+python3-rospkg:
+    ubuntu: ["python3-rospkg"]
+
+python3-rospkg-modules:
+    ubuntu: ["python3-rospkg-modules"]
+
+python3-rsa:
+    ubuntu: ["python3-rsa"]
+
+python3-rtree:
+    ubuntu: ["python3-rtree"]
+
+python3-ruamel.yaml:
+    ubuntu: ["python3-ruamel.yaml"]
+
+python3-ruff-pip:
+    pip: ["ruff"]
+
+python3-sbp-pip:
+    pip: ["sbp"]
+
+python3-schedule:
+    ubuntu: ["python3-schedule"]
+
+python3-schema:
+    ubuntu: ["python3-schema"]
+
+python3-scikit-sparse-pip:
+    pip: ["scikit-sparse"]
+
+python3-scikit-spatial-pip:
+    pip: ["scikit-spatial"]
+
+python3-scipy:
+    ubuntu: ["python3-scipy"]
+
+python3-scp:
+    ubuntu: ["python3-scp"]
+
+python3-seaborn:
+    ubuntu: ["python3-seaborn"]
+
+python3-segno:
+    pip: ["segno"]
+    pip: ["segno"]
+
+python3-selenium:
+    ubuntu: ["python3-selenium"]
+
+python3-semantic-version:
+    ubuntu: ["python3-semantic-version"]
+
+python3-semver:
+    ubuntu: ["python3-semver"]
+
+python3-sense-emu-pip:
+    pip: ["sense-emu"]
+
+python3-sense-hat-pip:
+    pip: ["sense-hat"]
+
+python3-serial:
+    ubuntu: ["python3-serial"]
+
+python3-setuptools:
+    ubuntu: ["python3-setuptools"]
+
+python3-sexpdata:
+    pip: ["sexpdata"]
+
+python3-sh:
+    ubuntu: ["python3-sh"]
+
+python3-shapely:
+    ubuntu: ["python3-shapely"]
+
+python3-sila2lib-pip:
+    pip: ["sila2lib"]
+
+python3-simple-pid-pip:
+    pip: ["simple-pid"]
+
+python3-simplejpeg-pip:
+    pip: ["simplejpeg"]
+
+python3-simplejson:
+    ubuntu: ["python3-simplejson"]
+
+python3-simplification-pip:
+    pip: ["simplification"]
+
+python3-singleton-pattern-decorator-pip:
+    pip: ["singleton-pattern-decorator"]
+
+python3-sip:
+    ubuntu: ["python3-sip-dev"]
+
+python3-siphon-pip:
+    pip: ["siphon"]
+
+python3-six:
+    ubuntu: ["python3-six"]
+
+python3-skimage:
+    ubuntu: ["python3-skimage"]
+
+python3-sklearn:
+    ubuntu: ["python3-sklearn"]
+
+python3-smbus:
+    ubuntu: ["python3-smbus"]
+
+python3-smbus2:
+    ubuntu:
+        default: ["python3-smbus2"]
+        focal: nonexistent
+
+python3-smbus2-pip:
+    pip: ["smbus2"]
+
+python3-smc-pip:
+    pip: ["smc"]
+
+python3-socketio:
+    ubuntu:
+        default: ["python3-socketio"]
+        bionic: nonexistent
+
+python3-sortedcollections-pip:
+    pip: ["sortedcollections"]
+
+python3-sounddevice-pip:
+    pip: ["sounddevice"]
+
+python3-sparkfun-ublox-gps-pip:
+    pip: ["sparkfun-ublox-gps"]
+
+python3-sphinx:
+    ubuntu: ["python3-sphinx"]
+
+python3-sphinx-argparse:
+    ubuntu: ["python3-sphinx-argparse"]
+
+python3-sphinx-autoapi-pip:
+    pip: ["sphinx-autoapi"]
+
+python3-sphinx-rtd-theme:
+    ubuntu: ["python3-sphinx-rtd-theme"]
+
+python3-spidev-pip:
+    pip: ["spidev"]
+
+python3-sqlalchemy:
+    ubuntu: ["python3-sqlalchemy"]
+
+python3-sqlalchemy-utils:
+    ubuntu: ["python3-sqlalchemy-utils"]
+
+python3-sqlite-utils-pip:
+    pip: ["sqlite-utils"]
+
+python3-sqlmodel:
+    pip: ["sqlmodel"]
+    pip: ["sqlmodel"]
+
+python3-squaternion-pip:
+    pip: ["squaternion"]
+
+python3-sshkeyboard-pip:
+    pip: ["sshkeyboard"]
+
+python3-sshtunnel:
+    ubuntu:
+        focal: ["python3-sshtunnel"]
+        jammy: ["python3-sshtunnel"]
+
+python3-stable-baselines3-pip:
+    pip: ["stable-baselines3"]
+
+python3-staticmap-pip:
+    pip: ["staticmap"]
+
+python3-stonesoup-pip:
+    pip: ["stonesoup"]
+
+python3-streamz:
+    pip: ["streamz"]
+
+python3-suas-interop-clients-pip:
+    pip: ["suas-interop-clients"]
+
+python3-svg.path:
+    ubuntu: ["python3-svg.path"]
+
+python3-sympy:
+    ubuntu: ["python3-sympy"]
+
+python3-systemd:
+    ubuntu: ["python3-systemd"]
+
+python3-sysv-ipc:
+    ubuntu: ["python3-sysv-ipc"]
+
+python3-tables:
+    ubuntu: ["python3-tables"]
+
+python3-tabulate:
+    ubuntu: ["python3-tabulate"]
+
+python3-tcr-roboclaw-pip:
+    pip: ["tcr-roboclaw"]
+
+python3-tensorboardX-pip:
+    pip: ["tensorboardX"]
+
+python3-termcolor:
+    ubuntu: ["python3-termcolor"]
+
+python3-texttable:
+    ubuntu: ["python3-texttable"]
+
+python3-textual:
+    ubuntu:
+        default: ["python3-textual"]
+        focal: nonexistent
+
+python3-thop-pip:
+    pip: ["thop"]
+
+python3-thriftpy:
+    ubuntu: ["python3-thriftpy"]
+
+python3-tikzplotlib-pip:
+    pip: ["tikzplotlib"]
+
+python3-tilestache-pip:
+    pip: ["tilestache"]
+
+python3-timm-pip:
+    pip: ["timm"]
+
+python3-tinkerforge-pip:
+    pip: ["tinkerforge"]
+
+python3-tk:
+    ubuntu: ["python3-tk"]
+
+python3-toml:
+    ubuntu: ["python3-toml"]
+
+python3-toppra-pip:
+    pip: ["toppra"]
+
+python3-torch:
+    ubuntu:
+        default: ["python3-torch"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-torchvision:
+    ubuntu:
+        default: ["python3-torchvision"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-tornado:
+    ubuntu: ["python3-tornado"]
+
+python3-tqdm:
+    ubuntu:
+        default: ["python3-tqdm"]
+
+python3-transformers-pip:
+    pip: ["transformers"]
+
+python3-transforms3d:
+    pip: ["transforms3d"]
+    pip: ["transforms3d"]
+
+python3-transitions:
+    ubuntu: ["python3-transitions"]
+
+python3-triangle-pip:
+    pip: ["triangle"]
+
+python3-trimesh-pip:
+    pip: ["trimesh"]
+
+python3-twilio:
+    ubuntu: ["python3-twilio"]
+
+python3-twisted:
+    ubuntu: ["python3-twisted"]
+
+python3-typeguard:
+    pip: ["typeguard"]
+
+python3-typeguard-pip:
+    pip: ["typeguard"]
+
+python3-types-pyyaml:
+    pip: ["types-pyyaml"]
+
+python3-typing-extensions:
+    pip: ["typing-extensions"]
+
+python3-tz:
+    ubuntu: ["python3-tz"]
+
+python3-ubjson:
+    ubuntu:
+        default: ["python3-ubjson"]
+
+python3-ujson:
+    ubuntu: ["python3-ujson"]
+
+python3-ultralytics-pip:
+    pip: ["ultralytics"]
+
+python3-unidecode:
+    ubuntu: ["python3-unidecode"]
+
+python3-unidiff:
+    ubuntu: ["python3-unidiff"]
+
+python3-urdfpy-pip:
+    pip: ["urdfpy"]
+
+python3-urllib3:
+    ubuntu: ["python3-urllib3"]
+
+python3-urwid:
+    ubuntu: ["python3-urwid"]
+
+python3-usb:
+    ubuntu: ["python3-usb"]
+
+python3-uvicorn:
+    pip: ["uvicorn"]
+
+python3-uvloop:
+    ubuntu: ["python3-uvloop"]
+
+python3-validators:
+    ubuntu:
+        default: ["python3-validators"]
+        focal: nonexistent
+
+python3-vcstool:
+    ubuntu: ["python3-vcstool"]
+
+python3-vedo-pip:
+    pip: ["vedo"]
+
+python3-venv:
+    ubuntu: ["python3-venv"]
+
+python3-virtualserialports-pip:
+    pip: ["PyVirtualSerialPorts"]
+
+python3-voluptuous:
+    ubuntu: ["python3-voluptuous"]
+
+python3-waitress:
+    ubuntu: ["python3-waitress"]
+
+python3-wand:
+    ubuntu: ["python3-wand"]
+
+python3-watchdog:
+    ubuntu: ["python3-watchdog"]
+
+python3-waymo-open-dataset-tf-2-6-0-pip:
+    pip: ["waymo-open-dataset-tf-2-6-0"]
+
+python3-weasyprint-pip:
+    pip: ["weasyprint"]
+
+python3-webargs:
+    pip: ["webargs"]
+    pip: ["webargs"]
+
+python3-webpy:
+    ubuntu: ["python3-webpy"]
+
+python3-websocket:
+    ubuntu: ["python3-websocket"]
+
+python3-websockets:
+    ubuntu: ["python3-websockets"]
+
+python3-werkzeug:
+    ubuntu: ["python3-werkzeug"]
+
+python3-west-pip:
+    pip: ["west"]
+
+python3-wgconfig-pip:
+    pip: ["wgconfig"]
+
+python3-whichcraft:
+    ubuntu: ["python3-whichcraft"]
+
+python3-wrapt:
+    ubuntu: ["python3-wrapt"]
+
+python3-wxgtk4.0:
+    ubuntu: ["python3-wxgtk4.0"]
+
+python3-xdot:
+    ubuntu: ["xdot"]
+
+python3-xlsxwriter:
+    ubuntu: ["python3-xlsxwriter"]
+
+python3-xmlschema:
+    pip: ["xmlschema"]
+
+python3-xmltodict:
+    ubuntu: ["python3-xmltodict"]
+
+python3-yaml:
+    ubuntu: ["python3-yaml"]
+
+python3-yappi:
+    ubuntu:
+        default: ["python3-yappi"]
+        bionic: nonexistent
+
+python3-yoctopuce-pip:
+    pip: ["yoctopuce"]
+
+python3-yolov5:
+    pip: ["yolov5"]
+
+python3-zmq:
+    ubuntu: ["python3-zmq"]
+
+qdarkstyle-pip:
+    pip: ["qdarkstyle"]
+
+quadprog-pip:
+    pip: ["quadprog"]
+
+rosbag-metadata-pip:
+    pip: ["rosbag-metadata"]
+
+roslibpy-pip:
+    pip: ["roslibpy"]
+
+rpy2:
+    ubuntu: ["python-rpy2"]
+
+sphinxcontrib-bibtex-pip:
+    pip: ["sphinxcontrib-bibtex"]
+
+svgpathtools-pip:
+    pip: ["svgpathtools"]
+
+tilestache:
+    ubuntu: ["tilestache"]
+
+uavcan-pip:
+    pip: ["uavcan"]
+
+urdf2webots-pip:
+    pip: ["urdf2webots"]
+
+virtualenv:
+    ubuntu: ["virtualenv"]
+
+wxpython:
+    ubuntu:
+        default: ["python-wxgtk3.0"]
+
+yapf:
+    ubuntu:
+        bionic: ["yapf"]
+
+yapf3:
+    ubuntu:
+        default: ["yapf3"]
+
+zulip-pip:
+    pip: ["zulip"]
+
+bundler:
+    ubuntu: ["bundler"]
+
+facets:
+    gem: ["facets"]
+
+flexmock:
+    ubuntu: ["ruby-flexmock"]
+
+hoe:
+    ubuntu: ["ruby-hoe"]
+
+metaruby:
+    gem: ["metaruby"]
+
+nokogiri:
+    ubuntu: ["ruby-nokogiri"]
+
+rake:
+    ubuntu: ["rake"]
+
+rake-compiler:
+    ubuntu: ["rake-compiler"]
+
+rdoc:
+    ubuntu: ["ruby"]
+
+rubocop:
+    ubuntu: ["rubocop"]
+
+ruby:
+    ubuntu: ["ruby"]
+
+ruby-backports:
+    ubuntu: ["ruby-backports"]
+
+ruby-dev:
+    ubuntu: ["ruby-dev"]
+
+ruby-ronn:
+    ubuntu: ["ruby-ronn"]
+
+ruby-sass:
+    ubuntu: ["ruby-sass"]
+
+utilrb:
+    gem: ["utilrb"]
+

--- a/ubuntu.osdeps-jazzy
+++ b/ubuntu.osdeps-jazzy
@@ -2,6 +2,8 @@
 # This file is generated, do not edit!
 # based on https://github.com/ros/rosdistro tag jazzy/2024-12-23
 #
+# If you need a refresh, call autoproj reconfigure or delete just this file and run autoproj update --config
+#
 ace:
     ubuntu: ["libace-dev"]
 

--- a/ubuntu.osdeps-jazzy
+++ b/ubuntu.osdeps-jazzy
@@ -1,0 +1,7793 @@
+#
+# This file is generated, do not edit!
+# based on https://github.com/ros/rosdistro tag jazzy/2024-12-23
+#
+ace:
+    ubuntu: ["libace-dev"]
+
+ack:
+    ubuntu:
+        default: ["ack"]
+
+ack-grep:
+    ubuntu: ["ack-grep"]
+
+acl:
+    ubuntu: ["acl", "libacl1-dev"]
+
+acpi:
+    ubuntu: ["acpi"]
+
+alsa-oss:
+    ubuntu: ["alsa-oss"]
+
+alsa-utils:
+    ubuntu: ["alsa-utils"]
+
+ant:
+    ubuntu: ["ant"]
+
+antlr:
+    ubuntu: ["antlr", "libantlr-dev"]
+
+apache2:
+    ubuntu: ["apache2"]
+
+apache2-mpm-prefork:
+    ubuntu: ["apache2-mpm-prefork"]
+
+apparmor:
+    ubuntu: ["apparmor"]
+
+apr:
+    ubuntu: ["libapr1-dev", "libaprutil1-dev"]
+
+apt-transport-https:
+    ubuntu: ["apt-transport-https"]
+
+aravis:
+    ubuntu:
+        default: ["libaravis-0.8-0", "aravis-tools"]
+        bionic: nonexistent
+        focal: ["libaravis-0.6-0", "aravis-tools"]
+
+aravis-dev:
+    ubuntu:
+        default: ["libaravis-dev"]
+        bionic: nonexistent
+
+arduino-core:
+    ubuntu: ["arduino-core"]
+
+arista:
+    ubuntu: ["arista"]
+
+armadillo:
+    ubuntu: ["libarmadillo-dev"]
+
+asio:
+    ubuntu: ["libasio-dev"]
+
+assimp:
+    ubuntu:
+        default: ["libassimp-dev"]
+
+assimp-dev:
+    ubuntu:
+        default: ["libassimp-dev"]
+
+at-spi2-core:
+    ubuntu: ["at-spi2-core"]
+
+atlas:
+    ubuntu: ["libatlas-base-dev"]
+
+autoconf:
+    ubuntu: ["autoconf"]
+
+autoconf-archive:
+    ubuntu: ["autoconf-archive"]
+
+automake:
+    ubuntu: ["automake"]
+
+autopoint:
+    ubuntu: ["autopoint"]
+
+autossh:
+    ubuntu: ["autossh"]
+
+avahi-daemon:
+    ubuntu: ["avahi-daemon"]
+
+avahi-utils:
+    ubuntu: ["avahi-utils"]
+
+avr-libc:
+    ubuntu: ["avr-libc"]
+
+avrdude:
+    ubuntu: ["avrdude"]
+
+awscli:
+    ubuntu: ["awscli"]
+
+babeltrace:
+    ubuntu: ["babeltrace"]
+
+bandit:
+    ubuntu: ["bandit"]
+
+bazaar:
+    ubuntu: ["bzr"]
+
+beep:
+    ubuntu: ["beep"]
+
+benchmark:
+    ubuntu:
+        default: ["libbenchmark-dev"]
+
+binutils:
+    ubuntu: ["binutils-dev"]
+
+bison:
+    ubuntu: ["bison"]
+
+blender:
+    ubuntu: ["blender"]
+
+bluez:
+    ubuntu: ["bluez"]
+
+boost:
+    ubuntu: ["libboost-all-dev"]
+
+box2d-dev:
+    ubuntu: ["libbox2d-dev"]
+
+bullet:
+    ubuntu:
+        default: ["libbullet-dev"]
+
+bullet-extras:
+    ubuntu: ["libbullet-extras-dev"]
+
+bzip2:
+    ubuntu: ["libbz2-dev"]
+
+ca-certificates:
+    ubuntu: ["ca-certificates"]
+
+can-utils:
+    ubuntu: ["can-utils"]
+
+cargo:
+    ubuntu: ["cargo"]
+
+castxml:
+    ubuntu: ["castxml"]
+
+catch2:
+    ubuntu:
+        default: ["catch2"]
+        focal: nonexistent
+
+cccc:
+    ubuntu: ["cccc"]
+
+cdk:
+    ubuntu: ["libcdk5"]
+
+cdk-dev:
+    ubuntu: ["libcdk5-dev"]
+
+cgal:
+    ubuntu: ["libcgal-dev"]
+
+cgal-qt5-dev:
+    ubuntu: ["libcgal-qt5-dev"]
+
+checkinstall:
+    ubuntu: ["checkinstall"]
+
+chromedriver:
+    ubuntu: ["chromium-chromedriver"]
+
+chromium-browser:
+    ubuntu: ["chromium-browser"]
+
+chrony:
+    ubuntu: ["chrony"]
+
+clang:
+    ubuntu: ["clang"]
+
+clang-format:
+    ubuntu: ["clang-format"]
+
+clang-tidy:
+    ubuntu:
+        default: ["clang-tidy"]
+
+clangd:
+    ubuntu: ["clangd"]
+
+cli11:
+    ubuntu:
+        default: ["libcli11-dev"]
+        focal: nonexistent
+
+cmake:
+    ubuntu: ["cmake"]
+
+coinor-libcbc-dev:
+    ubuntu: ["coinor-libcbc-dev"]
+
+coinor-libcbc3:
+    ubuntu: ["coinor-libcbc3"]
+
+coinor-libcgl-dev:
+    ubuntu: ["coinor-libcgl-dev"]
+
+coinor-libclp-dev:
+    ubuntu: ["coinor-libclp-dev"]
+
+coinor-libcoinutils-dev:
+    ubuntu: ["coinor-libcoinutils-dev"]
+
+coinor-libipopt-dev:
+    ubuntu: ["coinor-libipopt-dev"]
+
+coinor-libosi-dev:
+    ubuntu: ["coinor-libosi-dev"]
+
+collada-dom:
+    ubuntu:
+        default: ["libcollada-dom2.4-dp-dev"]
+
+collectd:
+    ubuntu: ["collectd"]
+
+collectd-utils:
+    ubuntu: ["collectd-utils"]
+
+comedi:
+    ubuntu: ["libcomedi-dev"]
+
+coreutils:
+    ubuntu: ["coreutils"]
+
+couchdb:
+    ubuntu: ["couchdb"]
+
+cppad:
+    ubuntu: ["cppad"]
+
+cppcheck:
+    ubuntu: ["cppcheck"]
+
+cppunit:
+    ubuntu: ["libcppunit-dev"]
+
+cpuburn:
+    ubuntu: ["cpuburn"]
+
+crypto++:
+    ubuntu: ["libcrypto++-dev"]
+
+curl:
+    ubuntu: ["libcurl4-openssl-dev", "curl"]
+
+curlpp-dev:
+    ubuntu: ["libcurlpp-dev"]
+
+cvs:
+    ubuntu: ["cvs"]
+
+cwiid:
+    ubuntu: ["libcwiid1"]
+
+cwiid-dev:
+    ubuntu: ["libcwiid-dev"]
+
+daemontools:
+    ubuntu: ["daemontools"]
+
+darknet:
+    ubuntu: ["darknet"]
+
+dcraw:
+    ubuntu: ["dcraw"]
+
+debhelper:
+    ubuntu: ["debhelper"]
+
+debtree:
+    ubuntu: ["debtree"]
+
+devilspie2:
+    ubuntu: ["devilspie2"]
+
+devscripts:
+    ubuntu: ["devscripts"]
+
+dfu-util:
+    ubuntu: ["dfu-util"]
+
+dh-python:
+    ubuntu: ["dh-python"]
+
+disper:
+    ubuntu: ["disper"]
+
+dkms:
+    ubuntu: ["dkms"]
+
+dnsmasq:
+    ubuntu: ["dnsmasq"]
+
+docker-compose:
+    ubuntu: ["docker-compose"]
+
+docker.io:
+    ubuntu: ["docker.io"]
+
+doxygen:
+    ubuntu: ["doxygen"]
+
+dpkg:
+    ubuntu: ["dpkg"]
+
+dpkg-dev:
+    ubuntu: ["dpkg-dev"]
+
+dvipng:
+    ubuntu: ["dvipng"]
+
+e2fsprogs:
+    ubuntu: ["e2fsprogs"]
+
+eclipse:
+    ubuntu:
+        karmic: ["eclipse", "eclipse-platform", "eclipse-rcp", "eclipse-pde"]
+
+ed:
+    ubuntu: ["ed"]
+
+eigen:
+    ubuntu: ["libeigen3-dev"]
+
+eigen2:
+    ubuntu: ["libeigen2-dev"]
+
+emacs:
+    ubuntu: ["emacs"]
+
+embree:
+    ubuntu:
+        default: ["libembree-dev"]
+        bionic: nonexistent
+
+enblend:
+    ubuntu: ["enblend"]
+
+enet:
+    ubuntu: ["libenet-dev"]
+
+espeak:
+    ubuntu: ["espeak"]
+
+ethtool:
+    ubuntu: ["ethtool"]
+
+exfat-fuse:
+    ubuntu: ["exfat-fuse"]
+
+exfat-utils:
+    ubuntu: ["exfat-utils"]
+
+exiv2:
+    ubuntu: ["exiv2"]
+
+f2c:
+    ubuntu: ["f2c", "libf2c2", "libf2c2-dev"]
+
+fakeroot:
+    ubuntu: ["fakeroot"]
+
+fcgi:
+    ubuntu: ["libfcgi-dev", "libapache2-mod-fastcgi", "spawn-fcgi"]
+
+festival:
+    ubuntu: ["festival", "festvox-kallpc16k"]
+
+festival-dev:
+    ubuntu: ["festival-dev"]
+
+ffmpeg:
+    ubuntu:
+        default: ["ffmpeg", "libavcodec-dev", "libavformat-dev", "libavutil-dev", "libswscale-dev"]
+
+ffmpeg-dev:
+    ubuntu: ["libavcodec-dev", "libavdevice-dev", "libavfilter-dev", "libavformat-dev", "libavutil-dev", "libpostproc-dev", "libswresample-dev", "libswscale-dev"]
+
+ffmpeg2theora:
+    ubuntu: ["ffmpeg2theora"]
+
+file:
+    ubuntu: ["file"]
+
+filezilla:
+    ubuntu: ["filezilla"]
+
+flac:
+    ubuntu: ["flac"]
+
+flawfinder:
+    ubuntu: ["flawfinder"]
+
+flex:
+    ubuntu: ["flex"]
+
+flite:
+    ubuntu: ["flite"]
+
+fltk:
+    ubuntu:
+        bionic: ["fluid", "libfltk1.3-dev"]
+        focal: ["fluid", "libfltk1.3-dev"]
+
+fluid:
+    ubuntu: ["fluid"]
+
+fluidsynth:
+    ubuntu: ["fluidsynth"]
+
+fmt:
+    ubuntu: ["libfmt-dev"]
+
+fonts-noto:
+    ubuntu: ["fonts-noto"]
+
+fonts-roboto:
+    ubuntu: ["fonts-roboto-hinted", "fonts-roboto-unhinted"]
+
+fping:
+    ubuntu: ["fping"]
+
+freeimage:
+    ubuntu: ["libfreeimage-dev"]
+
+freetype:
+    ubuntu: ["libfreetype6"]
+
+fsharp:
+    ubuntu: ["fsharp"]
+
+fswebcam:
+    ubuntu: ["fswebcam"]
+
+ftdi-eeprom:
+    ubuntu: ["ftdi-eeprom"]
+
+fxload:
+    ubuntu: ["fxload"]
+
+g++-10:
+    ubuntu:
+        focal: ["g++-10"]
+        jammy: ["g++-10"]
+
+g++-5-arm-linux-gnueabihf:
+    ubuntu: ["g++-5-arm-linux-gnueabihf"]
+
+g++-5-multilib:
+    ubuntu: ["g++-5-multilib"]
+
+g++-multilib:
+    ubuntu: ["g++-multilib"]
+
+g++-static:
+    ubuntu: ["g++"]
+
+gamin:
+    ubuntu: ["gamin"]
+
+gawk:
+    ubuntu: ["gawk"]
+
+gazebo:
+    ubuntu:
+        bionic: ["gazebo9"]
+        focal: ["gazebo11"]
+        jammy: ["gazebo"]
+
+gazebo11:
+    ubuntu:
+        focal: ["gazebo11"]
+        jammy: ["gazebo"]
+
+gazebo5:
+    ubuntu: ["gazebo5"]
+
+gazebo7:
+    ubuntu: ["gazebo7"]
+
+gazebo9:
+    ubuntu:
+        bionic: ["gazebo9"]
+
+gcc-arm-none-eabi:
+    ubuntu: ["gcc-arm-none-eabi"]
+
+gcc-avr:
+    ubuntu: ["gcc-avr"]
+
+gcc-multilib:
+    ubuntu: ["gcc-multilib"]
+
+gcc-static:
+    ubuntu: ["gcc"]
+
+gccxml:
+    ubuntu: ["gccxml"]
+
+gcovr:
+    ubuntu: ["gcovr"]
+
+gdal-bin:
+    ubuntu: ["gdal-bin"]
+
+geographiclib:
+    ubuntu:
+        default: ["libgeographiclib-dev"]
+        focal: ["libgeographic-dev"]
+        jammy: ["libgeographic-dev"]
+
+geographiclib-tools:
+    ubuntu: ["geographiclib-tools"]
+
+geos:
+    ubuntu: ["libgeos-dev"]
+
+gettext-base:
+    ubuntu: ["gettext-base"]
+
+gforth:
+    ubuntu: ["gforth"]
+
+gfortran:
+    ubuntu: ["gfortran"]
+
+ghc:
+    ubuntu: ["ghc"]
+
+gifsicle:
+    ubuntu: ["gifsicle"]
+
+gimp:
+    ubuntu: ["gimp"]
+
+git:
+    ubuntu: ["git"]
+
+git-lfs:
+    ubuntu: ["git-lfs"]
+
+gitg:
+    ubuntu: ["gitg"]
+
+gitk:
+    ubuntu: ["gitk"]
+
+gksu:
+    ubuntu: ["gksu"]
+
+glpk:
+    ubuntu: ["libglpk-dev"]
+
+glslang-dev:
+    ubuntu: ["glslang-dev"]
+
+glslc:
+    ubuntu:
+        default: ["glslc"]
+        focal: nonexistent
+        jammy: nonexistent
+
+glut:
+    ubuntu: ["freeglut3-dev"]
+
+gnat:
+    ubuntu: ["gnat"]
+
+gnome-terminal:
+    ubuntu: ["gnome-terminal"]
+
+gnuplot:
+    ubuntu: ["gnuplot"]
+
+gnuplot-iostream:
+    ubuntu: ["libgnuplot-iostream-dev"]
+
+gnuplot-x11:
+    ubuntu: ["gnuplot-x11"]
+
+golang-go:
+    ubuntu: ["golang-go"]
+
+google-mock:
+    ubuntu: ["google-mock"]
+
+gpac:
+    ubuntu: ["gpac"]
+
+gperf:
+    ubuntu: ["gperf"]
+
+gperftools:
+    ubuntu: ["google-perftools", "libgoogle-perftools-dev"]
+
+gpg-agent:
+    ubuntu:
+        default: ["gpg-agent"]
+
+gphoto2:
+    ubuntu: ["gphoto2"]
+
+gprbuild:
+    ubuntu: ["gprbuild"]
+
+gpsd:
+    ubuntu: ["gpsd"]
+
+gradle:
+    ubuntu: ["gradle"]
+
+graphicsmagick:
+    ubuntu: ["libgraphicsmagick++1-dev", "graphicsmagick-libmagick-dev-compat"]
+
+graphviz:
+    ubuntu: ["graphviz"]
+
+graphviz-dev:
+    ubuntu: ["libgraphviz-dev"]
+
+gringo:
+    ubuntu: ["gringo"]
+
+gstreamer0.10-plugins-good:
+    ubuntu: ["gstreamer0.10-plugins-good"]
+
+gstreamer0.10-pocketsphinx:
+    ubuntu: ["gstreamer0.10-pocketsphinx"]
+
+gstreamer1.0:
+    ubuntu: ["gstreamer1.0-tools", "libgstreamer1.0-0", "gir1.2-gstreamer-1.0"]
+
+gstreamer1.0-alsa:
+    ubuntu: ["gstreamer1.0-alsa"]
+
+gstreamer1.0-gl:
+    ubuntu:
+        default: ["gstreamer1.0-gl"]
+
+gstreamer1.0-libav:
+    ubuntu: ["gstreamer1.0-libav"]
+
+gstreamer1.0-plugins-bad:
+    ubuntu: ["gstreamer1.0-plugins-bad"]
+
+gstreamer1.0-plugins-base:
+    ubuntu: ["gstreamer1.0-plugins-base", "libgstreamer-plugins-base1.0-0", "gir1.2-gst-plugins-base-1.0"]
+
+gstreamer1.0-plugins-good:
+    ubuntu: ["gstreamer1.0-plugins-good", "libgstreamer-plugins-good1.0-0"]
+
+gstreamer1.0-plugins-ugly:
+    ubuntu: ["gstreamer1.0-plugins-ugly"]
+
+gstreamer1.0-rtsp:
+    ubuntu: ["gstreamer1.0-rtsp"]
+
+gstreamer1.0-tools:
+    ubuntu: ["gstreamer1.0-tools"]
+
+gstreamer1.0-x:
+    ubuntu: ["gstreamer1.0-x"]
+
+gtest:
+    ubuntu: ["libgtest-dev"]
+
+gtk-doc-tools:
+    ubuntu: ["gtk-doc-tools"]
+
+gtk2:
+    ubuntu: ["libgtk2.0-dev"]
+
+gtk3:
+    ubuntu: ["libgtk-3-dev"]
+
+gurumdds-2.6:
+    ubuntu:
+        bionic: ["gurumdds-2.6"]
+        focal: ["gurumdds-2.6"]
+
+gurumdds-2.7:
+    ubuntu:
+        bionic: ["gurumdds-2.7"]
+        focal: ["gurumdds-2.7"]
+
+gurumdds-2.8:
+    ubuntu:
+        bionic: ["gurumdds-2.8"]
+        focal: ["gurumdds-2.8"]
+        jammy: ["gurumdds-2.8"]
+
+gurumdds-3.0:
+    ubuntu:
+        jammy: ["gurumdds-3.0"]
+
+gv:
+    ubuntu: ["gv"]
+
+gz-citadel:
+    ubuntu:
+        focal: ["gz-citadel"]
+
+gz-cmake2:
+    ubuntu:
+        focal: ["libgz-cmake2-dev"]
+        jammy: ["libgz-cmake2-dev"]
+
+gz-common3:
+    ubuntu:
+        focal: ["libgz-common3-dev"]
+
+gz-common4:
+    ubuntu:
+        focal: ["libgz-common4-dev"]
+        jammy: ["libgz-common4-dev"]
+
+gz-fortress:
+    ubuntu:
+        focal: ["gz-fortress"]
+        jammy: ["gz-fortress"]
+
+gz-fuel-tools4:
+    ubuntu:
+        focal: ["libgz-fuel-tools4-dev"]
+
+gz-fuel-tools7:
+    ubuntu:
+        focal: ["libgz-fuel-tools7-dev"]
+        jammy: ["libgz-fuel-tools7-dev"]
+
+gz-gui3:
+    ubuntu:
+        focal: ["libgz-gui3-dev"]
+
+gz-gui6:
+    ubuntu:
+        focal: ["libgz-gui6-dev"]
+        jammy: ["libgz-gui6-dev"]
+
+gz-launch2:
+    ubuntu:
+        focal: ["libgz-launch2-dev"]
+
+gz-launch5:
+    ubuntu:
+        focal: ["libgz-launch5-dev"]
+        jammy: ["libgz-launch5-dev"]
+
+gz-math6:
+    ubuntu:
+        focal: ["libgz-math6-dev"]
+        jammy: ["libgz-math6-dev"]
+
+gz-math6-eigen3:
+    ubuntu:
+        focal: ["libgz-math6-eigen3-dev"]
+        jammy: ["libgz-math6-eigen3-dev"]
+
+gz-msgs5:
+    ubuntu:
+        focal: ["libgz-msgs5-dev"]
+
+gz-msgs8:
+    ubuntu:
+        focal: ["libgz-msgs8-dev"]
+        jammy: ["libgz-msgs8-dev"]
+
+gz-physics2:
+    ubuntu:
+        focal: ["libgz-physics2-dev"]
+
+gz-physics5:
+    ubuntu:
+        focal: ["libgz-physics5-dev"]
+        jammy: ["libgz-physics5-dev"]
+
+gz-plugin:
+    ubuntu:
+        focal: ["libgz-plugin-dev"]
+        jammy: ["libgz-plugin-dev"]
+
+gz-rendering3:
+    ubuntu:
+        focal: ["libgz-rendering3-dev"]
+
+gz-rendering6:
+    ubuntu:
+        focal: ["libgz-rendering6-dev"]
+        jammy: ["libgz-rendering6-dev"]
+
+gz-sensors3:
+    ubuntu:
+        focal: ["libgz-sensors3-dev"]
+
+gz-sensors6:
+    ubuntu:
+        focal: ["libgz-sensors6-dev"]
+        jammy: ["libgz-sensors6-dev"]
+
+gz-sim3:
+    ubuntu:
+        focal: ["libgz-sim3-dev"]
+
+gz-sim6:
+    ubuntu:
+        focal: ["libgz-sim6-dev"]
+        jammy: ["libgz-sim6-dev"]
+
+gz-sim6-plugins:
+    ubuntu:
+        focal: ["libgz-sim6-plugins"]
+        jammy: ["libgz-sim6-plugins"]
+
+gz-tools:
+    ubuntu:
+        focal: ["libgz-tools-dev"]
+        jammy: ["libgz-tools-dev"]
+
+gz-transport11:
+    ubuntu:
+        focal: ["libgz-transport11-dev"]
+        jammy: ["libgz-transport11-dev"]
+
+gz-transport8:
+    ubuntu:
+        focal: ["libgz-transport8-dev"]
+
+gz-utils1:
+    ubuntu:
+        focal: ["libgz-utils1-dev"]
+        jammy: ["libgz-utils1-dev"]
+
+gz-utils1-cli:
+    ubuntu:
+        focal: ["libgz-utils1-cli-dev"]
+        jammy: ["libgz-utils1-cli-dev"]
+
+haproxy:
+    ubuntu: ["haproxy"]
+
+hddtemp:
+    ubuntu:
+        default: nonexistent
+        bionic: ["hddtemp"]
+        focal: ["hddtemp"]
+
+hdf5:
+    ubuntu: ["libhdf5-dev"]
+
+hdf5-tools:
+    ubuntu: ["hdf5-tools"]
+
+hostapd:
+    ubuntu: ["hostapd"]
+
+hostname:
+    ubuntu: ["hostname"]
+
+htop:
+    ubuntu: ["htop"]
+
+hugin-tools:
+    ubuntu: ["hugin-tools"]
+
+i2c-tools:
+    ubuntu: ["i2c-tools"]
+
+ifstat:
+    ubuntu: ["ifstat"]
+
+ignition-citadel:
+    ubuntu:
+        focal: ["ignition-citadel"]
+
+ignition-cmake2:
+    ubuntu:
+        focal: ["libignition-cmake2-dev"]
+        jammy: ["libignition-cmake2-dev"]
+
+ignition-common3:
+    ubuntu:
+        focal: ["libignition-common3-dev"]
+
+ignition-common4:
+    ubuntu:
+        focal: ["libignition-common4-dev"]
+        jammy: ["libignition-common4-dev"]
+
+ignition-edifice:
+    ubuntu:
+        focal: ["ignition-edifice"]
+
+ignition-fortress:
+    ubuntu:
+        focal: ["ignition-fortress"]
+        jammy: ["ignition-fortress"]
+
+ignition-fuel-tools4:
+    ubuntu:
+        focal: ["libignition-fuel-tools4-dev"]
+
+ignition-fuel-tools6:
+    ubuntu:
+        focal: ["libignition-fuel-tools6-dev"]
+
+ignition-fuel-tools7:
+    ubuntu:
+        focal: ["libignition-fuel-tools7-dev"]
+        jammy: ["libignition-fuel-tools7-dev"]
+
+ignition-gazebo3:
+    ubuntu:
+        focal: ["libignition-gazebo3-dev"]
+
+ignition-gazebo5:
+    ubuntu:
+        focal: ["libignition-gazebo5-dev"]
+
+ignition-gazebo5-plugins:
+    ubuntu:
+        focal: ["libignition-gazebo5-plugins"]
+
+ignition-gazebo6:
+    ubuntu:
+        focal: ["libignition-gazebo6-dev"]
+        jammy: ["libignition-gazebo6-dev"]
+
+ignition-gazebo6-plugins:
+    ubuntu:
+        focal: ["libignition-gazebo6-plugins"]
+        jammy: ["libignition-gazebo6-plugins"]
+
+ignition-gui3:
+    ubuntu:
+        focal: ["libignition-gui3-dev"]
+
+ignition-gui5:
+    ubuntu:
+        focal: ["libignition-gui5-dev"]
+
+ignition-gui6:
+    ubuntu:
+        focal: ["libignition-gui6-dev"]
+        jammy: ["libignition-gui6-dev"]
+
+ignition-launch2:
+    ubuntu:
+        focal: ["libignition-launch2-dev"]
+
+ignition-launch4:
+    ubuntu:
+        focal: ["libignition-launch4-dev"]
+
+ignition-launch5:
+    ubuntu:
+        focal: ["libignition-launch5-dev"]
+        jammy: ["libignition-launch5-dev"]
+
+ignition-math6:
+    ubuntu:
+        focal: ["libignition-math6-dev"]
+        jammy: ["libignition-math6-dev"]
+
+ignition-math6-eigen3:
+    ubuntu:
+        focal: ["libignition-math6-eigen3-dev"]
+        jammy: ["libignition-math6-eigen3-dev"]
+
+ignition-msgs5:
+    ubuntu:
+        focal: ["libignition-msgs5-dev"]
+
+ignition-msgs7:
+    ubuntu:
+        focal: ["libignition-msgs7-dev"]
+
+ignition-msgs8:
+    ubuntu:
+        focal: ["libignition-msgs8-dev"]
+        jammy: ["libignition-msgs8-dev"]
+
+ignition-physics2:
+    ubuntu:
+        focal: ["libignition-physics2-dev"]
+
+ignition-physics4:
+    ubuntu:
+        focal: ["libignition-physics4-dev"]
+
+ignition-physics5:
+    ubuntu:
+        focal: ["libignition-physics5-dev"]
+        jammy: ["libignition-physics5-dev"]
+
+ignition-plugin:
+    ubuntu:
+        focal: ["libignition-plugin-dev"]
+        jammy: ["libignition-plugin-dev"]
+
+ignition-rendering3:
+    ubuntu:
+        focal: ["libignition-rendering3-dev"]
+
+ignition-rendering5:
+    ubuntu:
+        focal: ["libignition-rendering5-dev"]
+
+ignition-rendering6:
+    ubuntu:
+        focal: ["libignition-rendering6-dev"]
+        jammy: ["libignition-rendering6-dev"]
+
+ignition-sensors3:
+    ubuntu:
+        focal: ["libignition-sensors3-dev"]
+
+ignition-sensors5:
+    ubuntu:
+        focal: ["libignition-sensors5-dev"]
+
+ignition-sensors6:
+    ubuntu:
+        focal: ["libignition-sensors6-dev"]
+        jammy: ["libignition-sensors6-dev"]
+
+ignition-tools:
+    ubuntu:
+        focal: ["libignition-tools-dev"]
+        jammy: ["libignition-tools-dev"]
+
+ignition-transport10:
+    ubuntu:
+        focal: ["libignition-transport10-dev"]
+
+ignition-transport11:
+    ubuntu:
+        focal: ["libignition-transport11-dev"]
+        jammy: ["libignition-transport11-dev"]
+
+ignition-transport8:
+    ubuntu:
+        focal: ["libignition-transport8-dev"]
+
+ignition-utils1:
+    ubuntu:
+        focal: ["libignition-utils1-dev"]
+        jammy: ["libignition-utils1-dev"]
+
+ignition-utils1-cli:
+    ubuntu:
+        focal: ["libignition-utils1-cli-dev"]
+        jammy: ["libignition-utils1-cli-dev"]
+
+imagemagick:
+    ubuntu: ["imagemagick"]
+
+intel-opencl-icd:
+    ubuntu:
+        default: ["intel-opencl-icd"]
+        bionic: nonexistent
+
+intltool:
+    ubuntu: ["intltool"]
+
+inxi:
+    ubuntu: ["inxi"]
+
+iperf:
+    ubuntu: ["iperf"]
+
+ipmitool:
+    ubuntu: ["ipmitool"]
+
+iproute2:
+    ubuntu: ["iproute2"]
+
+iputils-ping:
+    ubuntu: ["iputils-ping"]
+
+iwyu:
+    ubuntu: ["iwyu"]
+
+jack:
+    ubuntu: ["libjack-jackd2-dev"]
+
+java:
+    ubuntu: ["default-jdk"]
+
+joystick:
+    ubuntu: ["joystick"]
+
+jq:
+    ubuntu: ["jq"]
+
+julius-voxforge:
+    ubuntu: ["julius-voxforge"]
+
+jython:
+    ubuntu: ["jython"]
+
+kakasi:
+    ubuntu: ["kakasi"]
+
+kate:
+    ubuntu: ["kate"]
+
+kgraphviewer:
+    ubuntu: ["kgraphviewer"]
+
+konsole:
+    ubuntu: ["konsole"]
+
+language-pack-de:
+    ubuntu: ["language-pack-de"]
+
+language-pack-en:
+    ubuntu: ["language-pack-en"]
+
+lcov:
+    ubuntu: ["lcov"]
+
+lensfun:
+    ubuntu: ["liblensfun1"]
+
+lensfun-dev:
+    ubuntu: ["liblensfun-dev"]
+
+leveldb:
+    ubuntu: ["libleveldb-dev"]
+
+lib32asound2:
+    ubuntu: ["lib32asound2"]
+
+libabsl-dev:
+    ubuntu:
+        default: ["libabsl-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libadolc-dev:
+    ubuntu: ["libadolc-dev"]
+
+libalglib-dev:
+    ubuntu: ["libalglib-dev"]
+
+libann-dev:
+    ubuntu: ["libann-dev"]
+
+libao-dev:
+    ubuntu: ["libao-dev"]
+
+libapache2-mod-python:
+    ubuntu: ["libapache2-mod-python"]
+
+libargtable2-dev:
+    ubuntu: ["libargtable2-dev"]
+
+libaria:
+    ubuntu:
+        default: ["libaria-dev"]
+
+libasound2-dev:
+    ubuntu: ["libasound2-dev"]
+
+libatomic:
+    ubuntu: ["libatomic1"]
+
+libav:
+    ubuntu:
+        default: nonexistent
+
+libavahi-client-dev:
+    ubuntu: ["libavahi-client-dev"]
+
+libavahi-core-dev:
+    ubuntu: ["libavahi-core-dev"]
+
+libavdevice-dev:
+    ubuntu: ["libavdevice-dev"]
+
+libb64-dev:
+    ubuntu: ["libb64-dev"]
+
+libbackward-cpp-dev:
+    ubuntu:
+        default: ["libbackward-cpp-dev"]
+        bionic: nonexistent
+
+libbdd-dev:
+    ubuntu: ["libbdd-dev"]
+
+libblas-dev:
+    ubuntu: ["libblas-dev"]
+
+libblosc-dev:
+    ubuntu: ["libblosc-dev"]
+
+libbluetooth:
+    ubuntu: ["libbluetooth3"]
+
+libbluetooth-dev:
+    ubuntu: ["libbluetooth-dev"]
+
+libboost-atomic:
+    ubuntu:
+        bionic: ["libboost-atomic1.65.1"]
+        focal: ["libboost-atomic1.71.0"]
+        jammy: ["libboost-atomic1.74.0"]
+        noble: ["libboost-atomic1.83.0"]
+
+libboost-atomic-dev:
+    ubuntu: ["libboost-atomic-dev"]
+
+libboost-chrono:
+    ubuntu:
+        bionic: ["libboost-chrono1.65.1"]
+        focal: ["libboost-chrono1.71.0"]
+        jammy: ["libboost-chrono1.74.0"]
+        noble: ["libboost-chrono1.83.0"]
+
+libboost-chrono-dev:
+    ubuntu: ["libboost-chrono-dev"]
+
+libboost-coroutine:
+    ubuntu:
+        bionic: ["libboost-coroutine1.65.1"]
+        focal: ["libboost-coroutine1.71.0"]
+        jammy: ["libboost-coroutine1.74.0"]
+        noble: ["libboost-coroutine1.83.0"]
+
+libboost-coroutine-dev:
+    ubuntu: ["libboost-coroutine-dev"]
+
+libboost-date-time:
+    ubuntu:
+        bionic: ["libboost-date-time1.65.1"]
+        focal: ["libboost-date-time1.71.0"]
+        jammy: ["libboost-date-time1.74.0"]
+        noble: ["libboost-date-time1.83.0"]
+
+libboost-date-time-dev:
+    ubuntu: ["libboost-date-time-dev"]
+
+libboost-dev:
+    ubuntu: ["libboost-dev"]
+
+libboost-filesystem:
+    ubuntu:
+        bionic: ["libboost-filesystem1.65.1"]
+        focal: ["libboost-filesystem1.71.0"]
+        jammy: ["libboost-filesystem1.74.0"]
+        noble: ["libboost-filesystem1.83.0"]
+
+libboost-filesystem-dev:
+    ubuntu: ["libboost-filesystem-dev"]
+
+libboost-iostreams:
+    ubuntu:
+        bionic: ["libboost-iostreams1.65.1"]
+        focal: ["libboost-iostreams1.71.0"]
+        jammy: ["libboost-iostreams1.74.0"]
+        noble: ["libboost-iostreams1.83.0"]
+
+libboost-iostreams-dev:
+    ubuntu: ["libboost-iostreams-dev"]
+
+libboost-math:
+    ubuntu:
+        bionic: ["libboost-math1.65.1"]
+        focal: ["libboost-math1.71.0"]
+        jammy: ["libboost-math1.74.0"]
+        noble: ["libboost-math1.83.0"]
+
+libboost-math-dev:
+    ubuntu: ["libboost-math-dev"]
+
+libboost-numpy-dev:
+    ubuntu: ["libboost-numpy-dev"]
+
+libboost-program-options:
+    ubuntu:
+        bionic: ["libboost-program-options1.65.1"]
+        focal: ["libboost-program-options1.71.0"]
+        jammy: ["libboost-program-options1.74.0"]
+        noble: ["libboost-program-options1.83.0"]
+
+libboost-program-options-dev:
+    ubuntu: ["libboost-program-options-dev"]
+
+libboost-python:
+    ubuntu:
+        bionic: ["libboost-python1.65.1"]
+        focal: ["libboost-python1.71.0"]
+        jammy: ["libboost-python1.74.0"]
+        noble: ["libboost-python1.83.0"]
+
+libboost-python-dev:
+    ubuntu: ["libboost-python-dev"]
+
+libboost-random:
+    ubuntu:
+        bionic: ["libboost-random1.65.1"]
+        focal: ["libboost-random1.71.0"]
+        jammy: ["libboost-random1.74.0"]
+        noble: ["libboost-random1.83.0"]
+
+libboost-random-dev:
+    ubuntu: ["libboost-random-dev"]
+
+libboost-regex:
+    ubuntu:
+        bionic: ["libboost-regex1.65.1"]
+        focal: ["libboost-regex1.71.0"]
+        jammy: ["libboost-regex1.74.0"]
+        noble: ["libboost-regex1.83.0"]
+
+libboost-regex-dev:
+    ubuntu: ["libboost-regex-dev"]
+
+libboost-serialization:
+    ubuntu:
+        bionic: ["libboost-serialization1.65.1"]
+        focal: ["libboost-serialization1.71.0"]
+        jammy: ["libboost-serialization1.74.0"]
+        noble: ["libboost-serialization1.83.0"]
+
+libboost-serialization-dev:
+    ubuntu: ["libboost-serialization-dev"]
+
+libboost-system:
+    ubuntu:
+        bionic: ["libboost-system1.65.1"]
+        focal: ["libboost-system1.71.0"]
+        jammy: ["libboost-system1.74.0"]
+        noble: ["libboost-system1.83.0"]
+
+libboost-system-dev:
+    ubuntu: ["libboost-system-dev"]
+
+libboost-thread:
+    ubuntu:
+        bionic: ["libboost-thread1.65.1"]
+        focal: ["libboost-thread1.71.0"]
+        jammy: ["libboost-thread1.74.0"]
+        noble: ["libboost-thread1.83.0"]
+
+libboost-thread-dev:
+    ubuntu: ["libboost-thread-dev"]
+
+libboost-timer:
+    ubuntu:
+        bionic: ["libboost-timer1.65.1"]
+        focal: ["libboost-timer1.71.0"]
+        jammy: ["libboost-timer1.74.0"]
+        noble: ["libboost-timer1.83.0"]
+
+libboost-timer-dev:
+    ubuntu: ["libboost-timer-dev"]
+
+libbsd-dev:
+    ubuntu: ["libbsd-dev"]
+
+libcairo2-dev:
+    ubuntu: ["libcairo2-dev"]
+
+libcap-dev:
+    ubuntu: ["libcap-dev"]
+
+libcap-ng-dev:
+    ubuntu: ["libcap-ng-dev"]
+
+libcap-ng0:
+    ubuntu: ["libcap-ng0"]
+
+libcap2:
+    ubuntu: ["libcap2"]
+
+libcap2-bin:
+    ubuntu: ["libcap2-bin"]
+
+libccd-dev:
+    ubuntu: ["libccd-dev"]
+
+libccid:
+    ubuntu: ["libccid"]
+
+libcdd-dev:
+    ubuntu: ["libcdd-dev"]
+
+libcegui-mk2-dev:
+    ubuntu: ["libcegui-mk2-dev"]
+
+libcereal-dev:
+    ubuntu: ["libcereal-dev"]
+
+libceres-dev:
+    ubuntu: ["libceres-dev"]
+
+libcgroup-dev:
+    ubuntu: ["libcgroup-dev"]
+
+libclang-dev:
+    ubuntu: ["libclang-dev"]
+
+libcoin60-dev:
+    ubuntu: ["libcoin60-dev"]
+
+libcoin80-dev:
+    ubuntu:
+        default: ["libcoin-dev"]
+        bionic: ["libcoin80-dev"]
+
+libconfig++-dev:
+    ubuntu: ["libconfig++-dev"]
+
+libconfig-dev:
+    ubuntu: ["libconfig-dev"]
+
+libconsole-bridge-dev:
+    ubuntu: ["libconsole-bridge-dev"]
+
+libcos4-dev:
+    ubuntu: ["libcos4-dev"]
+
+libcpp-httplib-dev:
+    ubuntu:
+        default: ["libcpp-httplib-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libcpprest-dev:
+    ubuntu: ["libcpprest-dev"]
+
+libcunit-dev:
+    ubuntu: ["libcunit1-dev"]
+
+libcurl:
+    ubuntu: ["libcurl4"]
+
+libcurl-dev:
+    ubuntu: ["libcurl4-openssl-dev"]
+
+libdbus-dev:
+    ubuntu: ["libdbus-1-dev"]
+
+libdc1394-dev:
+    ubuntu:
+        default: ["libdc1394-dev"]
+        bionic: ["libdc1394-22-dev"]
+        focal: ["libdc1394-22-dev"]
+
+libdevil-dev:
+    ubuntu: ["libdevil-dev"]
+
+libdlib-dev:
+    ubuntu:
+        default: ["libdlib-dev"]
+
+libdmtx-dev:
+    ubuntu: ["libdmtx-dev"]
+
+libdpkg-dev:
+    ubuntu: ["libdpkg-dev"]
+
+libdraco-dev:
+    ubuntu:
+        default: ["libdraco-dev"]
+        focal: nonexistent
+
+libdrm-dev:
+    ubuntu: ["libdrm-dev"]
+
+libdw-dev:
+    ubuntu: ["libdw-dev"]
+
+libdxflib-dev:
+    ubuntu: ["libdxflib-dev"]
+
+libedit:
+    ubuntu: ["libedit2"]
+
+libedit-dev:
+    ubuntu: ["libedit-dev"]
+
+libepoxy-dev:
+    ubuntu: ["libepoxy-dev"]
+
+libesd0-dev:
+    ubuntu: ["libesd0-dev"]
+
+libespeak-dev:
+    ubuntu: ["libespeak-dev"]
+
+libespeak-ng1:
+    ubuntu: ["libespeak-ng1"]
+
+libestools-dev:
+    ubuntu:
+        default: ["libestools-dev"]
+
+libev-dev:
+    ubuntu: ["libev-dev"]
+
+libevdev-dev:
+    ubuntu: ["libevdev-dev"]
+
+libevent-dev:
+    ubuntu: ["libevent-dev"]
+
+libexif:
+    ubuntu: ["libexif12"]
+
+libexif-dev:
+    ubuntu: ["libexif-dev"]
+
+libexiv2-dev:
+    ubuntu: ["libexiv2-dev"]
+
+libexpat1-dev:
+    ubuntu: ["libexpat1-dev"]
+
+libext2fs-dev:
+    ubuntu: ["libext2fs-dev"]
+
+libfcl:
+    ubuntu:
+        default: ["libfcl0.7"]
+        focal: ["libfcl0.5"]
+
+libfcl-dev:
+    ubuntu:
+        default: ["libfcl-dev"]
+
+libffi-dev:
+    ubuntu: ["libffi-dev"]
+
+libfftw3:
+    ubuntu: ["libfftw3-3", "libfftw3-dev"]
+
+libfl-dev:
+    ubuntu: ["libfl-dev"]
+
+libflann:
+    ubuntu:
+        default: ["libflann1.9"]
+
+libflann-dev:
+    ubuntu: ["libflann-dev"]
+
+libflatbuffers-dev:
+    ubuntu: ["libflatbuffers-dev"]
+
+libfltk-dev:
+    ubuntu: ["libfltk1.3-dev"]
+
+libfontconfig1-dev:
+    ubuntu: ["libfontconfig1-dev"]
+
+libfreeimage:
+    ubuntu: ["libfreeimage3"]
+
+libfreeimage-dev:
+    ubuntu: ["libfreeimage-dev"]
+
+libfreenect-dev:
+    ubuntu: ["libfreenect-dev"]
+
+libfreetype-dev:
+    ubuntu:
+        default: ["libfreetype-dev"]
+        bionic: ["libfreetype6-dev"]
+
+libfreetype6:
+    ubuntu: ["libfreetype6"]
+
+libfreetype6-dev:
+    ubuntu: ["libfreetype6-dev"]
+
+libftdi-dev:
+    ubuntu: ["libftdi-dev"]
+
+libftdi1-dev:
+    ubuntu: ["libftdi1-dev"]
+
+libftdipp-dev:
+    ubuntu:
+        bionic: ["libftdipp1-dev"]
+
+libftgl-dev:
+    ubuntu: ["libftgl-dev"]
+
+libfyaml-dev:
+    ubuntu:
+        default: ["libfyaml-dev"]
+        focal: nonexistent
+
+libgazebo-dev:
+    ubuntu:
+        focal: ["libgazebo11-dev"]
+        jammy: ["libgazebo-dev"]
+
+libgazebo11-dev:
+    ubuntu:
+        focal: ["libgazebo11-dev"]
+        jammy: ["libgazebo-dev"]
+
+libgazebo5-dev:
+    ubuntu: ["libgazebo5-dev"]
+
+libgazebo7-dev:
+    ubuntu: ["libgazebo7-dev"]
+
+libgazebo9-dev:
+    ubuntu:
+        bionic: ["libgazebo9-dev"]
+
+libgconf2:
+    ubuntu: ["libgconf-2-4"]
+
+libgdal-dev:
+    ubuntu: ["libgdal-dev"]
+
+libgeographiclib-dev:
+    ubuntu: ["libgeographiclib-dev"]
+
+libgeos++-dev:
+    ubuntu: ["libgeos++-dev"]
+
+libgeotiff-dev:
+    ubuntu: ["libgeotiff-dev"]
+
+libgflags-dev:
+    ubuntu: ["libgflags-dev"]
+
+libgfortran3:
+    ubuntu: ["libgfortran3"]
+
+libgif-dev:
+    ubuntu: ["libgif-dev"]
+
+libglew-dev:
+    ubuntu: ["libglew-dev"]
+
+libglfw3-dev:
+    ubuntu:
+        default: ["libglfw3-dev"]
+
+libglib-dev:
+    ubuntu: ["libglib2.0-dev"]
+
+libglm-dev:
+    ubuntu: ["libglm-dev"]
+
+libglui-dev:
+    ubuntu: ["libglui-dev"]
+
+libglw1-mesa:
+    ubuntu: ["libglw1-mesa"]
+
+libgmock-dev:
+    ubuntu:
+        default: ["libgmock-dev"]
+        bionic: nonexistent
+
+libgmp:
+    ubuntu: ["libgmp-dev"]
+
+libgnutls28-dev:
+    ubuntu: ["libgnutls28-dev"]
+
+libgomp1:
+    ubuntu: ["libgomp1"]
+
+libgoogle-glog-dev:
+    ubuntu: ["libgoogle-glog-dev"]
+
+libgpgme-dev:
+    ubuntu:
+        default: ["libgpgme-dev"]
+
+libgphoto-dev:
+    ubuntu:
+        default: ["libgphoto2-dev"]
+
+libgpiod-dev:
+    ubuntu: ["libgpiod-dev"]
+
+libgps:
+    ubuntu: ["libgps-dev"]
+
+libgrpc:
+    ubuntu: ["libgrpc++-dev"]
+
+libgsl:
+    ubuntu:
+        default: ["libgsl-dev"]
+
+libgstreamer-plugins-bad1.0-dev:
+    ubuntu: ["libgstreamer-plugins-bad1.0-dev"]
+
+libgstreamer-plugins-base0.10-0:
+    ubuntu: ["libgstreamer-plugins-base0.10-0"]
+
+libgstreamer-plugins-base0.10-dev:
+    ubuntu: ["libgstreamer-plugins-base0.10-dev"]
+
+libgstreamer-plugins-base1.0-dev:
+    ubuntu: ["libgstreamer-plugins-base1.0-dev"]
+
+libgstreamer0.10-0:
+    ubuntu: ["libgstreamer0.10-0"]
+
+libgstreamer0.10-dev:
+    ubuntu: ["libgstreamer0.10-dev"]
+
+libgstreamer1.0-dev:
+    ubuntu: ["libgstreamer1.0-dev"]
+
+libgstrtspserver-1.0-0:
+    ubuntu: ["libgstrtspserver-1.0-0"]
+
+libgstrtspserver-1.0-dev:
+    ubuntu: ["libgstrtspserver-1.0-dev"]
+
+libgtkmm:
+    ubuntu: ["libgtkmm-2.4-dev"]
+
+libgtkmm3.0-dev:
+    ubuntu: ["libgtkmm-3.0-dev"]
+
+libgts:
+    ubuntu: ["libgts-dev"]
+
+libhal-dev:
+    ubuntu: ["libhal-dev"]
+
+libhdf5-dev:
+    ubuntu: ["libhdf5-dev"]
+
+libhidapi-dev:
+    ubuntu: ["libhidapi-dev"]
+
+libhpptools-dev:
+    ubuntu: ["libhpptools-dev"]
+
+libi2c-dev:
+    ubuntu: ["libi2c-dev"]
+
+libicu-dev:
+    ubuntu: ["libicu-dev"]
+
+libignition-common3:
+    ubuntu:
+        focal: ["libignition-common3"]
+
+libignition-common4:
+    ubuntu:
+        focal: ["libignition-common4"]
+
+libignition-fuel-tools4:
+    ubuntu:
+        focal: ["libignition-fuel-tools4"]
+
+libignition-fuel-tools6:
+    ubuntu:
+        focal: ["libignition-fuel-tools6"]
+
+libignition-gazebo3:
+    ubuntu:
+        focal: ["libignition-gazebo3"]
+
+libignition-gazebo5:
+    ubuntu:
+        focal: ["libignition-gazebo5"]
+
+libignition-gui3:
+    ubuntu:
+        focal: ["libignition-gui3"]
+
+libignition-gui5:
+    ubuntu:
+        focal: ["libignition-gui5"]
+
+libignition-launch2:
+    ubuntu:
+        focal: ["libignition-launch2"]
+
+libignition-launch4:
+    ubuntu:
+        focal: ["libignition-launch4"]
+
+libignition-math6:
+    ubuntu:
+        focal: ["libignition-math6"]
+
+libignition-msgs5:
+    ubuntu:
+        focal: ["libignition-msgs5"]
+
+libignition-msgs7:
+    ubuntu:
+        focal: ["libignition-msgs7"]
+
+libignition-physics2:
+    ubuntu:
+        focal: ["libignition-physics2"]
+
+libignition-physics4:
+    ubuntu:
+        focal: ["libignition-physics4"]
+
+libignition-rendering3:
+    ubuntu:
+        focal: ["libignition-rendering3"]
+
+libignition-rendering5:
+    ubuntu:
+        focal: ["libignition-rendering5"]
+
+libignition-sensors3:
+    ubuntu:
+        focal: ["libignition-sensors3"]
+
+libignition-sensors5:
+    ubuntu:
+        focal: ["libignition-sensors5"]
+
+libignition-transport10:
+    ubuntu:
+        focal: ["libignition-transport10"]
+
+libignition-transport8:
+    ubuntu:
+        focal: ["libignition-transport8"]
+
+libignition-utils1:
+    ubuntu:
+        focal: ["libignition-utils1"]
+
+libiio-dev:
+    ubuntu: ["libiio-dev"]
+
+libimage-exiftool-perl:
+    ubuntu: ["libimage-exiftool-perl"]
+
+libirrlicht-dev:
+    ubuntu: ["libirrlicht-dev"]
+
+libiw-dev:
+    ubuntu: ["libiw-dev"]
+
+libjack-dev:
+    ubuntu: ["libjack-dev"]
+
+libjackson-json-java:
+    ubuntu: ["libjackson-json-java"]
+
+libjansson-dev:
+    ubuntu: ["libjansson-dev"]
+
+libjchart2d-java:
+    ubuntu: ["libjchart2d-java"]
+
+libjpeg:
+    ubuntu: ["libjpeg-dev"]
+
+libjson-glib:
+    ubuntu: ["libjson-glib-dev"]
+
+libjson-java:
+    ubuntu: ["libjson-java"]
+
+libjson0-dev:
+    ubuntu: ["libjson0-dev"]
+
+libjsoncpp:
+    ubuntu:
+        default: ["libjsoncpp25"]
+        bionic: ["libjsoncpp1"]
+        focal: ["libjsoncpp1"]
+
+libjsoncpp-dev:
+    ubuntu: ["libjsoncpp-dev"]
+
+libjsonrpccpp-client0:
+    ubuntu: ["libjsonrpccpp-client0"]
+
+libjsonrpccpp-common0:
+    ubuntu: ["libjsonrpccpp-common0"]
+
+libjsonrpccpp-dev:
+    ubuntu: ["libjsonrpccpp-dev"]
+
+libjsonrpccpp-server0:
+    ubuntu: ["libjsonrpccpp-server0"]
+
+libjsonrpccpp-stub0:
+    ubuntu: ["libjsonrpccpp-stub0"]
+
+libjsonrpccpp-tools:
+    ubuntu: ["libjsonrpccpp-tools"]
+
+libkdtree++-dev:
+    ubuntu: ["libkdtree++-dev"]
+
+libkml-dev:
+    ubuntu: ["libkml-dev"]
+
+liblapack-dev:
+    ubuntu: ["liblapack-dev"]
+
+liblapacke-dev:
+    ubuntu: ["liblapacke-dev"]
+
+liblcm:
+    ubuntu:
+        default: ["liblcm1"]
+
+liblcm-dev:
+    ubuntu:
+        default: ["liblcm-dev"]
+
+libleptonica-dev:
+    ubuntu: ["libleptonica-dev"]
+
+liblinear-dev:
+    ubuntu: ["liblinear-dev"]
+
+liblinphone-dev:
+    ubuntu: ["liblinphone-dev"]
+
+liblmdb-dev:
+    ubuntu: ["liblmdb-dev"]
+
+liblttng-ctl-dev:
+    ubuntu: ["liblttng-ctl-dev"]
+
+liblttng-ust-dev:
+    ubuntu: ["liblttng-ust-dev"]
+
+liblz4:
+    ubuntu: ["liblz4-1"]
+
+liblz4-dev:
+    ubuntu: ["liblz4-dev"]
+
+liblzma-dev:
+    ubuntu: ["liblzma-dev"]
+
+libmagick:
+    ubuntu: ["libmagick++-dev"]
+
+libmarble-dev:
+    ubuntu: ["libmarble-dev"]
+
+libmbedtls-dev:
+    ubuntu: ["libmbedtls-dev"]
+
+libmicrohttpd:
+    ubuntu: ["libmicrohttpd-dev"]
+
+libmlpack-dev:
+    ubuntu: ["libmlpack-dev"]
+
+libmnl-dev:
+    ubuntu: ["libmnl-dev"]
+
+libmockito-java:
+    ubuntu: ["libmockito-java"]
+
+libmodbus-dev:
+    ubuntu: ["libmodbus-dev"]
+
+libmodbus5:
+    ubuntu: ["libmodbus5"]
+
+libmongoc-1.0-0:
+    ubuntu: ["libmongoc-1.0-0"]
+
+libmongoc-dev:
+    ubuntu: ["libmongoc-dev"]
+
+libmongoclient-dev:
+    ubuntu: ["libmongoclient-dev"]
+
+libmotif-dev:
+    ubuntu: ["libmotif-dev"]
+
+libmp3lame-dev:
+    ubuntu: ["libmp3lame-dev"]
+
+libmpg123-dev:
+    ubuntu: ["libmpg123-dev"]
+
+libmpich-dev:
+    ubuntu: ["libmpich-dev"]
+
+libmpich2-dev:
+    ubuntu: ["libmpich2-dev"]
+
+libmsgsl-dev:
+    ubuntu: ["libmsgsl-dev"]
+
+libmysql++-dev:
+    ubuntu: ["libmysql++-dev"]
+
+libmysql++3v5:
+    ubuntu:
+        focal: ["libmysql++3v5"]
+        jammy: ["libmysql++3v5"]
+
+libmysqlclient-dev:
+    ubuntu: ["libmysqlclient-dev"]
+
+libmysqlcppconn-dev:
+    ubuntu: ["libmysqlcppconn-dev"]
+
+libnanoflann-dev:
+    ubuntu:
+        default: ["libnanoflann-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libnanopb-dev:
+    ubuntu:
+        default: ["libnanopb-dev"]
+        bionic: nonexistent
+
+libncurses:
+    ubuntu: ["libncurses6"]
+
+libncurses-dev:
+    ubuntu: ["libncurses-dev"]
+
+libneon27-gnutls-dev:
+    ubuntu: ["libneon27-gnutls-dev"]
+
+libnewmat10-dev:
+    ubuntu: ["libnewmat10-dev"]
+
+libnl-3:
+    ubuntu: ["libnl-3-200", "libnl-genl-3-200", "libnl-route-3-200"]
+
+libnl-3-dev:
+    ubuntu: ["libnl-3-dev", "libnl-genl-3-dev", "libnl-route-3-dev"]
+
+libnl-dev:
+    ubuntu: ["libnl-dev"]
+
+libnlopt-cxx-dev:
+    ubuntu:
+        default: ["libnlopt-cxx-dev"]
+        bionic: nonexistent
+
+libnlopt-dev:
+    ubuntu: ["libnlopt-dev"]
+
+libnlopt0:
+    ubuntu: ["libnlopt0"]
+
+libnotify:
+    ubuntu: ["libnotify-dev"]
+
+libnss3-dev:
+    ubuntu: ["libnss3-dev"]
+
+liboctomap-dev:
+    ubuntu: ["liboctomap-dev"]
+
+libogg:
+    ubuntu: ["libogg-dev"]
+
+libogre:
+    ubuntu: ["libogre-1.9.0v5"]
+
+libogre-1.12-dev:
+    ubuntu:
+        focal: ["libogre-1.12-dev"]
+        jammy: ["libogre-1.12-dev"]
+
+libogre-dev:
+    ubuntu: ["libogre-1.9-dev"]
+
+libogre1.12.10:
+    ubuntu:
+        jammy: ["libogre1.12.10"]
+
+libois-dev:
+    ubuntu: ["libois-dev"]
+
+libomp-dev:
+    ubuntu: ["libomp-dev"]
+
+libopal-dev:
+    ubuntu: ["libopal-dev"]
+
+libopen3d-dev:
+    ubuntu:
+        default: ["libopen3d-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libopenal-dev:
+    ubuntu: ["libopenal-dev"]
+
+libopenblas-dev:
+    ubuntu: ["libopenblas-dev"]
+
+libopencv-contrib-dev:
+    ubuntu: ["libopencv-contrib-dev"]
+
+libopencv-dev:
+    ubuntu: ["libopencv-dev"]
+
+libopencv-imgproc-dev:
+    ubuntu: ["libopencv-imgproc-dev"]
+
+libopenexr-dev:
+    ubuntu: ["libopenexr-dev"]
+
+libopenni-dev:
+    ubuntu: ["libopenni-dev"]
+
+libopenni-sensor-primesense-dev:
+    ubuntu: ["libopenni-sensor-primesense-dev"]
+
+libopenni2-dev:
+    ubuntu: ["libopenni2-dev"]
+
+libopenscenegraph:
+    ubuntu: ["openscenegraph", "libopenscenegraph-dev"]
+
+libopensplice67:
+    ubuntu:
+        bionic: ["libopensplice67"]
+
+libopensplice69:
+    ubuntu:
+        bionic: ["libopensplice69"]
+
+libopenvdb:
+    ubuntu:
+        bionic: ["libopenvdb5.0"]
+        focal: ["libopenvdb6.2"]
+        jammy: ["libopenvdb8.1"]
+
+libopenvdb-dev:
+    ubuntu: ["libopenvdb-dev", "libilmbase-dev"]
+
+libopus-dev:
+    ubuntu: ["libopus-dev"]
+
+liborocos-bfl:
+    ubuntu:
+        default: ["liborocos-bfl0.8"]
+        bionic: nonexistent
+
+liborocos-bfl-dev:
+    ubuntu: ["liborocos-bfl-dev"]
+
+liborocos-kdl:
+    ubuntu:
+        default: ["liborocos-kdl1.5"]
+        bionic: ["liborocos-kdl1.3"]
+        focal: ["liborocos-kdl1.4"]
+
+liborocos-kdl-dev:
+    ubuntu: ["liborocos-kdl-dev"]
+
+libosmesa6-dev:
+    ubuntu: ["libosmesa6-dev"]
+
+libpaho-mqtt:
+    ubuntu:
+        default: ["libpaho-mqtt1.3"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpaho-mqtt-dev:
+    ubuntu:
+        default: ["libpaho-mqtt-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpaho-mqttpp:
+    ubuntu:
+        default: ["libpaho-mqttpp3-1"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpaho-mqttpp-dev:
+    ubuntu:
+        default: ["libpaho-mqttpp-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpcap:
+    ubuntu: ["libpcap0.8-dev"]
+
+libpcl-all:
+    ubuntu:
+        bionic: ["libpcl-apps1.8", "libpcl-common1.8", "libpcl-features1.8", "libpcl-filters1.8", "libpcl-io1.8", "libpcl-kdtree1.8", "libpcl-keypoints1.8", "libpcl-ml1.8", "libpcl-octree1.8", "libpcl-outofcore1.8", "libpcl-people1.8", "libpcl-recognition1.8", "libpcl-registration1.8", "libpcl-sample-consensus1.8", "libpcl-search1.8", "libpcl-segmentation1.8", "libpcl-stereo1.8", "libpcl-surface1.8", "libpcl-tracking1.8", "libpcl-visualization1.8"]
+        focal: ["libpcl-apps1.10", "libpcl-common1.10", "libpcl-features1.10", "libpcl-filters1.10", "libpcl-io1.10", "libpcl-kdtree1.10", "libpcl-keypoints1.10", "libpcl-ml1.10", "libpcl-octree1.10", "libpcl-outofcore1.10", "libpcl-people1.10", "libpcl-recognition1.10", "libpcl-registration1.10", "libpcl-sample-consensus1.10", "libpcl-search1.10", "libpcl-segmentation1.10", "libpcl-stereo1.10", "libpcl-surface1.10", "libpcl-tracking1.10", "libpcl-visualization1.10"]
+        jammy: ["libpcl-apps1.12", "libpcl-common1.12", "libpcl-features1.12", "libpcl-filters1.12", "libpcl-io1.12", "libpcl-kdtree1.12", "libpcl-keypoints1.12", "libpcl-ml1.12", "libpcl-octree1.12", "libpcl-outofcore1.12", "libpcl-people1.12", "libpcl-recognition1.12", "libpcl-registration1.12", "libpcl-sample-consensus1.12", "libpcl-search1.12", "libpcl-segmentation1.12", "libpcl-stereo1.12", "libpcl-surface1.12", "libpcl-tracking1.12", "libpcl-visualization1.12"]
+        noble: ["libpcl-apps1.14", "libpcl-common1.14", "libpcl-features1.14", "libpcl-filters1.14", "libpcl-io1.14", "libpcl-kdtree1.14", "libpcl-keypoints1.14", "libpcl-ml1.14", "libpcl-octree1.14", "libpcl-outofcore1.14", "libpcl-people1.14", "libpcl-recognition1.14", "libpcl-registration1.14", "libpcl-sample-consensus1.14", "libpcl-search1.14", "libpcl-segmentation1.14", "libpcl-stereo1.14", "libpcl-surface1.14", "libpcl-tracking1.14", "libpcl-visualization1.14"]
+
+libpcl-all-dev:
+    ubuntu: ["libpcl-dev"]
+
+libpcl-apps:
+    ubuntu:
+        bionic: ["libpcl-apps1.8"]
+        focal: ["libpcl-apps1.10"]
+        jammy: ["libpcl-apps1.12"]
+        noble: ["libpcl-apps1.14"]
+
+libpcl-common:
+    ubuntu:
+        bionic: ["libpcl-common1.8"]
+        focal: ["libpcl-common1.10"]
+        jammy: ["libpcl-common1.12"]
+        noble: ["libpcl-common1.14"]
+
+libpcl-features:
+    ubuntu:
+        bionic: ["libpcl-features1.8"]
+        focal: ["libpcl-features1.10"]
+        jammy: ["libpcl-features1.12"]
+        noble: ["libpcl-features1.14"]
+
+libpcl-filters:
+    ubuntu:
+        bionic: ["libpcl-filters1.8"]
+        focal: ["libpcl-filters1.10"]
+        jammy: ["libpcl-filters1.12"]
+        noble: ["libpcl-filters1.14"]
+
+libpcl-io:
+    ubuntu:
+        bionic: ["libpcl-io1.8"]
+        focal: ["libpcl-io1.10"]
+        jammy: ["libpcl-io1.12"]
+        noble: ["libpcl-io1.14"]
+
+libpcl-kdtree:
+    ubuntu:
+        bionic: ["libpcl-kdtree1.8"]
+        focal: ["libpcl-kdtree1.10"]
+        jammy: ["libpcl-kdtree1.12"]
+        noble: ["libpcl-kdtree1.14"]
+
+libpcl-keypoints:
+    ubuntu:
+        bionic: ["libpcl-keypoints1.8"]
+        focal: ["libpcl-keypoints1.10"]
+        jammy: ["libpcl-keypoints1.12"]
+        noble: ["libpcl-keypoints1.14"]
+
+libpcl-ml:
+    ubuntu:
+        bionic: ["libpcl-ml1.8"]
+        focal: ["libpcl-ml1.10"]
+        jammy: ["libpcl-ml1.12"]
+        noble: ["libpcl-ml1.14"]
+
+libpcl-octree:
+    ubuntu:
+        bionic: ["libpcl-octree1.8"]
+        focal: ["libpcl-octree1.10"]
+        jammy: ["libpcl-octree1.12"]
+        noble: ["libpcl-octree1.14"]
+
+libpcl-outofcore:
+    ubuntu:
+        bionic: ["libpcl-outofcore1.8"]
+        focal: ["libpcl-outofcore1.10"]
+        jammy: ["libpcl-outofcore1.12"]
+        noble: ["libpcl-outofcore1.14"]
+
+libpcl-people:
+    ubuntu:
+        bionic: ["libpcl-people1.8"]
+        focal: ["libpcl-people1.10"]
+        jammy: ["libpcl-people1.12"]
+        noble: ["libpcl-people1.14"]
+
+libpcl-recognition:
+    ubuntu:
+        bionic: ["libpcl-recognition1.8"]
+        focal: ["libpcl-recognition1.10"]
+        jammy: ["libpcl-recognition1.12"]
+        noble: ["libpcl-recognition1.14"]
+
+libpcl-registration:
+    ubuntu:
+        bionic: ["libpcl-registration1.8"]
+        focal: ["libpcl-registration1.10"]
+        jammy: ["libpcl-registration1.12"]
+        noble: ["libpcl-registration1.14"]
+
+libpcl-sample-consensus:
+    ubuntu:
+        bionic: ["libpcl-sample-consensus1.8"]
+        focal: ["libpcl-sample-consensus1.10"]
+        jammy: ["libpcl-sample-consensus1.12"]
+        noble: ["libpcl-sample-consensus1.14"]
+
+libpcl-search:
+    ubuntu:
+        bionic: ["libpcl-search1.8"]
+        focal: ["libpcl-search1.10"]
+        jammy: ["libpcl-search1.12"]
+        noble: ["libpcl-search1.14"]
+
+libpcl-segmentation:
+    ubuntu:
+        bionic: ["libpcl-segmentation1.8"]
+        focal: ["libpcl-segmentation1.10"]
+        jammy: ["libpcl-segmentation1.12"]
+        noble: ["libpcl-segmentation1.14"]
+
+libpcl-stereo:
+    ubuntu:
+        bionic: ["libpcl-stereo1.8"]
+        focal: ["libpcl-stereo1.10"]
+        jammy: ["libpcl-stereo1.12"]
+        noble: ["libpcl-stereo1.14"]
+
+libpcl-surface:
+    ubuntu:
+        bionic: ["libpcl-surface1.8"]
+        focal: ["libpcl-surface1.10"]
+        jammy: ["libpcl-surface1.12"]
+        noble: ["libpcl-surface1.14"]
+
+libpcl-tracking:
+    ubuntu:
+        bionic: ["libpcl-tracking1.8"]
+        focal: ["libpcl-tracking1.10"]
+        jammy: ["libpcl-tracking1.12"]
+        noble: ["libpcl-tracking1.14"]
+
+libpcl-visualization:
+    ubuntu:
+        bionic: ["libpcl-visualization1.8"]
+        focal: ["libpcl-visualization1.10"]
+        jammy: ["libpcl-visualization1.12"]
+        noble: ["libpcl-visualization1.14"]
+
+libpcsclite-dev:
+    ubuntu: ["libpcsclite-dev"]
+
+libpcsclite1:
+    ubuntu: ["libpcsclite1"]
+
+libphonon:
+    ubuntu: ["libphonon4"]
+
+libphonon-dev:
+    ubuntu: ["libphonon-dev"]
+
+libpng++-dev:
+    ubuntu: ["libpng++-dev"]
+
+libpng-dev:
+    ubuntu:
+        default: ["libpng-dev"]
+
+libpng12-dev:
+    ubuntu: ["libpng12-dev"]
+
+libpoco-dev:
+    ubuntu: ["libpoco-dev"]
+
+libpocofoundation9:
+    ubuntu: ["libpocofoundation9"]
+
+libpopt-dev:
+    ubuntu: ["libpopt-dev"]
+
+libpq-dev:
+    ubuntu: ["libpq-dev"]
+
+libpqxx:
+    ubuntu:
+        bionic: ["libpqxx-4.0v5"]
+        focal: ["libpqxx-6.4"]
+
+libpqxx-dev:
+    ubuntu: ["libpqxx-dev"]
+
+libprocps-dev:
+    ubuntu: ["libprocps-dev"]
+
+libprocps6:
+    ubuntu:
+        bionic: ["libprocps6"]
+
+libpt-dev:
+    ubuntu: ["libpt-dev"]
+
+libpthread-stubs0-dev:
+    ubuntu: ["libpthread-stubs0-dev"]
+
+libpulse-dev:
+    ubuntu: ["libpulse-dev"]
+
+libqcustomplot-dev:
+    ubuntu: ["libqcustomplot-dev"]
+
+libqd-dev:
+    ubuntu: ["libqd-dev"]
+
+libqglviewer-dev-qt5:
+    ubuntu: ["libqglviewer-dev-qt5"]
+
+libqglviewer-qt4:
+    ubuntu:
+        bionic: ["libqglviewer2-qt4"]
+
+libqglviewer-qt4-dev:
+    ubuntu:
+        bionic: ["libqglviewer-dev-qt4"]
+
+libqglviewer2-qt5:
+    ubuntu: ["libqglviewer2-qt5"]
+
+libqhull:
+    ubuntu: ["libqhull-dev"]
+
+libqmi-glib-dev:
+    ubuntu: ["libqmi-glib-dev"]
+
+libqrencode:
+    ubuntu: ["libqrencode3"]
+
+libqrencode-dev:
+    ubuntu: ["libqrencode-dev"]
+
+libqt4:
+    ubuntu: ["libqt4-dbus", "libqt4-network", "libqt4-script", "libqt4-test", "libqt4-xml", "libqtcore4"]
+
+libqt4-dev:
+    ubuntu: ["libqt4-dev"]
+
+libqt4-opengl:
+    ubuntu: ["libqt4-opengl"]
+
+libqt4-opengl-dev:
+    ubuntu: ["libqt4-opengl-dev"]
+
+libqt4-sql-psql:
+    ubuntu: ["libqt4-sql-psql"]
+
+libqt5-charts-dev:
+    ubuntu: ["libqt5charts5-dev"]
+
+libqt5-concurrent:
+    ubuntu: ["libqt5concurrent5"]
+
+libqt5-core:
+    ubuntu: ["libqt5core5a"]
+
+libqt5-gstreamer-dev:
+    ubuntu: ["libqt5gstreamer-dev"]
+
+libqt5-gui:
+    ubuntu: ["libqt5gui5"]
+
+libqt5-multimedia:
+    ubuntu: ["libqt5multimedia5"]
+
+libqt5-network:
+    ubuntu: ["libqt5network5"]
+
+libqt5-opengl:
+    ubuntu: ["libqt5opengl5"]
+
+libqt5-opengl-dev:
+    ubuntu: ["libqt5opengl5-dev"]
+
+libqt5-printsupport:
+    ubuntu: ["libqt5printsupport5"]
+
+libqt5-qml:
+    ubuntu: ["libqt5qml5"]
+
+libqt5-quick:
+    ubuntu: ["libqt5quick5"]
+
+libqt5-serialport:
+    ubuntu: ["libqt5serialport5"]
+
+libqt5-serialport-dev:
+    ubuntu: ["libqt5serialport5-dev"]
+
+libqt5-sql:
+    ubuntu: ["libqt5sql5"]
+
+libqt5-svg:
+    ubuntu: ["libqt5svg5"]
+
+libqt5-svg-dev:
+    ubuntu: ["libqt5svg5-dev"]
+
+libqt5-websockets-dev:
+    ubuntu: ["libqt5websockets5-dev"]
+
+libqt5-widgets:
+    ubuntu: ["libqt5widgets5"]
+
+libqt5-xml:
+    ubuntu: ["libqt5xml5"]
+
+libqt5multimedia5-plugins:
+    ubuntu: ["libqt5multimedia5-plugins"]
+
+libqt5x11extras5-dev:
+    ubuntu: ["libqt5x11extras5-dev"]
+
+libqtgui4:
+    ubuntu: ["libqtgui4"]
+
+libqtwebkit-dev:
+    ubuntu: ["libqtwebkit-dev"]
+
+libqwt-qt5-dev:
+    ubuntu:
+        default: ["libqwt-qt5-dev"]
+
+libqwt5-qt4-dev:
+    ubuntu: ["libqwt5-qt4-dev"]
+
+libqwt6:
+    ubuntu: ["libqwt-dev"]
+
+libqwtplot3d-qt4-dev:
+    ubuntu: ["libqwtplot3d-qt4-dev"]
+
+librabbitmq-dev:
+    ubuntu: ["librabbitmq-dev"]
+
+librapidxml-dev:
+    ubuntu: ["librapidxml-dev"]
+
+libraw1394:
+    ubuntu: ["libraw1394-11"]
+
+libraw1394-dev:
+    ubuntu: ["libraw1394-dev"]
+
+librdkafka-dev:
+    ubuntu: ["librdkafka-dev"]
+
+libreadline:
+    ubuntu: ["libreadline-dev"]
+
+libreadline-dev:
+    ubuntu: ["libreadline-dev"]
+
+libreadline-java:
+    ubuntu: ["libreadline-java"]
+
+librtaudio-dev:
+    ubuntu: ["librtaudio-dev"]
+
+libsecp256k1-dev:
+    ubuntu: ["libsecp256k1-dev"]
+
+libsensors4-dev:
+    ubuntu: ["libsensors4-dev"]
+
+libserial-dev:
+    ubuntu: ["libserial-dev"]
+
+libshaderc-dev:
+    ubuntu:
+        default: ["libshaderc-dev"]
+        focal: nonexistent
+        jammy: nonexistent
+
+libsimage-dev:
+    ubuntu: ["libsimage-dev"]
+
+libsndfile1-dev:
+    ubuntu: ["libsndfile1-dev"]
+
+libsodium-dev:
+    ubuntu: ["libsodium-dev"]
+
+libsoqt4-dev:
+    ubuntu: ["libsoqt4-dev"]
+
+libsoundio-dev:
+    ubuntu: ["libsoundio-dev"]
+
+libsoup2-dev:
+    ubuntu: ["libsoup2.4-dev"]
+
+libspatialindex-dev:
+    ubuntu: ["libspatialindex-dev"]
+
+libspatialite:
+    ubuntu:
+        default: ["libsqlite3-mod-spatialite"]
+
+libspnav-dev:
+    ubuntu: ["libspnav-dev", "libx11-dev"]
+
+libsqlite3-dev:
+    ubuntu: ["libsqlite3-dev"]
+
+libsrtp0-dev:
+    ubuntu: ["libsrtp0-dev"]
+
+libssh-dev:
+    ubuntu: ["libssh-dev"]
+
+libssh2:
+    ubuntu: ["libssh2-1"]
+
+libssh2-dev:
+    ubuntu: ["libssh2-1-dev"]
+
+libssl-dev:
+    ubuntu: ["libssl-dev"]
+
+libstdc++5:
+    ubuntu: ["libstdc++5"]
+
+libstdc++6:
+    ubuntu: ["libstdc++6"]
+
+libsvm-dev:
+    ubuntu: ["libsvm-dev"]
+
+libsvm3:
+    ubuntu: ["libsvm3"]
+
+libsvn-dev:
+    ubuntu: ["libsvn-dev"]
+
+libswscale-dev:
+    ubuntu: ["libswscale-dev"]
+
+libsystemd-dev:
+    ubuntu:
+        default: ["libsystemd-dev"]
+
+libtclap-dev:
+    ubuntu: ["libtclap-dev"]
+
+libtesseract:
+    ubuntu: ["libtesseract-dev"]
+
+libtheora:
+    ubuntu: ["libtheora-dev"]
+
+libtiff-dev:
+    ubuntu: ["libtiff-dev"]
+
+libtiff4-dev:
+    ubuntu: ["libtiff4-dev"]
+
+libtins-dev:
+    ubuntu: ["libtins-dev"]
+
+libtool:
+    ubuntu: ["libtool", "libltdl-dev", "libtool-bin"]
+
+libttspico:
+    ubuntu: ["libttspico-dev", "libttspico-data", "libttspico-utils", "libttspico0"]
+
+libturbojpeg:
+    ubuntu:
+        default: ["libturbojpeg0-dev"]
+
+libudev-dev:
+    ubuntu: ["libudev-dev"]
+
+libunittest++:
+    ubuntu: ["libunittest++-dev"]
+
+libunwind:
+    ubuntu:
+        default: ["libunwind8"]
+
+libunwind-dev:
+    ubuntu:
+        default: ["libunwind-dev"]
+
+liburdfdom-dev:
+    ubuntu: ["liburdfdom-dev"]
+
+liburdfdom-headers-dev:
+    ubuntu: ["liburdfdom-headers-dev"]
+
+liburdfdom-tools:
+    ubuntu: ["liburdfdom-tools"]
+
+libusb:
+    ubuntu: ["libusb-0.1-4"]
+
+libusb-1.0:
+    ubuntu: ["libusb-1.0-0"]
+
+libusb-1.0-dev:
+    ubuntu: ["libusb-1.0-0-dev"]
+
+libusb-dev:
+    ubuntu: ["libusb-dev"]
+
+libuv-dev:
+    ubuntu:
+        bionic: ["libuv0.10-dev"]
+
+libuv1-dev:
+    ubuntu: ["libuv1-dev"]
+
+libuvc-dev:
+    ubuntu:
+        default: ["libuvc-dev"]
+
+libv4l-dev:
+    ubuntu: ["libv4l-dev"]
+
+libvlc:
+    ubuntu:
+        default: ["libvlc5", "vlc-bin"]
+
+libvlc-dev:
+    ubuntu: ["libvlc-dev"]
+
+libvlccore-dev:
+    ubuntu: ["libvlccore-dev"]
+
+libvorbis-dev:
+    ubuntu: ["libvorbis-dev"]
+
+libvpx-dev:
+    ubuntu: ["libvpx-dev"]
+
+libvtk:
+    ubuntu:
+        default: ["libvtk7-dev"]
+        bionic: ["libvtk6-dev"]
+
+libvtk-java:
+    ubuntu:
+        default: ["libvtk7-java"]
+        bionic: ["libvtk6-java"]
+
+libvtk-qt:
+    ubuntu:
+        default: ["libvtk7-qt-dev"]
+        bionic: ["libvtk6-qt-dev"]
+
+libvtk9-dev:
+    ubuntu:
+        default: ["libvtk9-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libvulkan-dev:
+    ubuntu:
+        default: ["libvulkan-dev"]
+
+libwebp-dev:
+    ubuntu: ["libwebp-dev"]
+
+libwebp-tools:
+    ubuntu: ["webp"]
+
+libwebsocketpp-dev:
+    ubuntu: ["libwebsocketpp-dev"]
+
+libwebsockets-dev:
+    ubuntu: ["libwebsockets-dev"]
+
+libx11:
+    ubuntu: ["libx11-dev"]
+
+libx11-dev:
+    ubuntu: ["libx11-dev"]
+
+libx11-xcb-dev:
+    ubuntu: ["libx11-xcb-dev"]
+
+libx264-dev:
+    ubuntu: ["libx264-dev"]
+
+libxaw:
+    ubuntu: ["libxaw7-dev"]
+
+libxcb-randr0-dev:
+    ubuntu: ["libxcb-randr0-dev"]
+
+libxcursor-dev:
+    ubuntu: ["libxcursor-dev"]
+
+libxenomai-dev:
+    ubuntu: ["libxenomai-dev"]
+
+libxext:
+    ubuntu: ["libxext-dev"]
+
+libxft-dev:
+    ubuntu: ["libxft-dev"]
+
+libxi-dev:
+    ubuntu: ["libxi-dev"]
+
+libxinerama-dev:
+    ubuntu: ["libxinerama-dev"]
+
+libxkbcommon-dev:
+    ubuntu: ["libxkbcommon-dev"]
+
+libxml++-2.6:
+    ubuntu: ["libxml++2.6-dev"]
+
+libxml2:
+    ubuntu: ["libxml2-dev"]
+
+libxml2-utils:
+    ubuntu: ["libxml2-utils"]
+
+libxmlrpc-c++:
+    ubuntu: ["libxmlrpc-c++8-dev"]
+
+libxmu-dev:
+    ubuntu: ["libxmu-dev"]
+
+libxrandr:
+    ubuntu: ["libxrandr-dev"]
+
+libxslt:
+    ubuntu: ["libxslt1-dev"]
+
+libxss1:
+    ubuntu: ["libxss1"]
+
+libxt-dev:
+    ubuntu: ["libxt-dev"]
+
+libxtst-dev:
+    ubuntu: ["libxtst-dev"]
+
+libxxf86vm:
+    ubuntu: ["libxxf86vm-dev"]
+
+libyaml:
+    ubuntu: ["libyaml-0-2"]
+
+libyaml-dev:
+    ubuntu: ["libyaml-dev"]
+
+libzip-dev:
+    ubuntu: ["libzip-dev"]
+
+libzmq3-dev:
+    ubuntu:
+        default: ["libzmq3-dev", "cppzmq-dev"]
+        bionic: ["libzmq3-dev"]
+        focal: ["libzmq3-dev"]
+        jammy: ["libzmq3-dev"]
+
+libzmqpp-dev:
+    ubuntu: ["libzmqpp-dev"]
+
+libzmqpp3:
+    ubuntu: ["libzmqpp3"]
+
+libzstd-dev:
+    ubuntu:
+        default: ["libzstd-dev"]
+
+light-locker:
+    ubuntu: ["light-locker"]
+
+lighttpd:
+    ubuntu: ["lighttpd"]
+
+lilypond:
+    ubuntu: ["lilypond"]
+
+linphone:
+    ubuntu: ["linphone"]
+
+linux-headers-generic:
+    ubuntu: ["linux-headers-generic"]
+
+linux-kernel-headers:
+    ubuntu: ["linux-libc-dev"]
+
+llvm:
+    ubuntu: ["llvm"]
+
+llvm-7:
+    ubuntu:
+        bionic: ["llvm-7"]
+        focal: ["llvm-7"]
+
+llvm-7-dev:
+    ubuntu:
+        bionic: ["llvm-7-dev"]
+        focal: ["llvm-7-dev"]
+
+llvm-dev:
+    ubuntu: ["llvm-dev"]
+
+lm-sensors:
+    ubuntu: ["lm-sensors"]
+
+log4cplus:
+    ubuntu: ["liblog4cplus-dev"]
+
+log4cxx:
+    ubuntu:
+        default: ["liblog4cxx-dev"]
+
+lsb-release:
+    ubuntu: ["lsb-release"]
+
+lttng-modules:
+    ubuntu: ["lttng-modules-dkms"]
+
+lttng-tools:
+    ubuntu: ["lttng-tools"]
+
+lua-dev:
+    ubuntu: ["liblua5.1-0-dev"]
+
+lua5.2-dev:
+    ubuntu: ["liblua5.2-dev"]
+
+lz4:
+    ubuntu: ["liblz4-dev"]
+
+m2r:
+    ubuntu:
+        default: ["m2r"]
+        bionic: nonexistent
+
+m4:
+    ubuntu: ["m4"]
+
+mapnik-utils:
+    ubuntu: ["mapnik-utils"]
+
+matio:
+    ubuntu: ["libmatio-dev"]
+
+maven:
+    ubuntu: ["maven"]
+
+mayavi:
+    ubuntu: ["mayavi2"]
+
+meld:
+    ubuntu: ["meld"]
+
+mercurial:
+    ubuntu: ["mercurial"]
+
+mesa-common-dev:
+    ubuntu: ["mesa-common-dev"]
+
+mesa-utils:
+    ubuntu: ["mesa-utils"]
+
+meshlab:
+    ubuntu: ["meshlab"]
+
+mkdocs:
+    ubuntu:
+        bionic: ["mkdocs"]
+
+mkdocs-bootstrap:
+    ubuntu:
+        bionic: ["mkdocs-bootstrap"]
+
+mkdocs-bootswatch:
+    ubuntu:
+        bionic: ["mkdocs-bootswatch"]
+
+mongodb:
+    ubuntu:
+        bionic: ["mongodb"]
+        focal: ["mongodb"]
+
+mongodb-dev:
+    ubuntu: ["libmongoclient-dev"]
+
+mono-complete:
+    ubuntu: ["mono-complete"]
+
+mono-devel:
+    ubuntu: ["mono-devel"]
+
+mosquitto:
+    ubuntu: ["mosquitto"]
+
+mosquitto-clients:
+    ubuntu: ["mosquitto-clients"]
+
+mosquitto-dev:
+    ubuntu: ["libmosquitto-dev"]
+
+mosquittopp-dev:
+    ubuntu: ["libmosquittopp-dev"]
+
+mpfr:
+    ubuntu: ["libmpfr-dev"]
+
+mpg123:
+    ubuntu: ["mpg123"]
+
+mplayer:
+    ubuntu: ["mplayer"]
+
+mrpt:
+    ubuntu: ["libmrpt-dev"]
+
+msgpack:
+    ubuntu: ["libmsgpack-dev"]
+
+msr-tools:
+    ubuntu: ["msr-tools"]
+
+multistrap:
+    ubuntu: ["multistrap"]
+
+muparser:
+    ubuntu: ["libmuparser-dev"]
+
+nanobind-dev:
+    pip: ["nanobind"]
+    pip: ["nanobind"]
+
+nanoflann:
+    ubuntu:
+        default: ["libnanoflann-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+nasm:
+    ubuntu: ["nasm"]
+
+nbtscan:
+    ubuntu: ["nbtscan"]
+
+net-tools:
+    ubuntu: ["net-tools"]
+
+netcdf:
+    ubuntu: ["libnetcdf-dev"]
+
+netpbm:
+    ubuntu: ["libnetpbm10-dev"]
+
+network-manager:
+    ubuntu: ["network-manager"]
+
+ninja-build:
+    ubuntu: ["ninja-build"]
+
+nite-dev:
+    ubuntu: ["nite-dev"]
+
+nkf:
+    ubuntu: ["nkf"]
+
+nlohmann-json-dev:
+    ubuntu:
+        default: ["nlohmann-json3-dev"]
+        bionic: ["nlohmann-json-dev"]
+
+nmap:
+    ubuntu: ["nmap"]
+
+nodejs:
+    ubuntu: ["nodejs"]
+
+nodejs-legacy:
+    ubuntu: ["nodejs-legacy"]
+
+npm:
+    ubuntu: ["npm"]
+
+ntp:
+    ubuntu: ["ntp"]
+
+ntpdate:
+    ubuntu: ["ntpdate"]
+
+nvidia-cg:
+    ubuntu: ["nvidia-cg-toolkit"]
+
+nvidia-cuda:
+    ubuntu: ["nvidia-cuda-toolkit"]
+
+nvidia-cuda-dev:
+    ubuntu: ["nvidia-cuda-dev"]
+
+nvidia-cudnn:
+    ubuntu:
+        default: ["nvidia-cudnn"]
+        focal: nonexistent
+
+ocl-icd-opencl-dev:
+    ubuntu: ["ocl-icd-opencl-dev"]
+
+octave:
+    ubuntu: ["octave"]
+
+odb:
+    ubuntu:
+        default: ["odb"]
+
+omniidl:
+    ubuntu: ["omniidl", "omniorb-idl"]
+
+omniorb:
+    ubuntu: ["omniorb", "omniidl", "omniorb-idl", "omniorb-nameserver", "libomniorb4-dev"]
+
+opencascade:
+    ubuntu:
+        bionic: ["liboce-visualization-dev"]
+        focal: ["libocct-data-exchange-dev", "libocct-draw-dev"]
+
+opencl-headers:
+    ubuntu: ["opencl-headers"]
+
+opende:
+    ubuntu: ["libode-dev"]
+
+opengl:
+    ubuntu: ["libgl1-mesa-dev", "libglu1-mesa-dev"]
+
+openjdk-6-jdk:
+    ubuntu: ["openjdk-6-jdk"]
+
+openmpi:
+    ubuntu: []
+
+openni-dev:
+    ubuntu: ["libopenni-dev"]
+
+openocd:
+    ubuntu: ["openocd"]
+
+openssh-client:
+    ubuntu: ["openssh-client"]
+
+openssh-server:
+    ubuntu: ["openssh-server"]
+
+openssl:
+    ubuntu: ["openssl"]
+
+optipng:
+    ubuntu: ["optipng"]
+
+osm2pgsql:
+    ubuntu: ["osm2pgsql"]
+
+osmium:
+    ubuntu: ["libosmium2-dev"]
+
+pandoc:
+    ubuntu: ["pandoc"]
+
+patchelf:
+    ubuntu: ["patchelf"]
+
+pcre:
+    ubuntu: ["libpcre3-dev"]
+
+pcre-dev:
+    ubuntu: ["libpcre++-dev"]
+
+pcscd:
+    ubuntu: ["pcscd"]
+
+phantomjs:
+    ubuntu: ["phantomjs"]
+
+pigz:
+    ubuntu: ["pigz"]
+
+pkg-config:
+    ubuntu: ["pkg-config"]
+
+pmccabe:
+    ubuntu: ["pmccabe"]
+
+pmount:
+    ubuntu: ["pmount"]
+
+polyclipping-dev:
+    ubuntu: ["libpolyclipping-dev"]
+
+poppler-utils:
+    ubuntu: ["poppler-utils"]
+
+portaudio:
+    ubuntu: ["libportaudio-dev"]
+
+portaudio19-dev:
+    ubuntu: ["portaudio19-dev"]
+
+postfix:
+    ubuntu: ["postfix"]
+
+postgresql:
+    ubuntu: ["postgresql", "postgresql-contrib"]
+
+postgresql-client:
+    ubuntu: ["postgresql-client"]
+
+postgresql-postgis:
+    ubuntu:
+        bionic: ["postgresql-10-postgis-2.4", "postgresql-contrib", "postgresql-server-dev-all"]
+        focal: ["postgresql-12-postgis-3", "postgresql-contrib", "postgresql-server-dev-all"]
+
+potrace:
+    ubuntu: ["potrace"]
+
+powertop:
+    ubuntu: ["powertop"]
+
+procps:
+    ubuntu: ["procps"]
+
+proj:
+    ubuntu: ["libproj-dev"]
+
+protobuf:
+    ubuntu:
+        bionic: ["libprotobuf10"]
+        focal: ["libprotobuf17"]
+        jammy: ["libprotobuf23"]
+        noble: ["libprotobuf32"]
+
+protobuf-compiler-grpc:
+    ubuntu: ["protobuf-compiler-grpc"]
+
+protobuf-dev:
+    ubuntu: ["libprotobuf-dev", "protobuf-compiler", "libprotoc-dev"]
+
+ps-engine:
+    ubuntu: ["ps-engine"]
+
+psmisc:
+    ubuntu: ["psmisc"]
+
+pstoedit:
+    ubuntu: ["pstoedit"]
+
+psutils:
+    ubuntu: ["psutils"]
+
+pugixml-dev:
+    ubuntu: ["libpugixml-dev"]
+
+pybind11-dev:
+    ubuntu: ["pybind11-dev"]
+
+pybind11-json-dev:
+    ubuntu:
+        default: ["pybind11-json-dev"]
+        focal: nonexistent
+
+python-dev:
+    ubuntu:
+        default: ["python-dev"]
+        focal: ["python2-dev"]
+
+qemu-user-static:
+    ubuntu: ["qemu-user-static"]
+
+qhull-bin:
+    ubuntu: ["qhull-bin"]
+
+qml-module-qt-labs-folderlistmodel:
+    ubuntu: ["qml-module-qt-labs-folderlistmodel"]
+
+qml-module-qt-labs-platform:
+    ubuntu: ["qml-module-qt-labs-platform"]
+
+qml-module-qt-labs-settings:
+    ubuntu: ["qml-module-qt-labs-settings"]
+
+qml-module-qtcharts:
+    ubuntu: ["qml-module-qtcharts"]
+
+qml-module-qtgraphicaleffects:
+    ubuntu: ["qml-module-qtgraphicaleffects"]
+
+qml-module-qtlocation:
+    ubuntu: ["qml-module-qtlocation"]
+
+qml-module-qtmultimedia:
+    ubuntu: ["qml-module-qtmultimedia"]
+
+qml-module-qtpositioning:
+    ubuntu: ["qml-module-qtpositioning"]
+
+qml-module-qtquick-controls:
+    ubuntu: ["qml-module-qtquick-controls"]
+
+qml-module-qtquick-controls2:
+    ubuntu: ["qml-module-qtquick-controls2"]
+
+qml-module-qtquick-dialogs:
+    ubuntu: ["qml-module-qtquick-dialogs"]
+
+qml-module-qtquick-extras:
+    ubuntu: ["qml-module-qtquick-extras"]
+
+qml-module-qtquick-layouts:
+    ubuntu: ["qml-module-qtquick-layouts"]
+
+qml-module-qtquick-templates2:
+    ubuntu: ["qml-module-qtquick-templates2"]
+
+qml-module-qtquick-window2:
+    ubuntu: ["qml-module-qtquick-window2"]
+
+qml-module-qtquick2:
+    ubuntu: ["qml-module-qtquick2"]
+
+qrencode:
+    ubuntu: ["qrencode"]
+
+qt4-dev-tools:
+    ubuntu: ["qt4-dev-tools"]
+
+qt4-linguist-tools:
+    ubuntu:
+        default: nonexistent
+        bionic: ["qt4-linguist-tools"]
+
+qt4-qmake:
+    ubuntu: ["qt4-qmake"]
+
+qt5-image-formats-plugins:
+    ubuntu: ["qt5-image-formats-plugins"]
+
+qt5-qmake:
+    ubuntu: ["qt5-qmake"]
+
+qtbase5-dev:
+    ubuntu: ["qtbase5-dev"]
+
+qtbase5-private-dev:
+    ubuntu: ["qtbase5-private-dev"]
+
+qtdeclarative5-dev:
+    ubuntu: ["qtdeclarative5-dev"]
+
+qtmobility-dev:
+    ubuntu: ["qtmobility-dev"]
+
+qtmultimedia5-dev:
+    ubuntu: ["qtmultimedia5-dev"]
+
+qtpositioning5-dev:
+    ubuntu: ["qtpositioning5-dev"]
+
+qtquickcontrols2-5-dev:
+    ubuntu: ["qtquickcontrols2-5-dev"]
+
+qttools5-dev:
+    ubuntu: ["qttools5-dev"]
+
+qttools5-dev-tools:
+    ubuntu: ["qttools5-dev-tools"]
+
+qtwebengine5-dev:
+    ubuntu: ["qtwebengine5-dev"]
+
+r-base:
+    ubuntu: ["r-base"]
+
+r-base-dev:
+    ubuntu: ["r-base-dev"]
+
+range-v3:
+    ubuntu:
+        default: ["librange-v3-dev"]
+
+rapidjson-dev:
+    ubuntu: ["rapidjson-dev"]
+
+readline-dev:
+    ubuntu: ["libreadline-dev"]
+
+recode:
+    ubuntu: ["recode"]
+
+recordmydesktop:
+    ubuntu: ["recordmydesktop"]
+
+redis-server:
+    ubuntu: ["redis-server"]
+
+robin-map-dev:
+    ubuntu: ["robin-map-dev"]
+
+robotino-api2:
+    ubuntu: ["robotino-api2"]
+
+rsync:
+    ubuntu: ["rsync"]
+
+rsyslog:
+    ubuntu: ["rsyslog"]
+
+rt-tests:
+    ubuntu: ["rt-tests"]
+
+rti-connext-dds-5.3.1:
+    ubuntu:
+        bionic: ["rti-connext-dds-5.3.1"]
+        focal: ["rti-connext-dds-5.3.1"]
+
+rti-connext-dds-6.0.1:
+    ubuntu:
+        default: ["rti-connext-dds-6.0.1"]
+        bionic: nonexistent
+
+rtmidi:
+    ubuntu: ["librtmidi-dev"]
+
+rustc:
+    ubuntu: ["rustc"]
+
+sbcl:
+    ubuntu: ["sbcl"]
+
+scons:
+    ubuntu: ["scons"]
+
+screen:
+    ubuntu: ["screen"]
+
+sdformat:
+    ubuntu:
+        bionic: ["libsdformat6-dev"]
+        focal: ["libsdformat9-dev"]
+        jammy: ["libsdformat-dev"]
+
+sdformat11:
+    ubuntu:
+        focal: ["libsdformat11-dev"]
+
+sdformat12:
+    ubuntu:
+        focal: ["libsdformat12-dev"]
+        jammy: ["libsdformat12-dev"]
+
+sdl:
+    ubuntu: ["libsdl1.2-dev"]
+
+sdl-gfx:
+    ubuntu: ["libsdl-gfx1.2-dev"]
+
+sdl-image:
+    ubuntu: ["libsdl-image1.2-dev"]
+
+sdl-mixer:
+    ubuntu: ["libsdl-mixer1.2-dev"]
+
+sdl-ttf:
+    ubuntu: ["libsdl-ttf2.0-dev"]
+
+sdl2:
+    ubuntu: ["libsdl2-dev"]
+
+sdl2-image:
+    ubuntu: ["libsdl2-image-dev"]
+
+sdl2-mixer:
+    ubuntu: ["libsdl2-mixer-dev"]
+
+sdl2-ttf:
+    ubuntu: ["libsdl2-ttf-dev"]
+
+semgrep:
+    pip: ["semgrep"]
+
+setserial:
+    ubuntu: ["setserial"]
+
+sfml-dev:
+    ubuntu: ["libsfml-dev"]
+
+simde:
+    ubuntu:
+        default: ["libsimde-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+sixad:
+    ubuntu: ["sixad"]
+
+slime:
+    ubuntu: ["slime"]
+
+smartmontools:
+    ubuntu: ["smartmontools"]
+
+smbclient:
+    ubuntu: ["smbclient"]
+
+snappy:
+    ubuntu: ["libsnappy-dev"]
+
+socat:
+    ubuntu: ["socat"]
+
+sound-theme-freedesktop:
+    ubuntu: ["sound-theme-freedesktop"]
+
+sox:
+    ubuntu: ["sox"]
+
+spacenavd:
+    ubuntu: ["spacenavd"]
+
+sparsehash:
+    ubuntu: ["libsparsehash-dev"]
+
+spdlog:
+    ubuntu: ["libspdlog-dev"]
+
+speech-dispatcher:
+    ubuntu: ["speech-dispatcher"]
+
+spirv-headers:
+    ubuntu:
+        default: ["spirv-headers"]
+        bionic: nonexistent
+
+spirv-tools:
+    ubuntu:
+        default: ["spirv-tools"]
+        bionic: nonexistent
+
+sqlite3:
+    ubuntu: ["sqlite3"]
+
+ssh-askpass:
+    ubuntu: ["ssh-askpass"]
+
+ssh-askpass-gnome:
+    ubuntu: ["ssh-askpass-gnome"]
+
+sshpass:
+    ubuntu: ["sshpass"]
+
+stress:
+    ubuntu: ["stress"]
+
+stress-ng:
+    ubuntu: ["stress-ng"]
+
+subversion:
+    ubuntu: ["subversion"]
+
+suitesparse:
+    ubuntu: ["libsuitesparse-dev"]
+
+supervisor:
+    ubuntu: ["supervisor"]
+
+swi-prolog:
+    ubuntu: ["swi-prolog"]
+
+swi-prolog-java:
+    ubuntu: ["swi-prolog-java"]
+
+swi-prolog-odbc:
+    ubuntu: ["swi-prolog-odbc"]
+
+swig:
+    ubuntu: ["swig"]
+
+sysbench:
+    ubuntu: ["sysbench"]
+
+sysstat:
+    ubuntu: ["sysstat"]
+
+systemd:
+    ubuntu: ["systemd"]
+
+tango-icon-theme:
+    ubuntu: ["tango-icon-theme"]
+
+tar:
+    ubuntu: ["libtar-dev"]
+
+tbb:
+    ubuntu: ["libtbb-dev"]
+
+tcsh:
+    ubuntu: ["tcsh"]
+
+terminator:
+    ubuntu: ["terminator"]
+
+tesseract-ocr:
+    ubuntu: ["tesseract-ocr"]
+
+tesseract-ocr-jpn:
+    ubuntu: ["tesseract-ocr-jpn"]
+
+texlive-fonts-extra:
+    ubuntu: ["texlive-fonts-extra"]
+
+texlive-fonts-recommended:
+    ubuntu: ["texlive-fonts-recommended"]
+
+texlive-full:
+    ubuntu: ["texlive-full"]
+
+texlive-latex-base:
+    ubuntu: ["texlive-latex-base"]
+
+texlive-latex-extra:
+    ubuntu: ["texlive-latex-extra"]
+
+texlive-latex-recommended:
+    ubuntu: ["texlive-latex-recommended"]
+
+texmaker:
+    ubuntu: ["texmaker"]
+
+tiled:
+    ubuntu: ["tiled"]
+
+time:
+    ubuntu: ["time"]
+
+tinyxml:
+    ubuntu: ["libtinyxml-dev"]
+
+tinyxml2:
+    ubuntu: ["libtinyxml2-dev"]
+
+tix:
+    ubuntu: ["tix"]
+
+tmux:
+    ubuntu: ["tmux"]
+
+touchegg:
+    ubuntu: ["touchegg"]
+
+trang:
+    ubuntu: ["trang"]
+
+tree:
+    ubuntu: ["tree"]
+
+tshark:
+    ubuntu: ["tshark"]
+
+ttf-kochi-gothic:
+    ubuntu: ["ttf-kochi-gothic"]
+
+ttf-kochi-mincho:
+    ubuntu: ["ttf-kochi-mincho"]
+
+ttf-sazanami-gothic:
+    ubuntu: ["ttf-sazanami-gothic"]
+
+ttf-sazanami-mincho:
+    ubuntu: ["ttf-sazanami-mincho"]
+
+udev:
+    ubuntu: ["udev"]
+
+udhcpc:
+    ubuntu: ["udhcpc"]
+
+unclutter:
+    ubuntu: ["unclutter"]
+
+uncrustify:
+    ubuntu: ["uncrustify"]
+
+unison:
+    ubuntu: ["unison"]
+
+unison-gui:
+    ubuntu: ["unison-gtk"]
+
+unoconv:
+    ubuntu: ["unoconv"]
+
+unrar:
+    ubuntu: ["unrar"]
+
+unzip:
+    ubuntu: ["unzip"]
+
+usbutils:
+    ubuntu: ["usbutils"]
+
+util-linux:
+    ubuntu:
+        default: ["util-linux"]
+        bionic: ["setpriv", "util-linux"]
+
+uuid:
+    ubuntu: ["uuid-dev"]
+
+uvcdynctrl:
+    ubuntu: ["uvcdynctrl"]
+
+v4l-utils:
+    ubuntu: ["v4l-utils"]
+
+valgrind:
+    ubuntu: ["valgrind"]
+
+vim:
+    ubuntu: ["vim"]
+
+vlc:
+    ubuntu: ["vlc"]
+
+vorbis-tools:
+    ubuntu: ["vorbis-tools"]
+
+wayland:
+    ubuntu: ["libwayland-client0", "libwayland-cursor0", "libwayland-egl1"]
+
+wayland-dev:
+    ubuntu: ["libwayland-dev", "wayland-protocols"]
+
+wget:
+    ubuntu: ["wget"]
+
+wireguard:
+    ubuntu:
+        default: ["wireguard"]
+        bionic: nonexistent
+
+wireless-tools:
+    ubuntu: ["wireless-tools"]
+
+wireshark:
+    ubuntu: ["wireshark"]
+
+wireshark-common:
+    ubuntu: ["wireshark-common"]
+
+wkhtmltopdf:
+    ubuntu: ["wkhtmltopdf"]
+
+wmctrl:
+    ubuntu: ["wmctrl"]
+
+workrave:
+    ubuntu: ["workrave", "workrave-data"]
+
+wx-common:
+    ubuntu: ["wx-common"]
+
+wxwidgets:
+    ubuntu:
+        default: ["libwxgtk3.2-dev"]
+        bionic: ["libwxgtk3.0-dev"]
+        focal: ["libwxgtk3.0-gtk3-dev"]
+        jammy: ["libwxgtk3.0-gtk3-dev"]
+
+x11proto-dri2-dev:
+    ubuntu: ["x11proto-dri2-dev"]
+
+x11proto-gl-dev:
+    ubuntu: ["x11proto-gl-dev"]
+
+x11proto-print-dev:
+    ubuntu: ["x11proto-print-dev"]
+
+xclip:
+    ubuntu: ["xclip"]
+
+xdg-utils:
+    ubuntu: ["xdg-utils"]
+
+xdotool:
+    ubuntu: ["xdotool"]
+
+xerces:
+    ubuntu: ["libxerces-c-dev"]
+
+xfonts-100dpi:
+    ubuntu: ["xfonts-100dpi"]
+
+xfonts-75dpi:
+    ubuntu: ["xfonts-75dpi"]
+
+xpath-perl:
+    ubuntu: ["libxml-xpath-perl"]
+
+xsimd:
+    ubuntu:
+        default: ["libxsimd-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+xsltproc:
+    ubuntu: ["xsltproc"]
+
+xtensor:
+    ubuntu:
+        default: ["libxtensor-dev"]
+        focal: nonexistent
+
+xterm:
+    ubuntu: ["xterm"]
+
+xulrunner-1.9.2:
+    ubuntu:
+        karmic: ["xulrunner-1.9.2"]
+
+xulrunner-dev:
+    ubuntu: ["libv8-dev"]
+
+xvfb:
+    ubuntu: ["xvfb"]
+
+xz-utils:
+    ubuntu: ["xz-utils"]
+
+yaml:
+    ubuntu: ["libyaml-dev"]
+
+yaml-cpp:
+    ubuntu: ["libyaml-cpp-dev"]
+
+yamllint:
+    ubuntu: ["yamllint"]
+
+yarn:
+    ubuntu:
+        default: ["yarnpkg"]
+        bionic: nonexistent
+
+yasm:
+    ubuntu: ["yasm"]
+
+zbar:
+    ubuntu: ["libzbar-dev"]
+
+zenity:
+    ubuntu: ["zenity"]
+
+zeromq3:
+    ubuntu: ["libzmq5"]
+
+zip:
+    ubuntu: ["zip"]
+
+zlib:
+    ubuntu: ["zlib1g-dev"]
+
+zsh:
+    ubuntu: ["zsh"]
+
+zziplib:
+    ubuntu: ["libzzip-dev"]
+
+adafruit-ads1x15-pip:
+    pip: ["Adafruit-ADS1x15"]
+
+adafruit-gpio-pip:
+    pip: ["Adafruit-GPIO"]
+
+adafruit-mcp3008-pip:
+    pip: ["Adafruit-MCP3008"]
+
+adafruit-pca9685-pip:
+    pip: ["adafruit-pca9685"]
+
+autograd-pip:
+    pip: ["autograd"]
+
+autolab-core-pip:
+    pip: ["autolab-core"]
+
+autolab-perception-pip:
+    pip: ["autolab_perception"]
+
+autolab-visualization-pip:
+    pip: ["visualization"]
+
+awsiotpythonsdk-pip:
+    pip: ["awsiotpythonsdk"]
+
+azure-core-pip:
+    pip: ["azure-core"]
+
+azure-iothub-device-client-pip:
+    pip: ["azure-iothub-device-client"]
+
+azure-mgmt-storage-pip:
+    pip: ["azure-mgmt-storage"]
+
+azure-storage-file-share-pip:
+    pip: ["azure-storage-file-share"]
+
+black:
+    ubuntu:
+        default: ["black"]
+        bionic: nonexistent
+
+canopen-pip:
+    pip: ["canopen"]
+
+carla-pip:
+    pip: ["carla"]
+
+casadi-pip:
+    pip: ["casadi"]
+
+cmakelint-pip:
+    pip: ["cmakelint"]
+
+cppcheck-junit-pip:
+    pip: ["cppcheck-junit"]
+
+cython:
+    ubuntu: ["cython"]
+
+cython3:
+    ubuntu: ["cython3"]
+
+dpath-pip:
+    pip: ["dpath"]
+
+ds4drv-pip:
+    pip: ["ds4drv"]
+
+epydoc:
+    ubuntu: ["python-epydoc"]
+
+exhale-pip:
+    pip: ["exhale"]
+
+gunicorn:
+    ubuntu: ["gunicorn"]
+
+gym-pip:
+    pip: ["gym"]
+
+imgaug-pip:
+    pip: ["imgaug"]
+
+intelhex-pip:
+    pip: ["intelhex"]
+
+ipython:
+    ubuntu: ["ipython"]
+
+ipython3:
+    ubuntu: ["ipython3"]
+
+jupyter-nbconvert:
+    ubuntu:
+        default: ["jupyter-nbconvert"]
+
+jupyter-notebook:
+    ubuntu:
+        default: ["jupyter-notebook"]
+
+libgv-python:
+    ubuntu: ["libgv-python"]
+
+libshiboken2-dev:
+    ubuntu: ["libshiboken2-dev"]
+
+mcap-ros2-support:
+    pip: ["mcap-ros2-support"]
+
+meson:
+    ubuntu: ["meson"]
+
+nuitka:
+    ubuntu: ["nuitka"]
+
+onvif_zeep:
+    pip: ["onvif_zeep"]
+
+opcua-pip:
+    pip: ["opcua"]
+
+paramiko:
+    ubuntu: ["python-paramiko"]
+
+pi-ina219-pip:
+    pip: ["pi-ina219"]
+
+pika:
+    ubuntu: ["python-pika"]
+
+pydocstyle:
+    ubuntu: ["pydocstyle"]
+
+pydrive-pip:
+    pip: ["PyDrive"]
+
+pyflakes3:
+    ubuntu: ["pyflakes3"]
+
+pymap3d-pip:
+    pip: ["pymap3d"]
+    pip: ["pymap3d"]
+
+pymodbustcp-pip:
+    pip: ["pyModbusTCP"]
+
+pynput-pip:
+    pip: ["pynput"]
+
+pyosmium:
+    ubuntu: ["python-pyosmium"]
+
+pyper-pip:
+    pip: ["pyper"]
+
+pyqt4-dev-tools:
+    ubuntu: ["pyqt4-dev-tools"]
+
+pyqt5-dev-tools:
+    ubuntu: ["pyqt5-dev-tools"]
+
+pyqt6-dev-tools:
+    ubuntu:
+        default: ["pyqt6-dev-tools"]
+        focal: nonexistent
+        jammy: nonexistent
+
+pyrebase-pip:
+    pip: ["pyrebase"]
+
+pyro4:
+    ubuntu: ["python2-pyro4"]
+
+pyros-setup-pip:
+    pip: ["pyros-setup"]
+
+pyside-tools:
+    ubuntu: ["pyside-tools"]
+
+python:
+    ubuntu:
+        bionic: ["python-dev"]
+
+python-absl-py-pip:
+    pip: ["absl-py"]
+
+python-adafruit-bno055-pip:
+    pip: ["adafruit_bno055"]
+
+python-alembic:
+    ubuntu:
+        default: ["python-alembic"]
+
+python-amqp:
+    ubuntu: ["python-amqp"]
+
+python-aniso8601:
+    ubuntu:
+        bionic: ["python-aniso8601"]
+
+python-annoy-pip:
+    pip: ["annoy"]
+
+python-anyjson:
+    ubuntu: ["python-anyjson"]
+
+python-apparmor:
+    ubuntu: ["python-apparmor"]
+
+python-argcomplete:
+    ubuntu: ["python-argcomplete"]
+
+python-argh:
+    ubuntu: ["python-argh"]
+
+python-argparse:
+    ubuntu:
+        default: []
+
+python-astor-pip:
+    pip: ["astor"]
+
+python-attrs:
+    ubuntu:
+        bionic: ["python-attr"]
+        focal: ["python-attr"]
+
+python-autobahn:
+    ubuntu:
+        default: ["python-autobahn"]
+
+python-avahi:
+    ubuntu: ["python-avahi"]
+
+python-babel:
+    ubuntu: ["python-babel"]
+
+python-backoff-pip:
+    pip: ["backoff"]
+
+python-backports.ssl-match-hostname:
+    ubuntu:
+        bionic: ["python-backports.ssl-match-hostname"]
+
+python-bcrypt:
+    ubuntu: ["python-bcrypt"]
+
+python-beautifulsoup:
+    ubuntu: ["python-beautifulsoup"]
+
+python-bitarray:
+    ubuntu: ["python-bitarray"]
+
+python-bitstring:
+    ubuntu:
+        bionic: ["python-bitstring"]
+
+python-bitstring-pip:
+    pip: ["bitstring"]
+
+python-blinker:
+    ubuntu: ["python-blinker"]
+
+python-bloom:
+    ubuntu:
+        default: ["python-bloom"]
+
+python-bluez:
+    ubuntu: ["python-bluez"]
+
+python-bokeh-pip:
+    pip: ["bokeh"]
+
+python-boltons:
+    ubuntu:
+        default: ["python-boltons"]
+
+python-boto3:
+    ubuntu:
+        default: ["python-boto3"]
+
+python-bottle:
+    ubuntu: ["python-bottle"]
+
+python-box2d:
+    ubuntu: ["python-box2d"]
+
+python-breathe:
+    ubuntu: ["python-breathe"]
+
+python-bs4:
+    ubuntu: ["python-bs4"]
+
+python-bson:
+    ubuntu: ["python-bson"]
+
+python-cairo:
+    ubuntu: ["python-cairo"]
+
+python-cairosvg:
+    ubuntu: ["python-cairosvg"]
+
+python-can:
+    ubuntu:
+        bionic: ["python-can"]
+
+python-cantools-pip:
+    pip: ["cantools"]
+
+python-catkin-lint:
+    ubuntu: ["python-catkin-lint"]
+
+python-catkin-pkg:
+    ubuntu:
+        bionic: ["python-catkin-pkg"]
+
+python-catkin-pkg-modules:
+    ubuntu: ["python-catkin-pkg-modules"]
+
+python-catkin-sphinx:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-catkin-sphinx"]
+
+python-catkin-tools:
+    ubuntu: ["python-catkin-tools"]
+
+python-cbor:
+    ubuntu: ["python-cbor"]
+
+python-celery:
+    ubuntu: ["python-celery"]
+
+python-certifi:
+    ubuntu:
+        bionic: ["python-certifi"]
+
+python-chainer-mask-rcnn-pip:
+    pip: ["chainer-mask-rcnn"]
+
+python-chainer-pip:
+    pip: ["chainer"]
+
+python-chainercv-pip:
+    pip: ["chainercv"]
+
+python-cheetah:
+    ubuntu: ["python-cheetah"]
+
+python-cherrypy:
+    ubuntu: ["python-cherrypy3"]
+
+python-clearsilver:
+    ubuntu: ["python-clearsilver"]
+
+python-click:
+    ubuntu:
+        bionic: ["python-click"]
+
+python-cobs-pip:
+    pip: ["cobs"]
+
+python-collada:
+    ubuntu: ["python-collada"]
+
+python-colorama:
+    ubuntu: ["python-colorama"]
+
+python-concurrent.futures:
+    ubuntu: ["python-concurrent.futures"]
+
+python-configparser:
+    ubuntu: ["python-configparser"]
+
+python-construct:
+    ubuntu:
+        bionic: ["python-construct"]
+
+python-construct-pip:
+    pip: ["construct"]
+
+python-control-pip:
+    pip: ["control"]
+
+python-cookiecutter:
+    ubuntu: ["python-cookiecutter"]
+
+python-cookiecutter-pip:
+    pip: ["cookiecutter"]
+
+python-couchdb:
+    ubuntu: ["python-couchdb"]
+
+python-coverage:
+    ubuntu:
+        bionic: ["python-coverage"]
+
+python-cpplint:
+    pip: ["cpplint"]
+
+python-crccheck-pip:
+    pip: ["crccheck"]
+
+python-crcmod:
+    ubuntu:
+        bionic: ["python-crcmod"]
+
+python-crypto:
+    ubuntu:
+        bionic: ["python-crypto"]
+
+python-cryptography:
+    ubuntu: ["python-cryptography"]
+
+python-cvxopt:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-cvxopt"]
+
+python-cvxpy-pip:
+    pip: ["cvxpy"]
+
+python-cwiid:
+    ubuntu: ["python-cwiid"]
+
+python-cython-pip:
+    pip: ["cython"]
+
+python-datadog-pip:
+    pip: ["datadog"]
+
+python-dateutil:
+    ubuntu: ["python-dateutil"]
+
+python-deap-pip:
+    pip: ["deap"]
+
+python-debian:
+    ubuntu:
+        bionic: ["python-debian"]
+
+python-decorator:
+    ubuntu: ["python-decorator"]
+
+python-deepdiff-pip:
+    pip: ["deepdiff"]
+
+python-defer-pip:
+    pip: ["defer"]
+
+python-defusedxml:
+    ubuntu: ["python-defusedxml"]
+
+python-dialogflow-pip:
+    pip: ["dialogflow"]
+
+python-django:
+    ubuntu: ["python-django"]
+
+python-django-cors-headers:
+    ubuntu: ["python-django-cors-headers"]
+
+python-django-extensions:
+    ubuntu: ["python-django-extensions"]
+
+python-django-extra-views:
+    ubuntu: ["python-django-extra-views"]
+
+python-djangorestframework:
+    ubuntu: ["python-djangorestframework"]
+
+python-dlib:
+    pip: ["dlib"]
+
+python-docker:
+    ubuntu: ["python-docker"]
+
+python-docopt:
+    ubuntu: ["python-docopt"]
+
+python-docutils:
+    ubuntu:
+        bionic: ["python-docutils"]
+
+python-docx:
+    pip: ["python-docx"]
+
+python-dt-apriltags-pip:
+    pip: ["dt-apriltags"]
+
+python-dxfgrabber-pip:
+    pip: ["dxfgrabber"]
+
+python-easygui:
+    ubuntu: ["python-easygui"]
+
+python-elasticsearch:
+    ubuntu:
+        bionic: ["python-elasticsearch"]
+
+python-empy:
+    ubuntu: ["python-empy"]
+
+python-enum:
+    ubuntu: ["python-enum"]
+
+python-enum34:
+    ubuntu: ["python-enum34"]
+
+python-enum34-pip:
+    pip: ["enum34"]
+
+python-evdev:
+    ubuntu: ["python-evdev"]
+
+python-expiringdict:
+    ubuntu: ["python-expiringdict"]
+
+python-face-alignment-pip:
+    pip: ["face-alignment"]
+
+python-face-recognition-pip:
+    pip: ["face_recognition"]
+
+python-falcon:
+    ubuntu: ["python-falcon"]
+
+python-fastdtw-pip:
+    pip: ["python-fastdtw"]
+
+python-fcl-pip:
+    pip: ["python-fcl"]
+
+python-fcn-pip:
+    pip: ["fcn"]
+
+python-filterpy-pip:
+    pip: ["filterpy"]
+
+python-fixtures:
+    ubuntu: ["python-fixtures"]
+
+python-flake8:
+    ubuntu:
+        bionic: ["python-flake8"]
+
+python-flask:
+    ubuntu:
+        default: ["python-flask"]
+
+python-flask-appbuilder-pip:
+    pip: ["flask-appbuilder"]
+
+python-flask-cors-pip:
+    pip: ["flask-cors"]
+
+python-flatdict-pip:
+    pip: ["flatdict"]
+
+python-freezegun-pip:
+    pip: ["freezegun"]
+
+python-frozendict:
+    ubuntu: ["python-frozendict"]
+
+python-ftdi1:
+    ubuntu: ["python-ftdi1"]
+
+python-funcsigs:
+    ubuntu: ["python-funcsigs"]
+
+python-future:
+    ubuntu:
+        bionic: ["python-future"]
+
+python-fuzzywuzzy-pip:
+    pip: ["fuzzywuzzy"]
+
+python-fysom:
+    pip: ["fysom"]
+
+python-gTTS-pip:
+    pip: ["gTTS"]
+
+python-gcloud-pip:
+    pip: ["gcloud"]
+
+python-gdal:
+    ubuntu:
+        bionic: ["python-gdal"]
+
+python-gdown-pip:
+    pip: ["gdown"]
+
+python-genshi:
+    ubuntu: ["python-genshi"]
+
+python-geocoder-pip:
+    pip: ["geocoder"]
+
+python-geographiclib:
+    ubuntu: ["python-geographiclib"]
+
+python-geopy:
+    ubuntu: ["python-geopy"]
+
+python-gevent:
+    ubuntu: ["python-gevent"]
+
+python-gi:
+    ubuntu: ["python-gi"]
+
+python-gi-cairo:
+    ubuntu: ["python-gi-cairo"]
+
+python-git:
+    ubuntu: ["python-git"]
+
+python-github-pip:
+    pip: ["PyGithub"]
+
+python-gitlab:
+    ubuntu:
+        bionic: ["python-gitlab"]
+
+python-gitpython-pip:
+    pip: ["gitpython"]
+
+python-glpk-pip:
+    pip: ["glpk"]
+
+python-gnupg:
+    ubuntu: ["python-gnupg"]
+
+python-gobject:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-gobject"]
+        focal: ["python-gobject"]
+
+python-google-cloud-bigquery-pip:
+    pip: ["google-cloud-bigquery"]
+
+python-google-cloud-speech-pip:
+    pip: ["google-cloud-speech"]
+
+python-google-cloud-storage-pip:
+    pip: ["google-cloud-storage"]
+
+python-google-cloud-texttospeech-pip:
+    pip: ["google-cloud-texttospeech"]
+
+python-google-cloud-vision-pip:
+    pip: ["google-cloud-vision"]
+
+python-googleapi:
+    ubuntu:
+        bionic: ["python-googleapi"]
+
+python-gpiozero:
+    ubuntu:
+        bionic: ["python-gpiozero"]
+
+python-gputil-pip:
+    pip: ["gputil"]
+
+python-gpxpy:
+    ubuntu:
+        bionic: ["python-gpxpy"]
+
+python-graphitesend-pip:
+    pip: ["graphitesend"]
+
+python-graphviz-pip:
+    pip: ["graphviz"]
+
+python-grpc-tools:
+    pip: ["grpcio-tools"]
+
+python-grpcio:
+    pip: ["grpcio"]
+
+python-gst-1.0:
+    ubuntu: ["python-gst-1.0"]
+
+python-gtk2:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-gtk2"]
+
+python-gurobipy-pip:
+    pip: ["gurobipy"]
+
+python-h5py:
+    ubuntu:
+        default: ["python-h5py"]
+
+python-httplib2:
+    ubuntu:
+        default: ["python-httplib2"]
+
+python-hypothesis:
+    ubuntu:
+        default: ["python-hypothesis"]
+
+python-imageio:
+    ubuntu:
+        bionic: ["python-imageio"]
+
+python-imaging:
+    ubuntu:
+        default: ["python-pil"]
+
+python-imaging-imagetk:
+    ubuntu: ["python-pil.imagetk"]
+
+python-impacket:
+    ubuntu: ["python-impacket"]
+
+python-influxdb:
+    ubuntu:
+        bionic: ["python-influxdb"]
+
+python-inject-pip:
+    pip: ["inject"]
+
+python-inotify-simple-pip:
+    pip: ["inotify-simple"]
+
+python-inputs-pip:
+    pip: ["inputs"]
+
+python-ipdb:
+    ubuntu: ["python-ipdb"]
+
+python-is-python3:
+    ubuntu:
+        default: ["python-is-python3"]
+        bionic: nonexistent
+
+python-itsdangerous:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-itsdangerous"]
+
+python-j1939-pip:
+    pip: ["j1939"]
+
+python-jasmine-pip:
+    pip: ["jasmine"]
+
+python-jetson-gpio-pip:
+    pip: ["Jetson.GPIO"]
+
+python-jetson-stats-pip:
+    pip: ["jetson-stats"]
+
+python-jinja2:
+    ubuntu: ["python-jinja2"]
+
+python-jira-pip:
+    pip: ["jira"]
+
+python-jmespath:
+    ubuntu: ["python-jmespath"]
+
+python-joblib:
+    ubuntu: ["python-joblib"]
+
+python-jsonpickle:
+    ubuntu: ["python-jsonpickle"]
+
+python-jsonpyes-pip:
+    pip: ["jsonpyes"]
+
+python-jsonref-pip:
+    pip: ["jsonref"]
+
+python-jsonschema:
+    ubuntu: ["python-jsonschema"]
+
+python-jsonschema-pip:
+    pip: ["jsonschema"]
+
+python-jwt:
+    ubuntu: ["python-jwt"]
+
+python-kdtree:
+    pip: ["kdtree"]
+
+python-keras-pip:
+    pip: ["keras"]
+
+python-keras-rl-pip:
+    pip: ["keras-rl"]
+
+python-kitchen:
+    ubuntu: ["python-kitchen"]
+
+python-kml:
+    ubuntu: ["python-kml"]
+
+python-kombu:
+    ubuntu: ["python-kombu"]
+
+python-kombu-pip:
+    pip: ["kombu"]
+
+python-levenshtein:
+    ubuntu: ["python-levenshtein"]
+
+python-libpcap:
+    ubuntu: ["python-libpcap"]
+
+python-libpgm-pip:
+    pip: ["libpgm"]
+
+python-librabbitmq-pip:
+    pip: ["librabbitmq"]
+
+python-lindypy-pip:
+    pip: ["lindypy"]
+
+python-lttngust:
+    pip: ["python-lttngust"]
+
+python-luis-pip:
+    pip: ["luis"]
+
+python-lxml:
+    ubuntu:
+        bionic: ["python-lxml"]
+        focal: ["python-lxml"]
+
+python-lzf-pip:
+    pip: ["python-lzf"]
+
+python-mahotas:
+    pip: ["mahotas"]
+
+python-mako:
+    ubuntu: ["python-mako"]
+
+python-mapnik:
+    ubuntu: ["python-mapnik"]
+
+python-marisa:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-marisa"]
+
+python-markdown:
+    ubuntu: ["python-markdown"]
+
+python-marshmallow:
+    pip: ["marshmallow"]
+
+python-math3d-pip:
+    pip: ["math3d"]
+
+python-matplotlib:
+    ubuntu:
+        bionic: ["python-matplotlib"]
+
+python-mechanize:
+    ubuntu: ["python-mechanize"]
+
+python-mistune:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-mistune"]
+
+python-mock:
+    ubuntu:
+        bionic: ["python-mock"]
+
+python-monotonic:
+    ubuntu: ["python-monotonic"]
+
+python-more-itertools:
+    ubuntu:
+        default: ["python-more-itertools"]
+
+python-msgpack:
+    ubuntu: ["python-msgpack"]
+
+python-multicast:
+    pip: ["py-multicast"]
+
+python-multiprocess-pip:
+    pip: ["multiprocess"]
+
+python-mysqldb:
+    ubuntu: ["python-mysqldb"]
+
+python-namedlist-pip:
+    pip: ["namedlist"]
+
+python-nclib-pip:
+    pip: ["nclib"]
+
+python-netaddr:
+    ubuntu:
+        bionic: ["python-netaddr"]
+
+python-netcdf4:
+    ubuntu: ["python-netcdf4"]
+
+python-netifaces:
+    ubuntu:
+        bionic: ["python-netifaces"]
+
+python-networkmanager:
+    ubuntu: ["python-networkmanager"]
+
+python-networkx:
+    ubuntu:
+        default: ["python-networkx"]
+
+python-nose:
+    ubuntu:
+        default: ["python-nose"]
+
+python-ntplib:
+    ubuntu: ["python-ntplib"]
+
+python-numpy:
+    ubuntu:
+        bionic: ["python-numpy"]
+        focal: ["python-numpy"]
+
+python-numpy-quaternion-pip:
+    pip: ["numpy-quaternion"]
+
+python-numpy-stl-pip:
+    pip: ["numpy-stl"]
+
+python-numpydoc:
+    ubuntu: ["python-numpydoc"]
+
+python-oauth2client:
+    ubuntu: ["python-oauth2client"]
+
+python-objectpath-pip:
+    pip: ["objectpath"]
+
+python-omniorb:
+    ubuntu:
+        focal: ["python-omniorb", "python-omniorb-omg", "omniidl-python"]
+
+python-open3d-pip:
+    pip: ["open3d-python"]
+
+python-opencv:
+    ubuntu: ["python-opencv"]
+
+python-opencv-contrib-pip:
+    pip: ["opencv-contrib-python"]
+
+python-opengl:
+    ubuntu:
+        bionic: ["python-opengl"]
+
+python-openssl:
+    ubuntu: ["python-openssl"]
+
+python-oyaml-pip:
+    pip: ["oyaml"]
+
+python-packaging:
+    ubuntu: ["python-packaging"]
+
+python-paho-mqtt:
+    ubuntu:
+        bionic: ["python-paho-mqtt"]
+
+python-paho-mqtt-pip:
+    pip: ["paho-mqtt"]
+
+python-pandacan-pip:
+    pip: ["pandacan"]
+
+python-pandas:
+    ubuntu: ["python-pandas"]
+
+python-parameterized:
+    ubuntu:
+        bionic: ["python-parameterized"]
+
+python-paramiko:
+    ubuntu: ["python-paramiko"]
+
+python-parse:
+    ubuntu: ["python-parse"]
+
+python-parso:
+    ubuntu:
+        bionic: ["python-parso"]
+
+python-passlib:
+    ubuntu: ["python-passlib"]
+
+python-pastedeploy:
+    ubuntu: ["python-pastedeploy"]
+
+python-path.py:
+    pip: ["path.py"]
+
+python-pathlib:
+    ubuntu: ["python-pathlib"]
+
+python-pathlib2:
+    ubuntu:
+        default: ["python-pathlib2"]
+
+python-pathos-pip:
+    pip: ["pathos"]
+
+python-pbr:
+    ubuntu: ["python-pbr"]
+
+python-pcapy:
+    ubuntu: ["python-pcapy"]
+
+python-pcg-gazebo-pip:
+    pip: ["pcg-gazebo"]
+
+python-pep8:
+    ubuntu:
+        default: ["python-pep8"]
+
+python-percol:
+    pip: ["percol"]
+
+python-periphery-pip:
+    pip: ["python-periphery"]
+
+python-persist-queue-pip:
+    pip: ["persist-queue"]
+
+python-pexpect:
+    ubuntu: ["python-pexpect"]
+
+python-pip:
+    ubuntu: ["python-pip"]
+
+python-pixel-ring-pip:
+    pip: ["pixel-ring"]
+
+python-pkg-resources:
+    ubuntu: ["python-pkg-resources"]
+
+python-planar-pip:
+    pip: ["planar"]
+
+python-plyfile-pip:
+    pip: ["plyfile"]
+
+python-poster:
+    ubuntu: ["python-poster"]
+
+python-pqdict-pip:
+    pip: ["pqdict"]
+
+python-prettytable:
+    ubuntu: ["python-prettytable"]
+
+python-progressbar:
+    ubuntu:
+        bionic: ["python-progressbar"]
+
+python-progressbar2-pip:
+    pip: ["progressbar2"]
+
+python-protobuf:
+    ubuntu: ["python-protobuf"]
+
+python-psutil:
+    ubuntu:
+        default: ["python-psutil"]
+
+python-pulsectl-pip:
+    pip: ["pulsectl"]
+
+python-pyassimp:
+    ubuntu:
+        bionic: ["python-pyassimp"]
+
+python-pyaudio:
+    ubuntu: ["python-pyaudio"]
+
+python-pycodestyle:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-pycodestyle"]
+
+python-pycpd-pip:
+    pip: ["pycpd"]
+
+python-pycryptodome:
+    ubuntu: ["python-pycryptodome"]
+
+python-pycurl:
+    ubuntu: ["python-pycurl"]
+
+python-pydbus:
+    ubuntu:
+        bionic: ["python-pydbus"]
+
+python-pydot:
+    ubuntu: ["python-pydot"]
+
+python-pyexiv2:
+    ubuntu: ["python-pyexiv2"]
+
+python-pyftpdlib:
+    ubuntu: ["python-pyftpdlib"]
+
+python-pygame:
+    ubuntu: ["python-pygame"]
+
+python-pygithub3:
+    pip: ["pygithub3"]
+
+python-pygps-pip:
+    pip: ["pyGPs"]
+
+python-pygraph:
+    ubuntu: ["python-pygraph"]
+
+python-pygraphviz:
+    ubuntu: ["python-pygraphviz"]
+
+python-pyinotify:
+    ubuntu: ["python-pyinotify"]
+
+python-pykalman:
+    pip: ["pykalman"]
+
+python-pylibftdi-pip:
+    pip: ["pylibftdi"]
+
+python-pylint:
+    ubuntu: ["pylint"]
+
+python-pylint3:
+    ubuntu:
+        default: ["pylint"]
+        bionic: ["pylint3"]
+
+python-pymavlink:
+    pip: ["pymavlink"]
+
+python-pymodbus:
+    ubuntu:
+        bionic: ["python-pymodbus"]
+
+python-pymodbus-pip:
+    pip: ["pymodbus"]
+
+python-pymongo:
+    ubuntu:
+        default: ["python-pymongo"]
+
+python-pymouse:
+    pip: ["pymouse"]
+
+python-pynfft:
+    ubuntu: ["python-pynfft"]
+
+python-pynmea2:
+    pip: ["pynmea2"]
+
+python-pypcd-pip:
+    pip: ["pypcd"]
+
+python-pypng:
+    ubuntu:
+        bionic: ["python-png"]
+
+python-pypozyx-pip:
+    pip: ["pypozyx"]
+
+python-pyproj:
+    ubuntu: ["python-pyproj"]
+
+python-pyqrcode:
+    ubuntu:
+        bionic: ["python-pyqrcode"]
+
+python-pyqtgraph:
+    ubuntu:
+        bionic: ["python-pyqtgraph"]
+
+python-pyquery:
+    ubuntu: ["python-pyquery"]
+
+python-pyramid:
+    ubuntu: ["python-pyramid"]
+
+python-pyrealsense2-pip:
+    pip: ["pyrealsense2"]
+
+python-pysimplegui27-pip:
+    pip: ["pysimplegui27"]
+
+python-pysnmp:
+    ubuntu: ["python-pysnmp4"]
+
+python-pytesseract-pip:
+    pip: ["pytesseract"]
+
+python-pytest:
+    ubuntu: ["python-pytest"]
+
+python-pytest-cov:
+    ubuntu: ["python-pytest-cov"]
+
+python-pytest-dependency-pip:
+    pip: ["pytest-dependency"]
+
+python-pytest-mock:
+    ubuntu: ["python-pytest-mock"]
+
+python-pytest-qt-pip:
+    pip: ["pytest-qt"]
+
+python-pytides-pip:
+    pip: ["pytides"]
+
+python-pytorch-pip:
+    pip: ["torch", "torchvision"]
+
+python-pytz-pip:
+    pip: ["pytz"]
+
+python-pyudev:
+    ubuntu:
+        default: ["python-pyudev"]
+
+python-pyusb-pip:
+    pip: ["pyusb"]
+
+python-pyuserinput:
+    pip: ["PyUserInput"]
+
+python-pyvirtualdisplay-pip:
+    pip: ["pyvirtualdisplay"]
+
+python-pyxhook-pip:
+    pip: ["pyxhook"]
+
+python-pyzbar-pip:
+    pip: ["pyzbar"]
+
+python-qrencode:
+    ubuntu: ["python-qrencode"]
+
+python-qt-bindings:
+    ubuntu:
+        default: ["python-pyside", "libpyside-dev", "libshiboken-dev", "shiboken", "python-qt4", "python-qt4-dev", "python-sip-dev"]
+
+python-qt-bindings-gl:
+    ubuntu: ["python-qt4-gl"]
+
+python-qt-bindings-qwt5:
+    ubuntu: ["python-qwt5-qt4"]
+
+python-qt-bindings-webkit:
+    ubuntu: ["python-qt4"]
+
+python-qt4-gl:
+    ubuntu: ["python-qt4-gl"]
+
+python-qt5-bindings:
+    ubuntu:
+        bionic: ["pyqt5-dev", "python-pyqt5", "python-pyqt5.qtsvg", "python-sip-dev"]
+
+python-qt5-bindings-gl:
+    ubuntu:
+        bionic: ["python-pyqt5.qtopengl"]
+
+python-qt5-bindings-qsci:
+    ubuntu: ["python-pyqt5.qsci"]
+
+python-qt5-bindings-quick:
+    ubuntu: ["python-pyqt5.qtquick"]
+
+python-qt5-bindings-webkit:
+    ubuntu:
+        bionic: ["python-pyqt5.qtwebkit"]
+
+python-qtpy:
+    ubuntu: ["python-qtpy"]
+
+python-qwt5-qt4:
+    ubuntu: ["python-qwt5-qt4"]
+
+python-rdflib:
+    ubuntu: ["python-rdflib"]
+
+python-readchar-pip:
+    pip: ["readchar"]
+
+python-redis:
+    ubuntu: ["python-redis"]
+
+python-redis-pip:
+    pip: ["redis"]
+
+python-requests:
+    ubuntu:
+        default: ["python-requests"]
+
+python-requests-oauthlib:
+    ubuntu: ["python-requests-oauthlib"]
+
+python-responses-pip:
+    pip: ["responses"]
+
+python-rosdep:
+    ubuntu:
+        bionic: ["python-rosdep"]
+
+python-rosdep-modules:
+    ubuntu: ["python-rosdep-modules"]
+
+python-rosinstall:
+    ubuntu:
+        default: ["python-rosinstall"]
+
+python-rosinstall-generator:
+    ubuntu: ["python-rosinstall-generator"]
+
+python-rospkg:
+    ubuntu:
+        default: ["python-rospkg"]
+
+python-rospkg-modules:
+    ubuntu: ["python-rospkg-modules"]
+
+python-rpi.gpio:
+    ubuntu:
+        bionic: ["python-rpi.gpio"]
+
+python-rpi.gpio-pip:
+    pip: ["RPi.GPIO"]
+
+python-rtree:
+    ubuntu: ["python-rtree"]
+
+python-ruamel.yaml:
+    ubuntu:
+        bionic: ["python-ruamel.yaml"]
+
+python-rx-pip:
+    pip: ["rx"]
+
+python-sbp-pip:
+    pip: ["sbp"]
+
+python-scapy:
+    ubuntu: ["python-scapy"]
+
+python-schedule:
+    ubuntu: ["python-schedule"]
+
+python-scipy:
+    ubuntu:
+        default: ["python-scipy"]
+
+python-scp:
+    ubuntu: ["python-scp"]
+
+python-seaborn:
+    ubuntu:
+        bionic: ["python-seaborn"]
+
+python-selectors2-pip:
+    pip: ["selectors2"]
+
+python-selenium-pip:
+    pip: ["selenium"]
+
+python-semantic-version:
+    ubuntu:
+        bionic: ["python-semantic-version"]
+
+python-semver:
+    ubuntu: ["python-semver"]
+
+python-serial:
+    ubuntu:
+        bionic: ["python-serial"]
+
+python-setproctitle:
+    ubuntu: ["python-setproctitle"]
+
+python-setuptools:
+    ubuntu:
+        bionic: ["python-setuptools"]
+
+python-sexpdata:
+    pip: ["sexpdata"]
+
+python-sh:
+    ubuntu:
+        bionic: ["python-sh"]
+
+python-shapely:
+    ubuntu:
+        default: ["python-shapely"]
+
+python-simplejson:
+    ubuntu: ["python-simplejson"]
+
+python-singledispatch:
+    ubuntu: ["python-singledispatch"]
+
+python-sip:
+    ubuntu:
+        default: ["python-sip-dev"]
+
+python-six:
+    ubuntu: ["python-six"]
+
+python-skimage:
+    ubuntu:
+        bionic: ["python-skimage"]
+
+python-skimage-pip:
+    pip: ["scikit-image"]
+
+python-sklearn:
+    ubuntu:
+        default: ["python-sklearn"]
+
+python-slackclient-pip:
+    pip: ["slackclient"]
+
+python-slacker-cli:
+    pip: ["slacker-cli"]
+
+python-slycot-pip:
+    pip: ["slycot"]
+
+python-smbus:
+    ubuntu: ["python-smbus"]
+
+python-sortedcontainers-pip:
+    pip: ["sortedcontainers"]
+
+python-sparqlwrapper:
+    ubuntu: ["python-sparqlwrapper"]
+
+python-speechrecognition-pip:
+    pip: ["speechrecognition"]
+
+python-sphinx:
+    ubuntu:
+        default: ["python-sphinx"]
+
+python-sphinx-argparse:
+    ubuntu:
+        bionic: ["python-sphinx-argparse"]
+
+python-sphinx-rtd-theme:
+    ubuntu:
+        bionic: ["python-sphinx-rtd-theme"]
+
+python-spidev-pip:
+    pip: ["spidev"]
+
+python-sqlalchemy:
+    ubuntu:
+        bionic: ["python-sqlalchemy"]
+
+python-sqlite:
+    ubuntu: ["python-sqlite"]
+
+python-statistics-pip:
+    pip: ["statistics"]
+
+python-statsd:
+    ubuntu: ["python-statsd"]
+
+python-subprocess32:
+    ubuntu:
+        default: ["python-subprocess32"]
+
+python-support:
+    ubuntu: ["python-support"]
+
+python-svg.path:
+    ubuntu:
+        bionic: ["python-svg.path"]
+
+python-svn:
+    ubuntu: ["python-svn"]
+
+python-sympy:
+    ubuntu:
+        bionic: ["python-sympy"]
+
+python-systemd:
+    ubuntu:
+        bionic: ["python-systemd"]
+
+python-sysv-ipc:
+    ubuntu: ["python-sysv-ipc"]
+
+python-tablib:
+    ubuntu: ["python-tablib"]
+
+python-tablib-pip:
+    pip: ["tablib"]
+
+python-tabulate:
+    ubuntu:
+        bionic: ["python-tabulate"]
+
+python-tabulate-pip:
+    pip: ["tabulate"]
+
+python-tblib:
+    ubuntu: ["python-tblib"]
+
+python-telegram-bot:
+    pip: ["python-telegram-bot"]
+
+python-tensorboard-pip:
+    pip: ["tensorboard"]
+
+python-tensorboardX-pip:
+    pip: ["tensorboardX"]
+
+python-tensorflow-gpu-pip:
+    pip: ["tensorflow-gpu"]
+
+python-tensorflow-hub-pip:
+    pip: ["tensorflow-hub"]
+
+python-tensorflow-pip:
+    pip: ["tensorflow"]
+
+python-tensorflow-serving-api-pip:
+    pip: ["tensorflow-serving-api"]
+
+python-termcolor:
+    ubuntu:
+        default: ["python-termcolor"]
+
+python-testscenarios:
+    ubuntu: ["python-testscenarios"]
+
+python-testtools:
+    ubuntu: ["python-testtools"]
+
+python-texttable:
+    ubuntu:
+        bionic: ["python-texttable"]
+
+python-tftpy:
+    ubuntu: ["python-tftpy"]
+
+python-tilestache:
+    ubuntu: ["tilestache"]
+
+python-tk:
+    ubuntu:
+        default: ["python-tk"]
+
+python-toml:
+    ubuntu: ["python-toml"]
+
+python-tornado:
+    ubuntu: ["python-tornado"]
+
+python-tornado-couchdb-pip:
+    pip: ["tornado-couchdb"]
+
+python-tornado-pip:
+    pip: ["tornado"]
+
+python-tqdm:
+    ubuntu:
+        bionic: ["python-tqdm"]
+
+python-transforms3d-pip:
+    pip: ["transforms3d"]
+
+python-transitions:
+    ubuntu:
+        bionic: ["python-transitions"]
+
+python-trep:
+    pip: ["trep"]
+
+python-triangle-pip:
+    pip: ["triangle"]
+
+python-trimesh-pip:
+    pip: ["trimesh"]
+
+python-twilio-pip:
+    pip: ["twilio"]
+
+python-twisted-bin:
+    ubuntu: ["python-twisted-bin"]
+
+python-twisted-core:
+    ubuntu: ["python-twisted-core"]
+
+python-twisted-web:
+    ubuntu: ["python-twisted-web"]
+
+python-twitter:
+    ubuntu: ["python-twitter"]
+
+python-typing:
+    ubuntu:
+        default: ["python-typing"]
+
+python-typing-pip:
+    pip: ["typing"]
+
+python-tz:
+    ubuntu: ["python-tz"]
+
+python-tzlocal-pip:
+    pip: ["tzlocal"]
+
+python-ubjson:
+    ubuntu:
+        bionic: ["python-ubjson"]
+
+python-ujson:
+    ubuntu:
+        bionic: ["python-ujson"]
+
+python-unittest2:
+    ubuntu: ["python-unittest2"]
+
+python-urlgrabber:
+    ubuntu: ["python-urlgrabber"]
+
+python-urllib3:
+    ubuntu: ["python-urllib3"]
+
+python-usb:
+    ubuntu: ["python-usb"]
+
+python-utm-pip:
+    pip: ["utm"]
+
+python-validictory-pip:
+    pip: ["validictory"]
+
+python-vcstool:
+    ubuntu: ["python-vcstool"]
+
+python-vedo-pip:
+    pip: ["vedo"]
+
+python-vine-pip:
+    pip: ["vine"]
+
+python-virtualenv:
+    ubuntu: ["python-virtualenv"]
+
+python-visual:
+    ubuntu: ["python-visual"]
+
+python-vlc-pip:
+    pip: ["python-vlc"]
+
+python-voluptuous:
+    ubuntu: ["python-voluptuous"]
+
+python-vtk:
+    ubuntu:
+        bionic: ["python-vtk6"]
+
+python-w1thermsensor-pip:
+    pip: ["w1thermsensor"]
+
+python-waitress:
+    ubuntu: ["python-waitress"]
+
+python-walrus-pip:
+    pip: ["walrus"]
+
+python-watchdog:
+    ubuntu:
+        bionic: ["python-watchdog"]
+
+python-webob:
+    ubuntu: ["python-webob"]
+
+python-webpy:
+    ubuntu: ["python-webpy"]
+
+python-webrtcvad-pip:
+    pip: ["webrtcvad"]
+
+python-websocket:
+    ubuntu:
+        bionic: ["python-websocket"]
+
+python-webtest:
+    ubuntu: ["python-webtest"]
+
+python-werkzeug:
+    ubuntu: ["python-werkzeug"]
+
+python-wheel:
+    ubuntu: ["python-wheel"]
+
+python-whichcraft:
+    ubuntu: ["python-whichcraft"]
+
+python-wrapt:
+    ubuntu: ["python-wrapt"]
+
+python-ws4py:
+    ubuntu: ["python-ws4py"]
+
+python-ws4py-pip:
+    pip: ["ws4py"]
+
+python-wstool:
+    ubuntu: ["python-wstool"]
+
+python-wtforms:
+    ubuntu: ["python-wtforms"]
+
+python-wxtools:
+    ubuntu: ["python-wxtools"]
+
+python-xdot:
+    ubuntu: ["xdot"]
+
+python-xlib:
+    ubuntu: ["python-xlib"]
+
+python-xlrd:
+    ubuntu: ["python-xlrd"]
+
+python-xmlplain-pip:
+    pip: ["xmlplain"]
+
+python-xmltodict:
+    ubuntu:
+        bionic: ["python-xmltodict"]
+
+python-yamale-pip:
+    pip: ["yamale"]
+
+python-yaml:
+    ubuntu:
+        bionic: ["python-yaml"]
+        focal: ["python-yaml"]
+
+python-zbar:
+    ubuntu: ["python-zbar"]
+
+python-zmq:
+    ubuntu:
+        default: ["python-zmq"]
+
+python3:
+    ubuntu: ["python3-dev"]
+
+python3-adafruit-blinka-pip:
+    pip: ["Adafruit-Blinka"]
+
+python3-adafruit-circuitpython-ads1x15-pip:
+    pip: ["adafruit-circuitpython-ads1x15"]
+
+python3-adafruit-circuitpython-bno055-pip:
+    pip: ["adafruit-circuitpython-bno055"]
+
+python3-adafruit-circuitpython-bno08x-pip:
+    pip: ["adafruit-circuitpython-bno08x"]
+
+python3-adafruit-circuitpython-lsm9ds0-pip:
+    pip: ["adafruit-circuitpython-lsm9ds0"]
+
+python3-adafruit-circuitpython-mcp230xx-pip:
+    pip: ["adafruit-circuitpython-mcp230xx"]
+
+python3-adafruit-circuitpython-mpu6050-pip:
+    pip: ["adafruit-circuitpython-mpu6050"]
+
+python3-adapt-parser-pip:
+    pip: ["adapt-parser"]
+
+python3-ahrs-pip:
+    pip: ["ahrs"]
+
+python3-aio-pika-pip:
+    pip: ["aio-pika"]
+
+python3-aiohttp:
+    ubuntu: ["python3-aiohttp"]
+
+python3-aiohttp-cors:
+    ubuntu: ["python3-aiohttp-cors"]
+
+python3-aiortc:
+    ubuntu:
+        jammy: ["python3-aiortc"]
+
+python3-albumentations-pip:
+    pip: ["albumentations"]
+
+python3-alembic:
+    ubuntu: ["python3-alembic"]
+
+python3-alsaaudio:
+    ubuntu: ["python3-alsaaudio"]
+
+python3-ansible-runner-pip:
+    pip: ["ansible-runner"]
+
+python3-antlr4:
+    ubuntu:
+        default: ["python3-antlr4"]
+        focal: nonexistent
+
+python3-anytree-pip:
+    pip: ["anytree"]
+
+python3-apa102-pi-pip:
+    pip: ["apa102-pi"]
+
+python3-argcomplete:
+    ubuntu: ["python3-argcomplete"]
+
+python3-astropy-pip:
+    pip: ["astropy"]
+
+python3-asyncssh:
+    ubuntu: ["python3-asyncssh"]
+
+python3-attrs:
+    ubuntu: ["python3-attr"]
+
+python3-autobahn:
+    ubuntu: ["python3-autobahn"]
+
+python3-awsiotsdk-pip:
+    pip: ["awsiotsdk"]
+
+python3-babel:
+    ubuntu: ["python3-babel"]
+
+python3-babeltrace:
+    ubuntu: ["python3-babeltrace"]
+
+python3-backoff-pip:
+    pip: ["backoff"]
+
+python3-bcrypt:
+    ubuntu: ["python3-bcrypt"]
+
+python3-beartype:
+    ubuntu:
+        default: ["python3-beartype"]
+        focal: nonexistent
+        jammy: nonexistent
+
+python3-bidict:
+    ubuntu:
+        default: ["python3-bidict"]
+        bionic: nonexistent
+
+python3-bitarray:
+    ubuntu: ["python3-bitarray"]
+
+python3-bitstring:
+    ubuntu: ["python3-bitstring"]
+
+python3-bloom:
+    ubuntu: ["python3-bloom"]
+
+python3-bluerobotics-ping-pip:
+    pip: ["bluerobotics-ping"]
+
+python3-bluez:
+    ubuntu:
+        default: ["python3-bluez"]
+        bionic: nonexistent
+
+python3-bokeh-pip:
+    pip: ["bokeh"]
+
+python3-bosdyn-api-pip:
+    pip: ["bosdyn-api", "bosdyn-choreography-protos"]
+
+python3-bosdyn-client-pip:
+    pip: ["bosdyn-client", "bosdyn-choreography-client"]
+
+python3-bosdyn-core-pip:
+    pip: ["bosdyn-core"]
+
+python3-bosdyn-mission-pip:
+    pip: ["bosdyn-mission"]
+
+python3-boto3:
+    ubuntu: ["python3-boto3"]
+
+python3-bottle:
+    ubuntu: ["python3-bottle"]
+
+python3-box:
+    pip: ["python-box"]
+    pip: ["python-box"]
+
+python3-breathe:
+    ubuntu: ["python3-breathe"]
+
+python3-bs4:
+    ubuntu: ["python3-bs4"]
+
+python3-bson:
+    ubuntu: ["python3-bson"]
+
+python3-build:
+    ubuntu:
+        default: ["python3-build"]
+        focal: nonexistent
+
+python3-cairo:
+    ubuntu: ["python3-cairo"]
+
+python3-cairosvg:
+    ubuntu: ["python3-cairosvg"]
+
+python3-can:
+    ubuntu:
+        default: ["python3-can"]
+
+python3-can-j1939-pip:
+    pip: ["can-j1939"]
+
+python3-cantools-pip:
+    pip: ["cantools"]
+
+python3-catkin-lint:
+    ubuntu:
+        default: ["catkin-lint"]
+        bionic: nonexistent
+
+python3-catkin-pkg:
+    ubuntu: ["python3-catkin-pkg"]
+
+python3-catkin-pkg-modules:
+    ubuntu: ["python3-catkin-pkg-modules"]
+
+python3-catkin-sphinx:
+    ubuntu:
+        default: nonexistent
+        focal: ["python3-catkin-sphinx"]
+
+python3-catkin-tools:
+    ubuntu: ["python3-catkin-tools"]
+
+python3-cbor2:
+    pip: ["cbor2"]
+    pip: ["cbor2"]
+
+python3-certifi:
+    ubuntu: ["python3-certifi"]
+
+python3-cffi:
+    ubuntu: ["python3-cffi"]
+
+python3-chainer-pip:
+    pip: ["chainer"]
+
+python3-charisma-sdk-pip:
+    pip: ["charisma-sdk"]
+
+python3-cherrypy3:
+    ubuntu: ["python3-cherrypy3"]
+
+python3-click:
+    ubuntu: ["python3-click"]
+
+python3-colcon-common-extensions:
+    ubuntu: ["python3-colcon-common-extensions"]
+
+python3-colcon-meson:
+    ubuntu:
+        jammy: ["python3-colcon-meson"]
+
+python3-collada:
+    ubuntu:
+        default: ["python3-collada"]
+        bionic: nonexistent
+
+python3-collada-pip:
+    pip: ["pycollada"]
+
+python3-colorama:
+    ubuntu: ["python3-colorama"]
+
+python3-colorcet:
+    pip: ["colorcet"]
+    pip: ["colorcet"]
+
+python3-conan-pip:
+    pip: ["conan"]
+
+python3-connexion-pip:
+    pip: ["connexion"]
+
+python3-construct:
+    ubuntu: ["python3-construct"]
+
+python3-cookiecutter:
+    ubuntu:
+        default: ["python3-cookiecutter"]
+        focal: nonexistent
+
+python3-coverage:
+    ubuntu: ["python3-coverage"]
+
+python3-crc16-pip:
+    pip: ["crc16"]
+
+python3-crcmod:
+    ubuntu: ["python3-crcmod"]
+
+python3-cryptography:
+    ubuntu: ["python3-cryptography"]
+
+python3-cvxopt:
+    ubuntu: ["python3-cvxopt"]
+
+python3-cvxpy-pip:
+    pip: ["cvxpy"]
+
+python3-cycler:
+    ubuntu: ["python3-cycler"]
+
+python3-dataclasses-json:
+    ubuntu:
+        default: ["python3-dataclasses-json"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-datadog-pip:
+    pip: ["datadog"]
+
+python3-dateutil:
+    ubuntu: ["python3-dateutil"]
+
+python3-dbus:
+    ubuntu: ["python3-dbus"]
+
+python3-decorator:
+    ubuntu: ["python3-decorator"]
+
+python3-deepdiff:
+    pip: ["deepdiff"]
+
+python3-defusedxml:
+    ubuntu: ["python3-defusedxml"]
+
+python3-deprecated:
+    ubuntu:
+        default: ["python3-deprecated"]
+        bionic: nonexistent
+
+python3-depthai-pip:
+    pip: ["depthai"]
+
+python3-dev:
+    ubuntu: ["python3-dev"]
+
+python3-dill:
+    ubuntu: ["python3-dill"]
+
+python3-distro:
+    ubuntu: ["python3-distro"]
+
+python3-distutils:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python3-distutils"]
+        focal: ["python3-distutils"]
+        jammy: ["python3-distutils"]
+
+python3-django:
+    ubuntu: ["python3-django"]
+
+python3-django-cors-headers:
+    ubuntu: ["python3-django-cors-headers"]
+
+python3-django-extensions:
+    ubuntu: ["python3-django-extensions"]
+
+python3-django-extra-views:
+    ubuntu: ["python3-django-extra-views"]
+
+python3-djangorestframework:
+    ubuntu: ["python3-djangorestframework"]
+
+python3-dlib-pip:
+    pip: ["dlib"]
+
+python3-do-mpc-pip:
+    pip: ["do-mpc"]
+
+python3-docker:
+    ubuntu: ["python3-docker"]
+
+python3-docopt:
+    ubuntu: ["python3-docopt"]
+
+python3-docutils:
+    ubuntu: ["python3-docutils"]
+
+python3-dubins-pip:
+    pip: ["dubins"]
+
+python3-easydict:
+    pip: ["easydict"]
+    pip: ["easydict"]
+
+python3-elasticsearch:
+    ubuntu: ["python3-elasticsearch"]
+
+python3-emoji:
+    pip: ["emoji"]
+    pip: ["emoji"]
+
+python3-empy:
+    ubuntu: ["python3-empy"]
+
+python3-environs-pip:
+    pip: ["environs"]
+
+python3-evdev:
+    ubuntu: ["python3-evdev"]
+
+python3-events-pip:
+    pip: ["Events"]
+
+python3-expiringdict:
+    ubuntu: ["python3-expiringdict"]
+
+python3-ezdxf:
+    pip: ["ezdxf"]
+    pip: ["ezdxf"]
+
+python3-fabric:
+    ubuntu: ["python3-fabric"]
+
+python3-falcon:
+    ubuntu: ["python3-falcon"]
+
+python3-fann2:
+    ubuntu: ["python3-fann2"]
+
+python3-fastapi:
+    pip: ["fastapi"]
+    pip: ["fastapi"]
+
+python3-fasteners-pip:
+    pip: ["fasteners"]
+
+python3-fastjsonschema:
+    ubuntu:
+        default: ["python3-fastjsonschema"]
+        focal: nonexistent
+
+python3-fastkml:
+    ubuntu: ["python3-fastkml"]
+
+python3-fastnumbers-pip:
+    pip: ["fastnumbers"]
+
+python3-fcn-pip:
+    pip: ["fcn"]
+
+python3-filetype-pip:
+    pip: ["filetype"]
+
+python3-filfinder-pip:
+    pip: ["fil_finder"]
+
+python3-fiona:
+    ubuntu: ["python3-fiona"]
+
+python3-flake8:
+    ubuntu: ["python3-flake8"]
+
+python3-flake8-black:
+    pip: ["flake8-black"]
+
+python3-flake8-blind-except:
+    ubuntu:
+        default: ["python3-flake8-blind-except"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-blind-except-pip:
+    pip: ["flake8-blind-except"]
+
+python3-flake8-builtins:
+    ubuntu:
+        default: ["python3-flake8-builtins"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-builtins-pip:
+    pip: ["flake8-builtins"]
+
+python3-flake8-class-newline:
+    ubuntu:
+        default: ["python3-flake8-class-newline"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-class-newline-pip:
+    pip: ["flake8-class-newline"]
+
+python3-flake8-comprehensions:
+    ubuntu:
+        default: ["python3-flake8-comprehensions"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-comprehensions-pip:
+    pip: ["flake8-comprehensions"]
+
+python3-flake8-deprecated:
+    ubuntu:
+        default: ["python3-flake8-deprecated"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-deprecated-pip:
+    pip: ["flake8-deprecated"]
+
+python3-flake8-docstrings:
+    ubuntu: ["python3-flake8-docstrings"]
+
+python3-flake8-docstrings-pip:
+    pip: ["flake8-docstrings"]
+
+python3-flake8-import-order:
+    ubuntu:
+        default: ["python3-flake8-import-order"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-import-order-pip:
+    pip: ["flake8-import-order"]
+
+python3-flake8-isort:
+    pip: ["flake8-isort"]
+
+python3-flake8-quotes:
+    ubuntu:
+        default: ["python3-flake8-quotes"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-quotes-pip:
+    pip: ["flake8-quotes"]
+
+python3-flaky:
+    ubuntu: ["python3-flaky"]
+
+python3-flask:
+    ubuntu: ["python3-flask"]
+
+python3-flask-bcrypt:
+    ubuntu: ["python3-flask-bcrypt"]
+
+python3-flask-cors:
+    ubuntu:
+        default: ["python3-flask-cors"]
+        bionic: nonexistent
+
+python3-flask-jwt-extended:
+    pip: ["flask-jwt-extended"]
+
+python3-flask-migrate:
+    ubuntu: ["python3-flask-migrate"]
+
+python3-flask-restplus-pip:
+    pip: ["flask-restplus"]
+
+python3-flask-socketio:
+    ubuntu: ["python3-flask-socketio"]
+
+python3-flask-sqlalchemy:
+    ubuntu: ["python3-flask-sqlalchemy"]
+
+python3-flatbuffers:
+    pip: ["flatbuffers"]
+    pip: ["flatbuffers"]
+
+python3-fonttools:
+    ubuntu: ["python3-fonttools"]
+
+python3-formant-pip:
+    pip: ["formant"]
+
+python3-fpdf2-pip:
+    pip: ["fpdf2"]
+
+python3-ftdi1:
+    ubuntu: ["python3-ftdi1"]
+
+python3-funcsigs:
+    ubuntu: ["python3-funcsigs"]
+
+python3-future:
+    ubuntu: ["python3-future"]
+
+python3-gdal:
+    ubuntu: ["python3-gdal"]
+
+python3-gdown-pip:
+    pip: ["gdown"]
+
+python3-geographiclib:
+    ubuntu: ["python3-geographiclib"]
+
+python3-geojson:
+    ubuntu: ["python3-geojson"]
+
+python3-geomag-pip:
+    pip: ["geomag"]
+
+python3-geopandas:
+    ubuntu: ["python3-geopandas"]
+
+python3-geopy:
+    ubuntu: ["python3-geopy"]
+
+python3-gi:
+    ubuntu: ["python3-gi"]
+
+python3-gi-cairo:
+    ubuntu: ["python3-gi-cairo"]
+
+python3-git:
+    ubuntu: ["python3-git"]
+
+python3-github:
+    ubuntu: ["python3-github"]
+
+python3-gitlab:
+    ubuntu: ["python3-gitlab"]
+
+python3-glpk-pip:
+    pip: ["glpk"]
+
+python3-gnupg:
+    ubuntu: ["python3-gnupg"]
+
+python3-google-auth:
+    ubuntu: ["python3-google-auth"]
+
+python3-google-auth-httplib2:
+    ubuntu:
+        default: ["python3-google-auth-httplib2"]
+        bionic: nonexistent
+
+python3-google-auth-oauthlib:
+    ubuntu:
+        default: ["python3-google-auth-oauthlib"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-google-cloud-pubsub-pip:
+    pip: ["google-cloud-pubsub"]
+
+python3-google-cloud-secret-manager-pip:
+    pip: ["google-cloud-secret-manager"]
+
+python3-google-cloud-storage-pip:
+    pip: ["google-cloud-storage"]
+
+python3-google-cloud-texttospeech-pip:
+    pip: ["google-cloud-texttospeech"]
+
+python3-googleapi:
+    ubuntu: ["python3-googleapi"]
+
+python3-gpiozero:
+    ubuntu:
+        default: ["python3-gpiozero"]
+        bionic: nonexistent
+
+python3-gpxpy:
+    ubuntu: ["python3-gpxpy"]
+
+python3-gql-pip:
+    pip: ["gql"]
+
+python3-graphviz:
+    ubuntu: ["python3-graphviz"]
+
+python3-grip:
+    ubuntu: ["grip"]
+
+python3-grpc-tools:
+    ubuntu:
+        default: ["python3-grpc-tools"]
+        bionic: nonexistent
+
+python3-grpcio:
+    ubuntu:
+        default: ["python3-grpcio"]
+        bionic: nonexistent
+
+python3-gtts:
+    ubuntu: ["python3-gtts"]
+
+python3-gurobipy-pip:
+    pip: ["gurobipy"]
+
+python3-gymnasium-pip:
+    pip: ["gymnasium"]
+
+python3-gymnasium-robotics-pip:
+    pip: ["gymnasium-robotics"]
+
+python3-gz-math6:
+    ubuntu:
+        focal: ["python3-gz-math6"]
+        jammy: ["python3-gz-math6"]
+
+python3-gz-sim6:
+    ubuntu:
+        focal: ["python3-gz-sim6"]
+        jammy: ["python3-gz-sim6"]
+
+python3-h5py:
+    ubuntu: ["python3-h5py"]
+
+python3-hidapi:
+    ubuntu: ["python3-hid"]
+
+python3-hidapi-cffi:
+    ubuntu: ["python3-hidapi"]
+
+python3-httplib2:
+    ubuntu: ["python3-httplib2"]
+
+python3-hypothesis:
+    ubuntu: ["python3-hypothesis"]
+
+python3-icecream:
+    ubuntu:
+        default: ["python3-icecream"]
+        focal: nonexistent
+
+python3-ifcfg:
+    ubuntu:
+        bionic: ["python3-ifcfg"]
+        focal: ["python3-ifcfg"]
+
+python3-ignition-gazebo6:
+    ubuntu:
+        focal: ["python3-ignition-gazebo6"]
+        jammy: ["python3-ignition-gazebo6"]
+
+python3-ignition-math6:
+    ubuntu:
+        focal: ["python3-ignition-math6"]
+        jammy: ["python3-ignition-math6"]
+
+python3-imageio:
+    ubuntu: ["python3-imageio"]
+
+python3-img2pdf:
+    ubuntu: ["python3-img2pdf"]
+
+python3-importlib-metadata:
+    pip: ["importlib-metadata"]
+
+python3-importlib-resources:
+    pip: ["importlib-resources"]
+
+python3-inflection:
+    ubuntu: ["python3-inflection"]
+
+python3-inflection-pip:
+    pip: ["inflection"]
+
+python3-influxdb:
+    ubuntu: ["python3-influxdb"]
+
+python3-influxdb-client-pip:
+    pip: ["influxdb-client"]
+
+python3-inject-pip:
+    pip: ["inject"]
+
+python3-inputimeout-pip:
+    pip: ["inputimeout"]
+
+python3-insightface-pip:
+    pip: ["insightface"]
+
+python3-interpreter:
+    ubuntu: ["python3-minimal"]
+
+python3-j1939-pip:
+    pip: ["j1939"]
+
+python3-jinja2:
+    ubuntu: ["python3-jinja2"]
+
+python3-jmespath:
+    ubuntu: ["python3-jmespath"]
+
+python3-joblib:
+    ubuntu: ["python3-joblib"]
+
+python3-jsonpickle:
+    ubuntu: ["python3-jsonpickle"]
+
+python3-jsonschema:
+    ubuntu: ["python3-jsonschema"]
+
+python3-junitparser:
+    ubuntu:
+        default: ["python3-junitparser"]
+        bionic: nonexistent
+
+python3-jupyros-pip:
+    pip: ["jupyros"]
+
+python3-jwt:
+    ubuntu: ["python3-jwt"]
+
+python3-kitchen:
+    ubuntu:
+        default: ["python3-kitchen"]
+
+python3-kivy:
+    ubuntu: ["python3-kivy"]
+
+python3-kiwisolver:
+    pip: ["kiwisolver"]
+
+python3-kml2geojson-pip:
+    pip: ["kml2geojson"]
+
+python3-lark-parser:
+    ubuntu:
+        default: ["python3-lark"]
+        bionic: ["python3-lark-parser"]
+
+python3-lensfun:
+    ubuntu: ["python3-lensfun"]
+
+python3-lgpio:
+    pip: ["lgpio"]
+
+python3-libgpiod:
+    ubuntu:
+        default: ["python3-libgpiod"]
+        bionic: nonexistent
+
+python3-libtmux:
+    ubuntu: ["python3-libtmux"]
+
+python3-lingua-franca-pip:
+    pip: ["lingua-franca"]
+
+python3-lockfile:
+    ubuntu: ["python3-lockfile"]
+
+python3-lttng:
+    ubuntu: ["python3-lttng"]
+
+python3-lxml:
+    ubuntu: ["python3-lxml"]
+
+python3-magic:
+    ubuntu: ["python3-magic"]
+
+python3-mako:
+    ubuntu: ["python3-mako"]
+
+python3-mapbox-earcut-pip:
+    pip: ["mapbox-earcut"]
+
+python3-mapnik:
+    ubuntu: ["python3-mapnik"]
+
+python3-marisa:
+    ubuntu: ["python3-marisa"]
+
+python3-markdown:
+    ubuntu: ["python3-markdown"]
+
+python3-marshmallow:
+    ubuntu: ["python3-marshmallow"]
+
+python3-marshmallow-dataclass-pip:
+    pip: ["marshmallow-dataclass"]
+
+python3-matplotlib:
+    ubuntu: ["python3-matplotlib"]
+
+python3-mavproxy-pip:
+    pip: ["MAVProxy"]
+
+python3-mccabe:
+    ubuntu: ["python3-mccabe"]
+
+python3-mechanize:
+    ubuntu:
+        default: ["python3-mechanize"]
+        bionic: nonexistent
+
+python3-mediapipe-pip:
+    pip: ["mediapipe"]
+
+python3-meshio:
+    ubuntu: ["python3-meshio"]
+
+python3-meson-pip:
+    pip: ["meson"]
+
+python3-minijinja:
+    pip: ["minijinja"]
+    pip: ["minijinja"]
+    pip: ["minijinja"]
+
+python3-minimalmodbus-pip:
+    pip: ["minimalmodbus"]
+
+python3-mistune:
+    ubuntu: ["python3-mistune"]
+
+python3-mlflow:
+    pip: ["mlflow"]
+
+python3-mock:
+    ubuntu: ["python3-mock"]
+
+python3-moonraker-api-pip:
+    pip: ["moonraker-api"]
+
+python3-more-itertools:
+    ubuntu: ["python3-more-itertools"]
+
+python3-moteus-pi3hat-pip:
+    pip: ["moteus-pi3hat"]
+
+python3-moteus-pip:
+    pip: ["moteus"]
+
+python3-motor-pip:
+    pip: ["motor"]
+
+python3-msgpack:
+    ubuntu: ["python3-msgpack"]
+
+python3-msk-pip:
+    pip: ["msk"]
+
+python3-msm-pip:
+    pip: ["msm"]
+
+python3-multimethod-pip:
+    pip: ["multimethod"]
+
+python3-multipledispatch:
+    ubuntu:
+        default: ["python3-multipledispatch"]
+        focal: nonexistent
+
+python3-munkres:
+    ubuntu: ["python3-munkres"]
+
+python3-mycroft-messagebus-client-pip:
+    pip: ["mycroft-messagebus-client"]
+
+python3-mypy:
+    ubuntu: ["python3-mypy"]
+
+python3-mysqldb:
+    ubuntu: ["python3-mysqldb"]
+
+python3-myst-parser-pip:
+    pip: ["myst-parser"]
+
+python3-natsort:
+    ubuntu: ["python3-natsort"]
+
+python3-nclib-pip:
+    pip: ["nclib"]
+
+python3-nep-pip:
+    pip: ["nep"]
+
+python3-nest-asyncio:
+    ubuntu:
+        default: ["python3-nest-asyncio"]
+        focal: nonexistent
+
+python3-netcdf4:
+    ubuntu: ["python3-netcdf4"]
+
+python3-netifaces:
+    ubuntu: ["python3-netifaces"]
+
+python3-networkmanager:
+    ubuntu: ["python3-networkmanager"]
+
+python3-networkx:
+    ubuntu: ["python3-networkx"]
+
+python3-nlopt:
+    ubuntu:
+        default: ["python3-nlopt"]
+        bionic: nonexistent
+
+python3-nmcli-pip:
+    pip: ["nmcli"]
+
+python3-nose:
+    ubuntu: ["python3-nose"]
+
+python3-nose-parameterized:
+    ubuntu: ["python3-nose-parameterized"]
+
+python3-nose-yanc:
+    ubuntu: ["python3-nose-yanc"]
+
+python3-ntplib:
+    ubuntu: ["python3-ntplib"]
+
+python3-numba:
+    ubuntu: ["python3-numba"]
+
+python3-numpy:
+    ubuntu: ["python3-numpy"]
+
+python3-numpy-stl:
+    ubuntu:
+        default: ["python3-numpy-stl"]
+
+python3-nuscenes-devkit-pip:
+    pip: ["nuscenes-devkit"]
+
+python3-nxt-python-pip:
+    pip: ["nxt-python"]
+
+python3-oauth2client:
+    ubuntu: ["python3-oauth2client"]
+
+python3-oct2py-pip:
+    pip: ["oct2py"]
+
+python3-odrive-pip:
+    pip: ["odrive"]
+
+python3-ollama-pip:
+    pip: ["ollama"]
+
+python3-omniorb:
+    pip: ["omniorb"]
+
+python3-onnxruntime-gpu-pip:
+    pip: ["onnxruntime-gpu"]
+
+python3-onnxruntime-openvino-pip:
+    pip: ["onnxruntime-openvino"]
+
+python3-onnxruntime-pip:
+    pip: ["onnxruntime"]
+
+python3-open3d:
+    ubuntu:
+        default: ["python3-open3d"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-open3d-pip:
+    pip: ["open3d"]
+
+python3-openai-pip:
+    pip: ["openai"]
+
+python3-opencv:
+    ubuntu: ["python3-opencv"]
+
+python3-opengl:
+    ubuntu: ["python3-opengl"]
+
+python3-openhsi-pip:
+    pip: ["openhsi"]
+
+python3-openpyxl:
+    ubuntu: ["python3-openpyxl"]
+
+python3-orjson:
+    pip: ["orjson"]
+
+python3-osrf-pycommon:
+    ubuntu: ["python3-osrf-pycommon"]
+
+python3-overrides:
+    pip: ["overrides"]
+
+python3-owlready2-pip:
+    pip: ["owlready2"]
+
+python3-owslib:
+    ubuntu: ["python3-owslib"]
+
+python3-packaging:
+    ubuntu: ["python3-packaging"]
+
+python3-padaos-pip:
+    pip: ["padaos"]
+
+python3-padatious-pip:
+    pip: ["padatious"]
+
+python3-paho-mqtt:
+    ubuntu:
+        default: ["python3-paho-mqtt"]
+
+python3-pandas:
+    ubuntu: ["python3-pandas"]
+
+python3-papermill-pip:
+    pip: ["papermill"]
+
+python3-parameterized:
+    ubuntu: ["python3-parameterized"]
+
+python3-paramiko:
+    ubuntu: ["python3-paramiko"]
+
+python3-parse:
+    ubuntu: ["python3-parse"]
+
+python3-pcg-gazebo-pip:
+    pip: ["pcg-gazebo"]
+
+python3-pep8:
+    ubuntu: ["python3-pep8"]
+
+python3-pep8-naming:
+    ubuntu: ["python3-pep8-naming"]
+
+python3-petact-pip:
+    pip: ["petact"]
+
+python3-pexpect:
+    ubuntu: ["python3-pexpect"]
+
+python3-pickleDB-pip:
+    pip: ["pickleDB"]
+
+python3-piexif:
+    ubuntu: ["python3-piexif"]
+
+python3-pigpio:
+    ubuntu: ["python3-pigpio"]
+
+python3-pika:
+    ubuntu: ["python3-pika"]
+
+python3-pil:
+    ubuntu: ["python3-pil"]
+
+python3-pil-imagetk:
+    ubuntu: ["python3-pil.imagetk"]
+
+python3-pip:
+    ubuntu: ["python3-pip"]
+
+python3-pkg-resources:
+    ubuntu: ["python3-pkg-resources"]
+
+python3-playsound-pip:
+    pip: ["playsound"]
+
+python3-ply:
+    ubuntu: ["python3-ply"]
+
+python3-pocketsphinx-pip:
+    pip: ["pocketsphinx"]
+
+python3-polling2-pip:
+    pip: ["polling2"]
+
+python3-pqdict-pip:
+    pip: ["pqdict"]
+
+python3-pre-commit:
+    pip: ["pre-commit"]
+    pip: ["pre-commit"]
+
+python3-precise-runner-pip:
+    pip: ["precise-runner"]
+
+python3-prettytable:
+    ubuntu: ["python3-prettytable"]
+
+python3-progressbar:
+    ubuntu: ["python3-progressbar"]
+
+python3-prometheus-client:
+    ubuntu: ["python3-prometheus-client"]
+
+python3-prompt-toolkit:
+    ubuntu: ["python3-prompt-toolkit"]
+
+python3-protobuf:
+    ubuntu: ["python3-protobuf"]
+
+python3-psutil:
+    ubuntu: ["python3-psutil"]
+
+python3-psycopg2:
+    ubuntu: ["python3-psycopg2"]
+
+python3-py3exiv2-pip:
+    pip: ["py3exiv2"]
+
+python3-pyads-pip:
+    pip: ["pyads"]
+
+python3-pyassimp:
+    ubuntu:
+        default: ["python3-pyassimp"]
+
+python3-pyaudio:
+    ubuntu: ["python3-pyaudio"]
+
+python3-pybullet-pip:
+    pip: ["pybullet"]
+
+python3-pyclipper:
+    ubuntu: ["python3-pyclipper"]
+
+python3-pycodestyle:
+    ubuntu: ["python3-pycodestyle"]
+
+python3-pycryptodome:
+    ubuntu: ["python3-pycryptodome"]
+
+python3-pydantic:
+    pip: ["pydantic"]
+
+python3-pydbus:
+    ubuntu: ["python3-pydbus"]
+
+python3-pydot:
+    ubuntu: ["python3-pydot"]
+
+python3-pyee:
+    ubuntu: ["python3-pyee"]
+
+python3-pyftdi-pip:
+    pip: ["pyftdi"]
+
+python3-pyftpdlib:
+    ubuntu: ["python3-pyftpdlib"]
+
+python3-pygame:
+    pip: ["pygame"]
+
+python3-pygit2:
+    ubuntu: ["python3-pygit2"]
+
+python3-pygments:
+    ubuntu: ["python3-pygments"]
+
+python3-pygraphviz:
+    ubuntu: ["python3-pygraphviz"]
+
+python3-pyinotify:
+    ubuntu: ["python3-pyinotify"]
+
+python3-pykdl:
+    ubuntu:
+        default: ["python3-pykdl"]
+        bionic: nonexistent
+
+python3-pylatexenc:
+    pip: ["pylatexenc"]
+    pip: ["pylatexenc"]
+
+python3-pylibdmtx:
+    pip: ["pylibdmtx"]
+    pip: ["pylibdmtx"]
+
+python3-pymap3d:
+    ubuntu:
+        default: ["python3-pymap3d"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-pymesh2-pip:
+    pip: ["pymesh2"]
+
+python3-pymodbus:
+    ubuntu:
+        default: ["python3-pymodbus"]
+
+python3-pymodbus-pip:
+    pip: ["pymodbus"]
+
+python3-pymongo:
+    ubuntu: ["python3-pymongo"]
+
+python3-pymongo-pip:
+    pip: ["pymongo"]
+
+python3-pynmea2:
+    ubuntu: ["python3-nmea2"]
+
+python3-pynmeagps-pip:
+    pip: ["pynmeagps"]
+
+python3-pynput:
+    ubuntu:
+        default: ["python3-pynput"]
+        focal: nonexistent
+
+python3-pyosmium:
+    ubuntu: ["python3-pyosmium"]
+
+python3-pyotp:
+    ubuntu: ["python3-pyotp"]
+
+python3-pyparsing:
+    ubuntu: ["python3-pyparsing"]
+
+python3-pypdf:
+    pip: ["pypdf"]
+    pip: ["pypdf"]
+    pip: ["pypdf"]
+
+python3-pypng:
+    ubuntu:
+        default: ["python3-png"]
+
+python3-pyproj:
+    ubuntu: ["python3-pyproj"]
+
+python3-pyqrcode:
+    ubuntu: ["python3-pyqrcode"]
+
+python3-pyqt5:
+    ubuntu: ["pyqt5-dev", "python3-pyqt5", "python3-pyqt5.qtsvg", "python3-sip-dev"]
+
+python3-pyqt5.qtquick:
+    ubuntu: ["python3-pyqt5.qtquick"]
+
+python3-pyqt5.qtwebengine:
+    ubuntu: ["python3-pyqt5.qtwebengine"]
+
+python3-pyqt6.qtmultimedia:
+    ubuntu:
+        default: ["python3-pyqt6.qtmultimedia"]
+        focal: nonexistent
+        jammy: nonexistent
+
+python3-pyqtdarktheme-pip:
+    pip: ["pyqtdarktheme"]
+
+python3-pyqtgraph:
+    ubuntu: ["python3-pyqtgraph"]
+
+python3-pyro-ppl-pip:
+    pip: ["pyro-ppl"]
+
+python3-pyrr-pip:
+    pip: ["pyrr"]
+
+python3-pyside2:
+    ubuntu:
+        default: ["libpyside2-dev", "libshiboken2-dev", "python3-pyside2.qtcore", "python3-pyside2.qtgui", "python3-pyside2.qthelp", "python3-pyside2.qtnetwork", "python3-pyside2.qtprintsupport", "python3-pyside2.qtsvg", "python3-pyside2.qttest", "python3-pyside2.qtwidgets", "python3-pyside2.qtxml", "shiboken2"]
+        bionic: nonexistent
+
+python3-pyside2.qtcore:
+    ubuntu: ["python3-pyside2.qtcore"]
+
+python3-pyside2.qtgui:
+    ubuntu: ["python3-pyside2.qtgui"]
+
+python3-pyside2.qtopengl:
+    ubuntu:
+        default: ["python3-pyside2.qtopengl"]
+        bionic: nonexistent
+
+python3-pyside2.qtqml:
+    ubuntu: ["python3-pyside2.qtqml"]
+
+python3-pyside2.qtquick:
+    ubuntu:
+        default: ["python3-pyside2.qtquick"]
+        bionic: nonexistent
+
+python3-pyside2.qtuitools:
+    ubuntu:
+        default: ["python3-pyside2.qtuitools"]
+        bionic: nonexistent
+
+python3-pyside2.qtwidgets:
+    ubuntu: ["python3-pyside2.qtwidgets"]
+
+python3-pyside6:
+    pip: ["PySide6"]
+    pip: ["PySide6"]
+    pip: ["PySide6"]
+
+python3-pyside6.qtasyncio:
+    ubuntu:
+        default: ["python3-pyside6.qtasyncio"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtcharts:
+    ubuntu:
+        default: ["python3-pyside6.qtcharts"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtconcurrent:
+    ubuntu:
+        default: ["python3-pyside6.qtconcurrent"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtcore:
+    ubuntu:
+        default: ["python3-pyside6.qtcore"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtdatavisualization:
+    ubuntu:
+        default: ["python3-pyside6.qtdatavisualization"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtgui:
+    ubuntu:
+        default: ["python3-pyside6.qtgui"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtqml:
+    ubuntu:
+        default: ["python3-pyside6.qtqml"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qttest:
+    ubuntu:
+        default: ["python3-pyside6.qttest"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtwidgets:
+    ubuntu:
+        default: ["python3-pyside6.qtwidgets"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pysnmp:
+    ubuntu: ["python3-pysnmp4"]
+
+python3-pysnmp-mibs:
+    ubuntu: ["python3-pysnmp4-mibs"]
+
+python3-pystemd:
+    pip: ["pystemd"]
+
+python3-pyswarms-pip:
+    pip: ["pyswarms"]
+
+python3-pytest:
+    ubuntu: ["python3-pytest"]
+
+python3-pytest-asyncio:
+    ubuntu:
+        default: ["python3-pytest-asyncio"]
+        bionic: nonexistent
+
+python3-pytest-benchmark:
+    ubuntu: ["python3-pytest-benchmark"]
+
+python3-pytest-cov:
+    ubuntu: ["python3-pytest-cov"]
+
+python3-pytest-mock:
+    ubuntu: ["python3-pytest-mock"]
+
+python3-pytest-order:
+    ubuntu:
+        default: ["python3-pytest-order"]
+        focal: nonexistent
+
+python3-pytest-pylint:
+    ubuntu: ["python3-pytest-pylint"]
+
+python3-pytest-ruff-pip:
+    pip: ["pytest-ruff"]
+
+python3-pytest-timeout:
+    ubuntu: ["python3-pytest-timeout"]
+
+python3-pytest-xdist:
+    ubuntu: ["python3-pytest-xdist"]
+
+python3-pytest-xvfb:
+    ubuntu: ["python3-pytest-xvfb"]
+
+python3-pytorch-pip:
+    pip: ["torch", "torchvision"]
+
+python3-pytrinamic-pip:
+    pip: ["pytrinamic"]
+
+python3-pyudev:
+    ubuntu: ["python3-pyudev"]
+
+python3-pyvista-pip:
+    pip: ["pyvista"]
+
+python3-pyxdg-pip:
+    pip: ["pyxdg"]
+
+python3-qpsolvers-pip:
+    pip: ["qpsolvers"]
+
+python3-qrcode:
+    ubuntu: ["python3-qrcode"]
+
+python3-qt5-bindings:
+    ubuntu:
+        default: ["libpyside2-dev", "libshiboken2-dev", "pyqt5-dev", "python3-pyqt5", "python3-pyqt5.qtsvg", "python3-pyside2.qtsvg", "python3-sip-dev", "shiboken2"]
+        bionic: ["pyqt5-dev", "python3-pyqt5", "python3-pyqt5.qtsvg", "python3-sip-dev"]
+
+python3-qt5-bindings-gl:
+    ubuntu: ["python3-pyqt5.qtopengl"]
+
+python3-qt5-bindings-webkit:
+    ubuntu: ["python3-pyqt5.qtwebkit"]
+
+python3-qtpy:
+    ubuntu: ["python3-qtpy"]
+
+python3-qwt:
+    ubuntu: ["python3-qwt"]
+
+python3-qwt-pip:
+    pip: ["PythonQwt"]
+
+python3-rafcon-pip:
+    pip: ["rafcon"]
+
+python3-rapidfuzz-pip:
+    pip: ["rapidfuzz"]
+
+python3-rasterio:
+    ubuntu: ["python3-rasterio"]
+
+python3-rdflib:
+    ubuntu: ["python3-rdflib"]
+
+python3-reportlab:
+    ubuntu: ["python3-reportlab"]
+
+python3-requests:
+    ubuntu: ["python3-requests"]
+
+python3-requests-futures:
+    ubuntu: ["python3-requests-futures"]
+
+python3-requests-oauthlib:
+    ubuntu: ["python3-requests-oauthlib"]
+
+python3-requests-toolbelt:
+    ubuntu: ["python3-requests-toolbelt"]
+
+python3-retrying:
+    ubuntu: ["python3-retrying"]
+
+python3-rich:
+    pip: ["rich"]
+
+python3-river-pip:
+    pip: ["river"]
+
+python3-rmsd-pip:
+    pip: ["rmsd"]
+
+python3-robodk-pip:
+    pip: ["robodk"]
+
+python3-rocker:
+    ubuntu: ["python3-rocker"]
+
+python3-rosbags-pip:
+    pip: ["rosbags"]
+
+python3-rosdep:
+    ubuntu: ["python3-rosdep"]
+
+python3-rosdep-modules:
+    ubuntu: ["python3-rosdep-modules"]
+
+python3-rosdistro-modules:
+    ubuntu: ["python3-rosdistro-modules"]
+
+python3-rosinstall-generator:
+    ubuntu: ["python3-rosinstall-generator"]
+
+python3-rospkg:
+    ubuntu: ["python3-rospkg"]
+
+python3-rospkg-modules:
+    ubuntu: ["python3-rospkg-modules"]
+
+python3-rsa:
+    ubuntu: ["python3-rsa"]
+
+python3-rtree:
+    ubuntu: ["python3-rtree"]
+
+python3-ruamel.yaml:
+    ubuntu: ["python3-ruamel.yaml"]
+
+python3-ruff-pip:
+    pip: ["ruff"]
+
+python3-sbp-pip:
+    pip: ["sbp"]
+
+python3-schedule:
+    ubuntu: ["python3-schedule"]
+
+python3-schema:
+    ubuntu: ["python3-schema"]
+
+python3-scikit-sparse-pip:
+    pip: ["scikit-sparse"]
+
+python3-scikit-spatial-pip:
+    pip: ["scikit-spatial"]
+
+python3-scipy:
+    ubuntu: ["python3-scipy"]
+
+python3-scp:
+    ubuntu: ["python3-scp"]
+
+python3-seaborn:
+    ubuntu: ["python3-seaborn"]
+
+python3-segno:
+    pip: ["segno"]
+    pip: ["segno"]
+
+python3-selenium:
+    ubuntu: ["python3-selenium"]
+
+python3-semantic-version:
+    ubuntu: ["python3-semantic-version"]
+
+python3-semver:
+    ubuntu: ["python3-semver"]
+
+python3-sense-emu-pip:
+    pip: ["sense-emu"]
+
+python3-sense-hat-pip:
+    pip: ["sense-hat"]
+
+python3-serial:
+    ubuntu: ["python3-serial"]
+
+python3-setuptools:
+    ubuntu: ["python3-setuptools"]
+
+python3-sexpdata:
+    pip: ["sexpdata"]
+
+python3-sh:
+    ubuntu: ["python3-sh"]
+
+python3-shapely:
+    ubuntu: ["python3-shapely"]
+
+python3-sila2lib-pip:
+    pip: ["sila2lib"]
+
+python3-simple-pid-pip:
+    pip: ["simple-pid"]
+
+python3-simplejpeg-pip:
+    pip: ["simplejpeg"]
+
+python3-simplejson:
+    ubuntu: ["python3-simplejson"]
+
+python3-simplification-pip:
+    pip: ["simplification"]
+
+python3-singleton-pattern-decorator-pip:
+    pip: ["singleton-pattern-decorator"]
+
+python3-sip:
+    ubuntu: ["python3-sip-dev"]
+
+python3-siphon-pip:
+    pip: ["siphon"]
+
+python3-six:
+    ubuntu: ["python3-six"]
+
+python3-skimage:
+    ubuntu: ["python3-skimage"]
+
+python3-sklearn:
+    ubuntu: ["python3-sklearn"]
+
+python3-smbus:
+    ubuntu: ["python3-smbus"]
+
+python3-smbus2:
+    ubuntu:
+        default: ["python3-smbus2"]
+        focal: nonexistent
+
+python3-smbus2-pip:
+    pip: ["smbus2"]
+
+python3-smc-pip:
+    pip: ["smc"]
+
+python3-socketio:
+    ubuntu:
+        default: ["python3-socketio"]
+        bionic: nonexistent
+
+python3-sortedcollections-pip:
+    pip: ["sortedcollections"]
+
+python3-sounddevice-pip:
+    pip: ["sounddevice"]
+
+python3-sparkfun-ublox-gps-pip:
+    pip: ["sparkfun-ublox-gps"]
+
+python3-sphinx:
+    ubuntu: ["python3-sphinx"]
+
+python3-sphinx-argparse:
+    ubuntu: ["python3-sphinx-argparse"]
+
+python3-sphinx-autoapi-pip:
+    pip: ["sphinx-autoapi"]
+
+python3-sphinx-rtd-theme:
+    ubuntu: ["python3-sphinx-rtd-theme"]
+
+python3-spidev-pip:
+    pip: ["spidev"]
+
+python3-sqlalchemy:
+    ubuntu: ["python3-sqlalchemy"]
+
+python3-sqlalchemy-utils:
+    ubuntu: ["python3-sqlalchemy-utils"]
+
+python3-sqlite-utils-pip:
+    pip: ["sqlite-utils"]
+
+python3-sqlmodel:
+    pip: ["sqlmodel"]
+    pip: ["sqlmodel"]
+
+python3-squaternion-pip:
+    pip: ["squaternion"]
+
+python3-sshkeyboard-pip:
+    pip: ["sshkeyboard"]
+
+python3-sshtunnel:
+    ubuntu:
+        focal: ["python3-sshtunnel"]
+        jammy: ["python3-sshtunnel"]
+
+python3-stable-baselines3-pip:
+    pip: ["stable-baselines3"]
+
+python3-staticmap-pip:
+    pip: ["staticmap"]
+
+python3-stonesoup-pip:
+    pip: ["stonesoup"]
+
+python3-streamz:
+    pip: ["streamz"]
+
+python3-suas-interop-clients-pip:
+    pip: ["suas-interop-clients"]
+
+python3-svg.path:
+    ubuntu: ["python3-svg.path"]
+
+python3-sympy:
+    ubuntu: ["python3-sympy"]
+
+python3-systemd:
+    ubuntu: ["python3-systemd"]
+
+python3-sysv-ipc:
+    ubuntu: ["python3-sysv-ipc"]
+
+python3-tables:
+    ubuntu: ["python3-tables"]
+
+python3-tabulate:
+    ubuntu: ["python3-tabulate"]
+
+python3-tcr-roboclaw-pip:
+    pip: ["tcr-roboclaw"]
+
+python3-tensorboardX-pip:
+    pip: ["tensorboardX"]
+
+python3-termcolor:
+    ubuntu: ["python3-termcolor"]
+
+python3-texttable:
+    ubuntu: ["python3-texttable"]
+
+python3-textual:
+    ubuntu:
+        default: ["python3-textual"]
+        focal: nonexistent
+
+python3-thop-pip:
+    pip: ["thop"]
+
+python3-thriftpy:
+    ubuntu: ["python3-thriftpy"]
+
+python3-tikzplotlib-pip:
+    pip: ["tikzplotlib"]
+
+python3-tilestache-pip:
+    pip: ["tilestache"]
+
+python3-timm-pip:
+    pip: ["timm"]
+
+python3-tinkerforge-pip:
+    pip: ["tinkerforge"]
+
+python3-tk:
+    ubuntu: ["python3-tk"]
+
+python3-toml:
+    ubuntu: ["python3-toml"]
+
+python3-toppra-pip:
+    pip: ["toppra"]
+
+python3-torch:
+    ubuntu:
+        default: ["python3-torch"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-torchvision:
+    ubuntu:
+        default: ["python3-torchvision"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-tornado:
+    ubuntu: ["python3-tornado"]
+
+python3-tqdm:
+    ubuntu:
+        default: ["python3-tqdm"]
+
+python3-transformers-pip:
+    pip: ["transformers"]
+
+python3-transforms3d:
+    pip: ["transforms3d"]
+    pip: ["transforms3d"]
+
+python3-transitions:
+    ubuntu: ["python3-transitions"]
+
+python3-triangle-pip:
+    pip: ["triangle"]
+
+python3-trimesh-pip:
+    pip: ["trimesh"]
+
+python3-twilio:
+    ubuntu: ["python3-twilio"]
+
+python3-twisted:
+    ubuntu: ["python3-twisted"]
+
+python3-typeguard:
+    pip: ["typeguard"]
+
+python3-typeguard-pip:
+    pip: ["typeguard"]
+
+python3-types-pyyaml:
+    pip: ["types-pyyaml"]
+
+python3-typing-extensions:
+    pip: ["typing-extensions"]
+
+python3-tz:
+    ubuntu: ["python3-tz"]
+
+python3-ubjson:
+    ubuntu:
+        default: ["python3-ubjson"]
+
+python3-ujson:
+    ubuntu: ["python3-ujson"]
+
+python3-ultralytics-pip:
+    pip: ["ultralytics"]
+
+python3-unidecode:
+    ubuntu: ["python3-unidecode"]
+
+python3-unidiff:
+    ubuntu: ["python3-unidiff"]
+
+python3-urdfpy-pip:
+    pip: ["urdfpy"]
+
+python3-urllib3:
+    ubuntu: ["python3-urllib3"]
+
+python3-urwid:
+    ubuntu: ["python3-urwid"]
+
+python3-usb:
+    ubuntu: ["python3-usb"]
+
+python3-uvicorn:
+    pip: ["uvicorn"]
+
+python3-uvloop:
+    ubuntu: ["python3-uvloop"]
+
+python3-validators:
+    ubuntu:
+        default: ["python3-validators"]
+        focal: nonexistent
+
+python3-vcstool:
+    ubuntu: ["python3-vcstool"]
+
+python3-vedo-pip:
+    pip: ["vedo"]
+
+python3-venv:
+    ubuntu: ["python3-venv"]
+
+python3-virtualserialports-pip:
+    pip: ["PyVirtualSerialPorts"]
+
+python3-voluptuous:
+    ubuntu: ["python3-voluptuous"]
+
+python3-waitress:
+    ubuntu: ["python3-waitress"]
+
+python3-wand:
+    ubuntu: ["python3-wand"]
+
+python3-watchdog:
+    ubuntu: ["python3-watchdog"]
+
+python3-waymo-open-dataset-tf-2-6-0-pip:
+    pip: ["waymo-open-dataset-tf-2-6-0"]
+
+python3-weasyprint-pip:
+    pip: ["weasyprint"]
+
+python3-webargs:
+    pip: ["webargs"]
+    pip: ["webargs"]
+
+python3-webpy:
+    ubuntu: ["python3-webpy"]
+
+python3-websocket:
+    ubuntu: ["python3-websocket"]
+
+python3-websockets:
+    ubuntu: ["python3-websockets"]
+
+python3-werkzeug:
+    ubuntu: ["python3-werkzeug"]
+
+python3-west-pip:
+    pip: ["west"]
+
+python3-wgconfig-pip:
+    pip: ["wgconfig"]
+
+python3-whichcraft:
+    ubuntu: ["python3-whichcraft"]
+
+python3-wrapt:
+    ubuntu: ["python3-wrapt"]
+
+python3-wxgtk4.0:
+    ubuntu: ["python3-wxgtk4.0"]
+
+python3-xdot:
+    ubuntu: ["xdot"]
+
+python3-xlsxwriter:
+    ubuntu: ["python3-xlsxwriter"]
+
+python3-xmlschema:
+    pip: ["xmlschema"]
+
+python3-xmltodict:
+    ubuntu: ["python3-xmltodict"]
+
+python3-yaml:
+    ubuntu: ["python3-yaml"]
+
+python3-yappi:
+    ubuntu:
+        default: ["python3-yappi"]
+        bionic: nonexistent
+
+python3-yoctopuce-pip:
+    pip: ["yoctopuce"]
+
+python3-yolov5:
+    pip: ["yolov5"]
+
+python3-zmq:
+    ubuntu: ["python3-zmq"]
+
+qdarkstyle-pip:
+    pip: ["qdarkstyle"]
+
+quadprog-pip:
+    pip: ["quadprog"]
+
+rosbag-metadata-pip:
+    pip: ["rosbag-metadata"]
+
+roslibpy-pip:
+    pip: ["roslibpy"]
+
+rpy2:
+    ubuntu: ["python-rpy2"]
+
+sphinxcontrib-bibtex-pip:
+    pip: ["sphinxcontrib-bibtex"]
+
+svgpathtools-pip:
+    pip: ["svgpathtools"]
+
+tilestache:
+    ubuntu: ["tilestache"]
+
+uavcan-pip:
+    pip: ["uavcan"]
+
+urdf2webots-pip:
+    pip: ["urdf2webots"]
+
+virtualenv:
+    ubuntu: ["virtualenv"]
+
+wxpython:
+    ubuntu:
+        default: ["python-wxgtk3.0"]
+
+yapf:
+    ubuntu:
+        bionic: ["yapf"]
+
+yapf3:
+    ubuntu:
+        default: ["yapf3"]
+
+zulip-pip:
+    pip: ["zulip"]
+
+bundler:
+    ubuntu: ["bundler"]
+
+facets:
+    gem: ["facets"]
+
+flexmock:
+    ubuntu: ["ruby-flexmock"]
+
+hoe:
+    ubuntu: ["ruby-hoe"]
+
+metaruby:
+    gem: ["metaruby"]
+
+nokogiri:
+    ubuntu: ["ruby-nokogiri"]
+
+rake:
+    ubuntu: ["rake"]
+
+rake-compiler:
+    ubuntu: ["rake-compiler"]
+
+rdoc:
+    ubuntu: ["ruby"]
+
+rubocop:
+    ubuntu: ["rubocop"]
+
+ruby:
+    ubuntu: ["ruby"]
+
+ruby-backports:
+    ubuntu: ["ruby-backports"]
+
+ruby-dev:
+    ubuntu: ["ruby-dev"]
+
+ruby-ronn:
+    ubuntu: ["ruby-ronn"]
+
+ruby-sass:
+    ubuntu: ["ruby-sass"]
+
+utilrb:
+    gem: ["utilrb"]
+

--- a/ubuntu.osdeps-rolling
+++ b/ubuntu.osdeps-rolling
@@ -1,0 +1,7793 @@
+#
+# This file is generated, do not edit!
+# based on https://github.com/ros/rosdistro tag rolling/2025-01-02
+#
+ace:
+    ubuntu: ["libace-dev"]
+
+ack:
+    ubuntu:
+        default: ["ack"]
+
+ack-grep:
+    ubuntu: ["ack-grep"]
+
+acl:
+    ubuntu: ["acl", "libacl1-dev"]
+
+acpi:
+    ubuntu: ["acpi"]
+
+alsa-oss:
+    ubuntu: ["alsa-oss"]
+
+alsa-utils:
+    ubuntu: ["alsa-utils"]
+
+ant:
+    ubuntu: ["ant"]
+
+antlr:
+    ubuntu: ["antlr", "libantlr-dev"]
+
+apache2:
+    ubuntu: ["apache2"]
+
+apache2-mpm-prefork:
+    ubuntu: ["apache2-mpm-prefork"]
+
+apparmor:
+    ubuntu: ["apparmor"]
+
+apr:
+    ubuntu: ["libapr1-dev", "libaprutil1-dev"]
+
+apt-transport-https:
+    ubuntu: ["apt-transport-https"]
+
+aravis:
+    ubuntu:
+        default: ["libaravis-0.8-0", "aravis-tools"]
+        bionic: nonexistent
+        focal: ["libaravis-0.6-0", "aravis-tools"]
+
+aravis-dev:
+    ubuntu:
+        default: ["libaravis-dev"]
+        bionic: nonexistent
+
+arduino-core:
+    ubuntu: ["arduino-core"]
+
+arista:
+    ubuntu: ["arista"]
+
+armadillo:
+    ubuntu: ["libarmadillo-dev"]
+
+asio:
+    ubuntu: ["libasio-dev"]
+
+assimp:
+    ubuntu:
+        default: ["libassimp-dev"]
+
+assimp-dev:
+    ubuntu:
+        default: ["libassimp-dev"]
+
+at-spi2-core:
+    ubuntu: ["at-spi2-core"]
+
+atlas:
+    ubuntu: ["libatlas-base-dev"]
+
+autoconf:
+    ubuntu: ["autoconf"]
+
+autoconf-archive:
+    ubuntu: ["autoconf-archive"]
+
+automake:
+    ubuntu: ["automake"]
+
+autopoint:
+    ubuntu: ["autopoint"]
+
+autossh:
+    ubuntu: ["autossh"]
+
+avahi-daemon:
+    ubuntu: ["avahi-daemon"]
+
+avahi-utils:
+    ubuntu: ["avahi-utils"]
+
+avr-libc:
+    ubuntu: ["avr-libc"]
+
+avrdude:
+    ubuntu: ["avrdude"]
+
+awscli:
+    ubuntu: ["awscli"]
+
+babeltrace:
+    ubuntu: ["babeltrace"]
+
+bandit:
+    ubuntu: ["bandit"]
+
+bazaar:
+    ubuntu: ["bzr"]
+
+beep:
+    ubuntu: ["beep"]
+
+benchmark:
+    ubuntu:
+        default: ["libbenchmark-dev"]
+
+binutils:
+    ubuntu: ["binutils-dev"]
+
+bison:
+    ubuntu: ["bison"]
+
+blender:
+    ubuntu: ["blender"]
+
+bluez:
+    ubuntu: ["bluez"]
+
+boost:
+    ubuntu: ["libboost-all-dev"]
+
+box2d-dev:
+    ubuntu: ["libbox2d-dev"]
+
+bullet:
+    ubuntu:
+        default: ["libbullet-dev"]
+
+bullet-extras:
+    ubuntu: ["libbullet-extras-dev"]
+
+bzip2:
+    ubuntu: ["libbz2-dev"]
+
+ca-certificates:
+    ubuntu: ["ca-certificates"]
+
+can-utils:
+    ubuntu: ["can-utils"]
+
+cargo:
+    ubuntu: ["cargo"]
+
+castxml:
+    ubuntu: ["castxml"]
+
+catch2:
+    ubuntu:
+        default: ["catch2"]
+        focal: nonexistent
+
+cccc:
+    ubuntu: ["cccc"]
+
+cdk:
+    ubuntu: ["libcdk5"]
+
+cdk-dev:
+    ubuntu: ["libcdk5-dev"]
+
+cgal:
+    ubuntu: ["libcgal-dev"]
+
+cgal-qt5-dev:
+    ubuntu: ["libcgal-qt5-dev"]
+
+checkinstall:
+    ubuntu: ["checkinstall"]
+
+chromedriver:
+    ubuntu: ["chromium-chromedriver"]
+
+chromium-browser:
+    ubuntu: ["chromium-browser"]
+
+chrony:
+    ubuntu: ["chrony"]
+
+clang:
+    ubuntu: ["clang"]
+
+clang-format:
+    ubuntu: ["clang-format"]
+
+clang-tidy:
+    ubuntu:
+        default: ["clang-tidy"]
+
+clangd:
+    ubuntu: ["clangd"]
+
+cli11:
+    ubuntu:
+        default: ["libcli11-dev"]
+        focal: nonexistent
+
+cmake:
+    ubuntu: ["cmake"]
+
+coinor-libcbc-dev:
+    ubuntu: ["coinor-libcbc-dev"]
+
+coinor-libcbc3:
+    ubuntu: ["coinor-libcbc3"]
+
+coinor-libcgl-dev:
+    ubuntu: ["coinor-libcgl-dev"]
+
+coinor-libclp-dev:
+    ubuntu: ["coinor-libclp-dev"]
+
+coinor-libcoinutils-dev:
+    ubuntu: ["coinor-libcoinutils-dev"]
+
+coinor-libipopt-dev:
+    ubuntu: ["coinor-libipopt-dev"]
+
+coinor-libosi-dev:
+    ubuntu: ["coinor-libosi-dev"]
+
+collada-dom:
+    ubuntu:
+        default: ["libcollada-dom2.4-dp-dev"]
+
+collectd:
+    ubuntu: ["collectd"]
+
+collectd-utils:
+    ubuntu: ["collectd-utils"]
+
+comedi:
+    ubuntu: ["libcomedi-dev"]
+
+coreutils:
+    ubuntu: ["coreutils"]
+
+couchdb:
+    ubuntu: ["couchdb"]
+
+cppad:
+    ubuntu: ["cppad"]
+
+cppcheck:
+    ubuntu: ["cppcheck"]
+
+cppunit:
+    ubuntu: ["libcppunit-dev"]
+
+cpuburn:
+    ubuntu: ["cpuburn"]
+
+crypto++:
+    ubuntu: ["libcrypto++-dev"]
+
+curl:
+    ubuntu: ["libcurl4-openssl-dev", "curl"]
+
+curlpp-dev:
+    ubuntu: ["libcurlpp-dev"]
+
+cvs:
+    ubuntu: ["cvs"]
+
+cwiid:
+    ubuntu: ["libcwiid1"]
+
+cwiid-dev:
+    ubuntu: ["libcwiid-dev"]
+
+daemontools:
+    ubuntu: ["daemontools"]
+
+darknet:
+    ubuntu: ["darknet"]
+
+dcraw:
+    ubuntu: ["dcraw"]
+
+debhelper:
+    ubuntu: ["debhelper"]
+
+debtree:
+    ubuntu: ["debtree"]
+
+devilspie2:
+    ubuntu: ["devilspie2"]
+
+devscripts:
+    ubuntu: ["devscripts"]
+
+dfu-util:
+    ubuntu: ["dfu-util"]
+
+dh-python:
+    ubuntu: ["dh-python"]
+
+disper:
+    ubuntu: ["disper"]
+
+dkms:
+    ubuntu: ["dkms"]
+
+dnsmasq:
+    ubuntu: ["dnsmasq"]
+
+docker-compose:
+    ubuntu: ["docker-compose"]
+
+docker.io:
+    ubuntu: ["docker.io"]
+
+doxygen:
+    ubuntu: ["doxygen"]
+
+dpkg:
+    ubuntu: ["dpkg"]
+
+dpkg-dev:
+    ubuntu: ["dpkg-dev"]
+
+dvipng:
+    ubuntu: ["dvipng"]
+
+e2fsprogs:
+    ubuntu: ["e2fsprogs"]
+
+eclipse:
+    ubuntu:
+        karmic: ["eclipse", "eclipse-platform", "eclipse-rcp", "eclipse-pde"]
+
+ed:
+    ubuntu: ["ed"]
+
+eigen:
+    ubuntu: ["libeigen3-dev"]
+
+eigen2:
+    ubuntu: ["libeigen2-dev"]
+
+emacs:
+    ubuntu: ["emacs"]
+
+embree:
+    ubuntu:
+        default: ["libembree-dev"]
+        bionic: nonexistent
+
+enblend:
+    ubuntu: ["enblend"]
+
+enet:
+    ubuntu: ["libenet-dev"]
+
+espeak:
+    ubuntu: ["espeak"]
+
+ethtool:
+    ubuntu: ["ethtool"]
+
+exfat-fuse:
+    ubuntu: ["exfat-fuse"]
+
+exfat-utils:
+    ubuntu: ["exfat-utils"]
+
+exiv2:
+    ubuntu: ["exiv2"]
+
+f2c:
+    ubuntu: ["f2c", "libf2c2", "libf2c2-dev"]
+
+fakeroot:
+    ubuntu: ["fakeroot"]
+
+fcgi:
+    ubuntu: ["libfcgi-dev", "libapache2-mod-fastcgi", "spawn-fcgi"]
+
+festival:
+    ubuntu: ["festival", "festvox-kallpc16k"]
+
+festival-dev:
+    ubuntu: ["festival-dev"]
+
+ffmpeg:
+    ubuntu:
+        default: ["ffmpeg", "libavcodec-dev", "libavformat-dev", "libavutil-dev", "libswscale-dev"]
+
+ffmpeg-dev:
+    ubuntu: ["libavcodec-dev", "libavdevice-dev", "libavfilter-dev", "libavformat-dev", "libavutil-dev", "libpostproc-dev", "libswresample-dev", "libswscale-dev"]
+
+ffmpeg2theora:
+    ubuntu: ["ffmpeg2theora"]
+
+file:
+    ubuntu: ["file"]
+
+filezilla:
+    ubuntu: ["filezilla"]
+
+flac:
+    ubuntu: ["flac"]
+
+flawfinder:
+    ubuntu: ["flawfinder"]
+
+flex:
+    ubuntu: ["flex"]
+
+flite:
+    ubuntu: ["flite"]
+
+fltk:
+    ubuntu:
+        bionic: ["fluid", "libfltk1.3-dev"]
+        focal: ["fluid", "libfltk1.3-dev"]
+
+fluid:
+    ubuntu: ["fluid"]
+
+fluidsynth:
+    ubuntu: ["fluidsynth"]
+
+fmt:
+    ubuntu: ["libfmt-dev"]
+
+fonts-noto:
+    ubuntu: ["fonts-noto"]
+
+fonts-roboto:
+    ubuntu: ["fonts-roboto-hinted", "fonts-roboto-unhinted"]
+
+fping:
+    ubuntu: ["fping"]
+
+freeimage:
+    ubuntu: ["libfreeimage-dev"]
+
+freetype:
+    ubuntu: ["libfreetype6"]
+
+fsharp:
+    ubuntu: ["fsharp"]
+
+fswebcam:
+    ubuntu: ["fswebcam"]
+
+ftdi-eeprom:
+    ubuntu: ["ftdi-eeprom"]
+
+fxload:
+    ubuntu: ["fxload"]
+
+g++-10:
+    ubuntu:
+        focal: ["g++-10"]
+        jammy: ["g++-10"]
+
+g++-5-arm-linux-gnueabihf:
+    ubuntu: ["g++-5-arm-linux-gnueabihf"]
+
+g++-5-multilib:
+    ubuntu: ["g++-5-multilib"]
+
+g++-multilib:
+    ubuntu: ["g++-multilib"]
+
+g++-static:
+    ubuntu: ["g++"]
+
+gamin:
+    ubuntu: ["gamin"]
+
+gawk:
+    ubuntu: ["gawk"]
+
+gazebo:
+    ubuntu:
+        bionic: ["gazebo9"]
+        focal: ["gazebo11"]
+        jammy: ["gazebo"]
+
+gazebo11:
+    ubuntu:
+        focal: ["gazebo11"]
+        jammy: ["gazebo"]
+
+gazebo5:
+    ubuntu: ["gazebo5"]
+
+gazebo7:
+    ubuntu: ["gazebo7"]
+
+gazebo9:
+    ubuntu:
+        bionic: ["gazebo9"]
+
+gcc-arm-none-eabi:
+    ubuntu: ["gcc-arm-none-eabi"]
+
+gcc-avr:
+    ubuntu: ["gcc-avr"]
+
+gcc-multilib:
+    ubuntu: ["gcc-multilib"]
+
+gcc-static:
+    ubuntu: ["gcc"]
+
+gccxml:
+    ubuntu: ["gccxml"]
+
+gcovr:
+    ubuntu: ["gcovr"]
+
+gdal-bin:
+    ubuntu: ["gdal-bin"]
+
+geographiclib:
+    ubuntu:
+        default: ["libgeographiclib-dev"]
+        focal: ["libgeographic-dev"]
+        jammy: ["libgeographic-dev"]
+
+geographiclib-tools:
+    ubuntu: ["geographiclib-tools"]
+
+geos:
+    ubuntu: ["libgeos-dev"]
+
+gettext-base:
+    ubuntu: ["gettext-base"]
+
+gforth:
+    ubuntu: ["gforth"]
+
+gfortran:
+    ubuntu: ["gfortran"]
+
+ghc:
+    ubuntu: ["ghc"]
+
+gifsicle:
+    ubuntu: ["gifsicle"]
+
+gimp:
+    ubuntu: ["gimp"]
+
+git:
+    ubuntu: ["git"]
+
+git-lfs:
+    ubuntu: ["git-lfs"]
+
+gitg:
+    ubuntu: ["gitg"]
+
+gitk:
+    ubuntu: ["gitk"]
+
+gksu:
+    ubuntu: ["gksu"]
+
+glpk:
+    ubuntu: ["libglpk-dev"]
+
+glslang-dev:
+    ubuntu: ["glslang-dev"]
+
+glslc:
+    ubuntu:
+        default: ["glslc"]
+        focal: nonexistent
+        jammy: nonexistent
+
+glut:
+    ubuntu: ["freeglut3-dev"]
+
+gnat:
+    ubuntu: ["gnat"]
+
+gnome-terminal:
+    ubuntu: ["gnome-terminal"]
+
+gnuplot:
+    ubuntu: ["gnuplot"]
+
+gnuplot-iostream:
+    ubuntu: ["libgnuplot-iostream-dev"]
+
+gnuplot-x11:
+    ubuntu: ["gnuplot-x11"]
+
+golang-go:
+    ubuntu: ["golang-go"]
+
+google-mock:
+    ubuntu: ["google-mock"]
+
+gpac:
+    ubuntu: ["gpac"]
+
+gperf:
+    ubuntu: ["gperf"]
+
+gperftools:
+    ubuntu: ["google-perftools", "libgoogle-perftools-dev"]
+
+gpg-agent:
+    ubuntu:
+        default: ["gpg-agent"]
+
+gphoto2:
+    ubuntu: ["gphoto2"]
+
+gprbuild:
+    ubuntu: ["gprbuild"]
+
+gpsd:
+    ubuntu: ["gpsd"]
+
+gradle:
+    ubuntu: ["gradle"]
+
+graphicsmagick:
+    ubuntu: ["libgraphicsmagick++1-dev", "graphicsmagick-libmagick-dev-compat"]
+
+graphviz:
+    ubuntu: ["graphviz"]
+
+graphviz-dev:
+    ubuntu: ["libgraphviz-dev"]
+
+gringo:
+    ubuntu: ["gringo"]
+
+gstreamer0.10-plugins-good:
+    ubuntu: ["gstreamer0.10-plugins-good"]
+
+gstreamer0.10-pocketsphinx:
+    ubuntu: ["gstreamer0.10-pocketsphinx"]
+
+gstreamer1.0:
+    ubuntu: ["gstreamer1.0-tools", "libgstreamer1.0-0", "gir1.2-gstreamer-1.0"]
+
+gstreamer1.0-alsa:
+    ubuntu: ["gstreamer1.0-alsa"]
+
+gstreamer1.0-gl:
+    ubuntu:
+        default: ["gstreamer1.0-gl"]
+
+gstreamer1.0-libav:
+    ubuntu: ["gstreamer1.0-libav"]
+
+gstreamer1.0-plugins-bad:
+    ubuntu: ["gstreamer1.0-plugins-bad"]
+
+gstreamer1.0-plugins-base:
+    ubuntu: ["gstreamer1.0-plugins-base", "libgstreamer-plugins-base1.0-0", "gir1.2-gst-plugins-base-1.0"]
+
+gstreamer1.0-plugins-good:
+    ubuntu: ["gstreamer1.0-plugins-good", "libgstreamer-plugins-good1.0-0"]
+
+gstreamer1.0-plugins-ugly:
+    ubuntu: ["gstreamer1.0-plugins-ugly"]
+
+gstreamer1.0-rtsp:
+    ubuntu: ["gstreamer1.0-rtsp"]
+
+gstreamer1.0-tools:
+    ubuntu: ["gstreamer1.0-tools"]
+
+gstreamer1.0-x:
+    ubuntu: ["gstreamer1.0-x"]
+
+gtest:
+    ubuntu: ["libgtest-dev"]
+
+gtk-doc-tools:
+    ubuntu: ["gtk-doc-tools"]
+
+gtk2:
+    ubuntu: ["libgtk2.0-dev"]
+
+gtk3:
+    ubuntu: ["libgtk-3-dev"]
+
+gurumdds-2.6:
+    ubuntu:
+        bionic: ["gurumdds-2.6"]
+        focal: ["gurumdds-2.6"]
+
+gurumdds-2.7:
+    ubuntu:
+        bionic: ["gurumdds-2.7"]
+        focal: ["gurumdds-2.7"]
+
+gurumdds-2.8:
+    ubuntu:
+        bionic: ["gurumdds-2.8"]
+        focal: ["gurumdds-2.8"]
+        jammy: ["gurumdds-2.8"]
+
+gurumdds-3.0:
+    ubuntu:
+        jammy: ["gurumdds-3.0"]
+
+gv:
+    ubuntu: ["gv"]
+
+gz-citadel:
+    ubuntu:
+        focal: ["gz-citadel"]
+
+gz-cmake2:
+    ubuntu:
+        focal: ["libgz-cmake2-dev"]
+        jammy: ["libgz-cmake2-dev"]
+
+gz-common3:
+    ubuntu:
+        focal: ["libgz-common3-dev"]
+
+gz-common4:
+    ubuntu:
+        focal: ["libgz-common4-dev"]
+        jammy: ["libgz-common4-dev"]
+
+gz-fortress:
+    ubuntu:
+        focal: ["gz-fortress"]
+        jammy: ["gz-fortress"]
+
+gz-fuel-tools4:
+    ubuntu:
+        focal: ["libgz-fuel-tools4-dev"]
+
+gz-fuel-tools7:
+    ubuntu:
+        focal: ["libgz-fuel-tools7-dev"]
+        jammy: ["libgz-fuel-tools7-dev"]
+
+gz-gui3:
+    ubuntu:
+        focal: ["libgz-gui3-dev"]
+
+gz-gui6:
+    ubuntu:
+        focal: ["libgz-gui6-dev"]
+        jammy: ["libgz-gui6-dev"]
+
+gz-launch2:
+    ubuntu:
+        focal: ["libgz-launch2-dev"]
+
+gz-launch5:
+    ubuntu:
+        focal: ["libgz-launch5-dev"]
+        jammy: ["libgz-launch5-dev"]
+
+gz-math6:
+    ubuntu:
+        focal: ["libgz-math6-dev"]
+        jammy: ["libgz-math6-dev"]
+
+gz-math6-eigen3:
+    ubuntu:
+        focal: ["libgz-math6-eigen3-dev"]
+        jammy: ["libgz-math6-eigen3-dev"]
+
+gz-msgs5:
+    ubuntu:
+        focal: ["libgz-msgs5-dev"]
+
+gz-msgs8:
+    ubuntu:
+        focal: ["libgz-msgs8-dev"]
+        jammy: ["libgz-msgs8-dev"]
+
+gz-physics2:
+    ubuntu:
+        focal: ["libgz-physics2-dev"]
+
+gz-physics5:
+    ubuntu:
+        focal: ["libgz-physics5-dev"]
+        jammy: ["libgz-physics5-dev"]
+
+gz-plugin:
+    ubuntu:
+        focal: ["libgz-plugin-dev"]
+        jammy: ["libgz-plugin-dev"]
+
+gz-rendering3:
+    ubuntu:
+        focal: ["libgz-rendering3-dev"]
+
+gz-rendering6:
+    ubuntu:
+        focal: ["libgz-rendering6-dev"]
+        jammy: ["libgz-rendering6-dev"]
+
+gz-sensors3:
+    ubuntu:
+        focal: ["libgz-sensors3-dev"]
+
+gz-sensors6:
+    ubuntu:
+        focal: ["libgz-sensors6-dev"]
+        jammy: ["libgz-sensors6-dev"]
+
+gz-sim3:
+    ubuntu:
+        focal: ["libgz-sim3-dev"]
+
+gz-sim6:
+    ubuntu:
+        focal: ["libgz-sim6-dev"]
+        jammy: ["libgz-sim6-dev"]
+
+gz-sim6-plugins:
+    ubuntu:
+        focal: ["libgz-sim6-plugins"]
+        jammy: ["libgz-sim6-plugins"]
+
+gz-tools:
+    ubuntu:
+        focal: ["libgz-tools-dev"]
+        jammy: ["libgz-tools-dev"]
+
+gz-transport11:
+    ubuntu:
+        focal: ["libgz-transport11-dev"]
+        jammy: ["libgz-transport11-dev"]
+
+gz-transport8:
+    ubuntu:
+        focal: ["libgz-transport8-dev"]
+
+gz-utils1:
+    ubuntu:
+        focal: ["libgz-utils1-dev"]
+        jammy: ["libgz-utils1-dev"]
+
+gz-utils1-cli:
+    ubuntu:
+        focal: ["libgz-utils1-cli-dev"]
+        jammy: ["libgz-utils1-cli-dev"]
+
+haproxy:
+    ubuntu: ["haproxy"]
+
+hddtemp:
+    ubuntu:
+        default: nonexistent
+        bionic: ["hddtemp"]
+        focal: ["hddtemp"]
+
+hdf5:
+    ubuntu: ["libhdf5-dev"]
+
+hdf5-tools:
+    ubuntu: ["hdf5-tools"]
+
+hostapd:
+    ubuntu: ["hostapd"]
+
+hostname:
+    ubuntu: ["hostname"]
+
+htop:
+    ubuntu: ["htop"]
+
+hugin-tools:
+    ubuntu: ["hugin-tools"]
+
+i2c-tools:
+    ubuntu: ["i2c-tools"]
+
+ifstat:
+    ubuntu: ["ifstat"]
+
+ignition-citadel:
+    ubuntu:
+        focal: ["ignition-citadel"]
+
+ignition-cmake2:
+    ubuntu:
+        focal: ["libignition-cmake2-dev"]
+        jammy: ["libignition-cmake2-dev"]
+
+ignition-common3:
+    ubuntu:
+        focal: ["libignition-common3-dev"]
+
+ignition-common4:
+    ubuntu:
+        focal: ["libignition-common4-dev"]
+        jammy: ["libignition-common4-dev"]
+
+ignition-edifice:
+    ubuntu:
+        focal: ["ignition-edifice"]
+
+ignition-fortress:
+    ubuntu:
+        focal: ["ignition-fortress"]
+        jammy: ["ignition-fortress"]
+
+ignition-fuel-tools4:
+    ubuntu:
+        focal: ["libignition-fuel-tools4-dev"]
+
+ignition-fuel-tools6:
+    ubuntu:
+        focal: ["libignition-fuel-tools6-dev"]
+
+ignition-fuel-tools7:
+    ubuntu:
+        focal: ["libignition-fuel-tools7-dev"]
+        jammy: ["libignition-fuel-tools7-dev"]
+
+ignition-gazebo3:
+    ubuntu:
+        focal: ["libignition-gazebo3-dev"]
+
+ignition-gazebo5:
+    ubuntu:
+        focal: ["libignition-gazebo5-dev"]
+
+ignition-gazebo5-plugins:
+    ubuntu:
+        focal: ["libignition-gazebo5-plugins"]
+
+ignition-gazebo6:
+    ubuntu:
+        focal: ["libignition-gazebo6-dev"]
+        jammy: ["libignition-gazebo6-dev"]
+
+ignition-gazebo6-plugins:
+    ubuntu:
+        focal: ["libignition-gazebo6-plugins"]
+        jammy: ["libignition-gazebo6-plugins"]
+
+ignition-gui3:
+    ubuntu:
+        focal: ["libignition-gui3-dev"]
+
+ignition-gui5:
+    ubuntu:
+        focal: ["libignition-gui5-dev"]
+
+ignition-gui6:
+    ubuntu:
+        focal: ["libignition-gui6-dev"]
+        jammy: ["libignition-gui6-dev"]
+
+ignition-launch2:
+    ubuntu:
+        focal: ["libignition-launch2-dev"]
+
+ignition-launch4:
+    ubuntu:
+        focal: ["libignition-launch4-dev"]
+
+ignition-launch5:
+    ubuntu:
+        focal: ["libignition-launch5-dev"]
+        jammy: ["libignition-launch5-dev"]
+
+ignition-math6:
+    ubuntu:
+        focal: ["libignition-math6-dev"]
+        jammy: ["libignition-math6-dev"]
+
+ignition-math6-eigen3:
+    ubuntu:
+        focal: ["libignition-math6-eigen3-dev"]
+        jammy: ["libignition-math6-eigen3-dev"]
+
+ignition-msgs5:
+    ubuntu:
+        focal: ["libignition-msgs5-dev"]
+
+ignition-msgs7:
+    ubuntu:
+        focal: ["libignition-msgs7-dev"]
+
+ignition-msgs8:
+    ubuntu:
+        focal: ["libignition-msgs8-dev"]
+        jammy: ["libignition-msgs8-dev"]
+
+ignition-physics2:
+    ubuntu:
+        focal: ["libignition-physics2-dev"]
+
+ignition-physics4:
+    ubuntu:
+        focal: ["libignition-physics4-dev"]
+
+ignition-physics5:
+    ubuntu:
+        focal: ["libignition-physics5-dev"]
+        jammy: ["libignition-physics5-dev"]
+
+ignition-plugin:
+    ubuntu:
+        focal: ["libignition-plugin-dev"]
+        jammy: ["libignition-plugin-dev"]
+
+ignition-rendering3:
+    ubuntu:
+        focal: ["libignition-rendering3-dev"]
+
+ignition-rendering5:
+    ubuntu:
+        focal: ["libignition-rendering5-dev"]
+
+ignition-rendering6:
+    ubuntu:
+        focal: ["libignition-rendering6-dev"]
+        jammy: ["libignition-rendering6-dev"]
+
+ignition-sensors3:
+    ubuntu:
+        focal: ["libignition-sensors3-dev"]
+
+ignition-sensors5:
+    ubuntu:
+        focal: ["libignition-sensors5-dev"]
+
+ignition-sensors6:
+    ubuntu:
+        focal: ["libignition-sensors6-dev"]
+        jammy: ["libignition-sensors6-dev"]
+
+ignition-tools:
+    ubuntu:
+        focal: ["libignition-tools-dev"]
+        jammy: ["libignition-tools-dev"]
+
+ignition-transport10:
+    ubuntu:
+        focal: ["libignition-transport10-dev"]
+
+ignition-transport11:
+    ubuntu:
+        focal: ["libignition-transport11-dev"]
+        jammy: ["libignition-transport11-dev"]
+
+ignition-transport8:
+    ubuntu:
+        focal: ["libignition-transport8-dev"]
+
+ignition-utils1:
+    ubuntu:
+        focal: ["libignition-utils1-dev"]
+        jammy: ["libignition-utils1-dev"]
+
+ignition-utils1-cli:
+    ubuntu:
+        focal: ["libignition-utils1-cli-dev"]
+        jammy: ["libignition-utils1-cli-dev"]
+
+imagemagick:
+    ubuntu: ["imagemagick"]
+
+intel-opencl-icd:
+    ubuntu:
+        default: ["intel-opencl-icd"]
+        bionic: nonexistent
+
+intltool:
+    ubuntu: ["intltool"]
+
+inxi:
+    ubuntu: ["inxi"]
+
+iperf:
+    ubuntu: ["iperf"]
+
+ipmitool:
+    ubuntu: ["ipmitool"]
+
+iproute2:
+    ubuntu: ["iproute2"]
+
+iputils-ping:
+    ubuntu: ["iputils-ping"]
+
+iwyu:
+    ubuntu: ["iwyu"]
+
+jack:
+    ubuntu: ["libjack-jackd2-dev"]
+
+java:
+    ubuntu: ["default-jdk"]
+
+joystick:
+    ubuntu: ["joystick"]
+
+jq:
+    ubuntu: ["jq"]
+
+julius-voxforge:
+    ubuntu: ["julius-voxforge"]
+
+jython:
+    ubuntu: ["jython"]
+
+kakasi:
+    ubuntu: ["kakasi"]
+
+kate:
+    ubuntu: ["kate"]
+
+kgraphviewer:
+    ubuntu: ["kgraphviewer"]
+
+konsole:
+    ubuntu: ["konsole"]
+
+language-pack-de:
+    ubuntu: ["language-pack-de"]
+
+language-pack-en:
+    ubuntu: ["language-pack-en"]
+
+lcov:
+    ubuntu: ["lcov"]
+
+lensfun:
+    ubuntu: ["liblensfun1"]
+
+lensfun-dev:
+    ubuntu: ["liblensfun-dev"]
+
+leveldb:
+    ubuntu: ["libleveldb-dev"]
+
+lib32asound2:
+    ubuntu: ["lib32asound2"]
+
+libabsl-dev:
+    ubuntu:
+        default: ["libabsl-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libadolc-dev:
+    ubuntu: ["libadolc-dev"]
+
+libalglib-dev:
+    ubuntu: ["libalglib-dev"]
+
+libann-dev:
+    ubuntu: ["libann-dev"]
+
+libao-dev:
+    ubuntu: ["libao-dev"]
+
+libapache2-mod-python:
+    ubuntu: ["libapache2-mod-python"]
+
+libargtable2-dev:
+    ubuntu: ["libargtable2-dev"]
+
+libaria:
+    ubuntu:
+        default: ["libaria-dev"]
+
+libasound2-dev:
+    ubuntu: ["libasound2-dev"]
+
+libatomic:
+    ubuntu: ["libatomic1"]
+
+libav:
+    ubuntu:
+        default: nonexistent
+
+libavahi-client-dev:
+    ubuntu: ["libavahi-client-dev"]
+
+libavahi-core-dev:
+    ubuntu: ["libavahi-core-dev"]
+
+libavdevice-dev:
+    ubuntu: ["libavdevice-dev"]
+
+libb64-dev:
+    ubuntu: ["libb64-dev"]
+
+libbackward-cpp-dev:
+    ubuntu:
+        default: ["libbackward-cpp-dev"]
+        bionic: nonexistent
+
+libbdd-dev:
+    ubuntu: ["libbdd-dev"]
+
+libblas-dev:
+    ubuntu: ["libblas-dev"]
+
+libblosc-dev:
+    ubuntu: ["libblosc-dev"]
+
+libbluetooth:
+    ubuntu: ["libbluetooth3"]
+
+libbluetooth-dev:
+    ubuntu: ["libbluetooth-dev"]
+
+libboost-atomic:
+    ubuntu:
+        bionic: ["libboost-atomic1.65.1"]
+        focal: ["libboost-atomic1.71.0"]
+        jammy: ["libboost-atomic1.74.0"]
+        noble: ["libboost-atomic1.83.0"]
+
+libboost-atomic-dev:
+    ubuntu: ["libboost-atomic-dev"]
+
+libboost-chrono:
+    ubuntu:
+        bionic: ["libboost-chrono1.65.1"]
+        focal: ["libboost-chrono1.71.0"]
+        jammy: ["libboost-chrono1.74.0"]
+        noble: ["libboost-chrono1.83.0"]
+
+libboost-chrono-dev:
+    ubuntu: ["libboost-chrono-dev"]
+
+libboost-coroutine:
+    ubuntu:
+        bionic: ["libboost-coroutine1.65.1"]
+        focal: ["libboost-coroutine1.71.0"]
+        jammy: ["libboost-coroutine1.74.0"]
+        noble: ["libboost-coroutine1.83.0"]
+
+libboost-coroutine-dev:
+    ubuntu: ["libboost-coroutine-dev"]
+
+libboost-date-time:
+    ubuntu:
+        bionic: ["libboost-date-time1.65.1"]
+        focal: ["libboost-date-time1.71.0"]
+        jammy: ["libboost-date-time1.74.0"]
+        noble: ["libboost-date-time1.83.0"]
+
+libboost-date-time-dev:
+    ubuntu: ["libboost-date-time-dev"]
+
+libboost-dev:
+    ubuntu: ["libboost-dev"]
+
+libboost-filesystem:
+    ubuntu:
+        bionic: ["libboost-filesystem1.65.1"]
+        focal: ["libboost-filesystem1.71.0"]
+        jammy: ["libboost-filesystem1.74.0"]
+        noble: ["libboost-filesystem1.83.0"]
+
+libboost-filesystem-dev:
+    ubuntu: ["libboost-filesystem-dev"]
+
+libboost-iostreams:
+    ubuntu:
+        bionic: ["libboost-iostreams1.65.1"]
+        focal: ["libboost-iostreams1.71.0"]
+        jammy: ["libboost-iostreams1.74.0"]
+        noble: ["libboost-iostreams1.83.0"]
+
+libboost-iostreams-dev:
+    ubuntu: ["libboost-iostreams-dev"]
+
+libboost-math:
+    ubuntu:
+        bionic: ["libboost-math1.65.1"]
+        focal: ["libboost-math1.71.0"]
+        jammy: ["libboost-math1.74.0"]
+        noble: ["libboost-math1.83.0"]
+
+libboost-math-dev:
+    ubuntu: ["libboost-math-dev"]
+
+libboost-numpy-dev:
+    ubuntu: ["libboost-numpy-dev"]
+
+libboost-program-options:
+    ubuntu:
+        bionic: ["libboost-program-options1.65.1"]
+        focal: ["libboost-program-options1.71.0"]
+        jammy: ["libboost-program-options1.74.0"]
+        noble: ["libboost-program-options1.83.0"]
+
+libboost-program-options-dev:
+    ubuntu: ["libboost-program-options-dev"]
+
+libboost-python:
+    ubuntu:
+        bionic: ["libboost-python1.65.1"]
+        focal: ["libboost-python1.71.0"]
+        jammy: ["libboost-python1.74.0"]
+        noble: ["libboost-python1.83.0"]
+
+libboost-python-dev:
+    ubuntu: ["libboost-python-dev"]
+
+libboost-random:
+    ubuntu:
+        bionic: ["libboost-random1.65.1"]
+        focal: ["libboost-random1.71.0"]
+        jammy: ["libboost-random1.74.0"]
+        noble: ["libboost-random1.83.0"]
+
+libboost-random-dev:
+    ubuntu: ["libboost-random-dev"]
+
+libboost-regex:
+    ubuntu:
+        bionic: ["libboost-regex1.65.1"]
+        focal: ["libboost-regex1.71.0"]
+        jammy: ["libboost-regex1.74.0"]
+        noble: ["libboost-regex1.83.0"]
+
+libboost-regex-dev:
+    ubuntu: ["libboost-regex-dev"]
+
+libboost-serialization:
+    ubuntu:
+        bionic: ["libboost-serialization1.65.1"]
+        focal: ["libboost-serialization1.71.0"]
+        jammy: ["libboost-serialization1.74.0"]
+        noble: ["libboost-serialization1.83.0"]
+
+libboost-serialization-dev:
+    ubuntu: ["libboost-serialization-dev"]
+
+libboost-system:
+    ubuntu:
+        bionic: ["libboost-system1.65.1"]
+        focal: ["libboost-system1.71.0"]
+        jammy: ["libboost-system1.74.0"]
+        noble: ["libboost-system1.83.0"]
+
+libboost-system-dev:
+    ubuntu: ["libboost-system-dev"]
+
+libboost-thread:
+    ubuntu:
+        bionic: ["libboost-thread1.65.1"]
+        focal: ["libboost-thread1.71.0"]
+        jammy: ["libboost-thread1.74.0"]
+        noble: ["libboost-thread1.83.0"]
+
+libboost-thread-dev:
+    ubuntu: ["libboost-thread-dev"]
+
+libboost-timer:
+    ubuntu:
+        bionic: ["libboost-timer1.65.1"]
+        focal: ["libboost-timer1.71.0"]
+        jammy: ["libboost-timer1.74.0"]
+        noble: ["libboost-timer1.83.0"]
+
+libboost-timer-dev:
+    ubuntu: ["libboost-timer-dev"]
+
+libbsd-dev:
+    ubuntu: ["libbsd-dev"]
+
+libcairo2-dev:
+    ubuntu: ["libcairo2-dev"]
+
+libcap-dev:
+    ubuntu: ["libcap-dev"]
+
+libcap-ng-dev:
+    ubuntu: ["libcap-ng-dev"]
+
+libcap-ng0:
+    ubuntu: ["libcap-ng0"]
+
+libcap2:
+    ubuntu: ["libcap2"]
+
+libcap2-bin:
+    ubuntu: ["libcap2-bin"]
+
+libccd-dev:
+    ubuntu: ["libccd-dev"]
+
+libccid:
+    ubuntu: ["libccid"]
+
+libcdd-dev:
+    ubuntu: ["libcdd-dev"]
+
+libcegui-mk2-dev:
+    ubuntu: ["libcegui-mk2-dev"]
+
+libcereal-dev:
+    ubuntu: ["libcereal-dev"]
+
+libceres-dev:
+    ubuntu: ["libceres-dev"]
+
+libcgroup-dev:
+    ubuntu: ["libcgroup-dev"]
+
+libclang-dev:
+    ubuntu: ["libclang-dev"]
+
+libcoin60-dev:
+    ubuntu: ["libcoin60-dev"]
+
+libcoin80-dev:
+    ubuntu:
+        default: ["libcoin-dev"]
+        bionic: ["libcoin80-dev"]
+
+libconfig++-dev:
+    ubuntu: ["libconfig++-dev"]
+
+libconfig-dev:
+    ubuntu: ["libconfig-dev"]
+
+libconsole-bridge-dev:
+    ubuntu: ["libconsole-bridge-dev"]
+
+libcos4-dev:
+    ubuntu: ["libcos4-dev"]
+
+libcpp-httplib-dev:
+    ubuntu:
+        default: ["libcpp-httplib-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libcpprest-dev:
+    ubuntu: ["libcpprest-dev"]
+
+libcunit-dev:
+    ubuntu: ["libcunit1-dev"]
+
+libcurl:
+    ubuntu: ["libcurl4"]
+
+libcurl-dev:
+    ubuntu: ["libcurl4-openssl-dev"]
+
+libdbus-dev:
+    ubuntu: ["libdbus-1-dev"]
+
+libdc1394-dev:
+    ubuntu:
+        default: ["libdc1394-dev"]
+        bionic: ["libdc1394-22-dev"]
+        focal: ["libdc1394-22-dev"]
+
+libdevil-dev:
+    ubuntu: ["libdevil-dev"]
+
+libdlib-dev:
+    ubuntu:
+        default: ["libdlib-dev"]
+
+libdmtx-dev:
+    ubuntu: ["libdmtx-dev"]
+
+libdpkg-dev:
+    ubuntu: ["libdpkg-dev"]
+
+libdraco-dev:
+    ubuntu:
+        default: ["libdraco-dev"]
+        focal: nonexistent
+
+libdrm-dev:
+    ubuntu: ["libdrm-dev"]
+
+libdw-dev:
+    ubuntu: ["libdw-dev"]
+
+libdxflib-dev:
+    ubuntu: ["libdxflib-dev"]
+
+libedit:
+    ubuntu: ["libedit2"]
+
+libedit-dev:
+    ubuntu: ["libedit-dev"]
+
+libepoxy-dev:
+    ubuntu: ["libepoxy-dev"]
+
+libesd0-dev:
+    ubuntu: ["libesd0-dev"]
+
+libespeak-dev:
+    ubuntu: ["libespeak-dev"]
+
+libespeak-ng1:
+    ubuntu: ["libespeak-ng1"]
+
+libestools-dev:
+    ubuntu:
+        default: ["libestools-dev"]
+
+libev-dev:
+    ubuntu: ["libev-dev"]
+
+libevdev-dev:
+    ubuntu: ["libevdev-dev"]
+
+libevent-dev:
+    ubuntu: ["libevent-dev"]
+
+libexif:
+    ubuntu: ["libexif12"]
+
+libexif-dev:
+    ubuntu: ["libexif-dev"]
+
+libexiv2-dev:
+    ubuntu: ["libexiv2-dev"]
+
+libexpat1-dev:
+    ubuntu: ["libexpat1-dev"]
+
+libext2fs-dev:
+    ubuntu: ["libext2fs-dev"]
+
+libfcl:
+    ubuntu:
+        default: ["libfcl0.7"]
+        focal: ["libfcl0.5"]
+
+libfcl-dev:
+    ubuntu:
+        default: ["libfcl-dev"]
+
+libffi-dev:
+    ubuntu: ["libffi-dev"]
+
+libfftw3:
+    ubuntu: ["libfftw3-3", "libfftw3-dev"]
+
+libfl-dev:
+    ubuntu: ["libfl-dev"]
+
+libflann:
+    ubuntu:
+        default: ["libflann1.9"]
+
+libflann-dev:
+    ubuntu: ["libflann-dev"]
+
+libflatbuffers-dev:
+    ubuntu: ["libflatbuffers-dev"]
+
+libfltk-dev:
+    ubuntu: ["libfltk1.3-dev"]
+
+libfontconfig1-dev:
+    ubuntu: ["libfontconfig1-dev"]
+
+libfreeimage:
+    ubuntu: ["libfreeimage3"]
+
+libfreeimage-dev:
+    ubuntu: ["libfreeimage-dev"]
+
+libfreenect-dev:
+    ubuntu: ["libfreenect-dev"]
+
+libfreetype-dev:
+    ubuntu:
+        default: ["libfreetype-dev"]
+        bionic: ["libfreetype6-dev"]
+
+libfreetype6:
+    ubuntu: ["libfreetype6"]
+
+libfreetype6-dev:
+    ubuntu: ["libfreetype6-dev"]
+
+libftdi-dev:
+    ubuntu: ["libftdi-dev"]
+
+libftdi1-dev:
+    ubuntu: ["libftdi1-dev"]
+
+libftdipp-dev:
+    ubuntu:
+        bionic: ["libftdipp1-dev"]
+
+libftgl-dev:
+    ubuntu: ["libftgl-dev"]
+
+libfyaml-dev:
+    ubuntu:
+        default: ["libfyaml-dev"]
+        focal: nonexistent
+
+libgazebo-dev:
+    ubuntu:
+        focal: ["libgazebo11-dev"]
+        jammy: ["libgazebo-dev"]
+
+libgazebo11-dev:
+    ubuntu:
+        focal: ["libgazebo11-dev"]
+        jammy: ["libgazebo-dev"]
+
+libgazebo5-dev:
+    ubuntu: ["libgazebo5-dev"]
+
+libgazebo7-dev:
+    ubuntu: ["libgazebo7-dev"]
+
+libgazebo9-dev:
+    ubuntu:
+        bionic: ["libgazebo9-dev"]
+
+libgconf2:
+    ubuntu: ["libgconf-2-4"]
+
+libgdal-dev:
+    ubuntu: ["libgdal-dev"]
+
+libgeographiclib-dev:
+    ubuntu: ["libgeographiclib-dev"]
+
+libgeos++-dev:
+    ubuntu: ["libgeos++-dev"]
+
+libgeotiff-dev:
+    ubuntu: ["libgeotiff-dev"]
+
+libgflags-dev:
+    ubuntu: ["libgflags-dev"]
+
+libgfortran3:
+    ubuntu: ["libgfortran3"]
+
+libgif-dev:
+    ubuntu: ["libgif-dev"]
+
+libglew-dev:
+    ubuntu: ["libglew-dev"]
+
+libglfw3-dev:
+    ubuntu:
+        default: ["libglfw3-dev"]
+
+libglib-dev:
+    ubuntu: ["libglib2.0-dev"]
+
+libglm-dev:
+    ubuntu: ["libglm-dev"]
+
+libglui-dev:
+    ubuntu: ["libglui-dev"]
+
+libglw1-mesa:
+    ubuntu: ["libglw1-mesa"]
+
+libgmock-dev:
+    ubuntu:
+        default: ["libgmock-dev"]
+        bionic: nonexistent
+
+libgmp:
+    ubuntu: ["libgmp-dev"]
+
+libgnutls28-dev:
+    ubuntu: ["libgnutls28-dev"]
+
+libgomp1:
+    ubuntu: ["libgomp1"]
+
+libgoogle-glog-dev:
+    ubuntu: ["libgoogle-glog-dev"]
+
+libgpgme-dev:
+    ubuntu:
+        default: ["libgpgme-dev"]
+
+libgphoto-dev:
+    ubuntu:
+        default: ["libgphoto2-dev"]
+
+libgpiod-dev:
+    ubuntu: ["libgpiod-dev"]
+
+libgps:
+    ubuntu: ["libgps-dev"]
+
+libgrpc:
+    ubuntu: ["libgrpc++-dev"]
+
+libgsl:
+    ubuntu:
+        default: ["libgsl-dev"]
+
+libgstreamer-plugins-bad1.0-dev:
+    ubuntu: ["libgstreamer-plugins-bad1.0-dev"]
+
+libgstreamer-plugins-base0.10-0:
+    ubuntu: ["libgstreamer-plugins-base0.10-0"]
+
+libgstreamer-plugins-base0.10-dev:
+    ubuntu: ["libgstreamer-plugins-base0.10-dev"]
+
+libgstreamer-plugins-base1.0-dev:
+    ubuntu: ["libgstreamer-plugins-base1.0-dev"]
+
+libgstreamer0.10-0:
+    ubuntu: ["libgstreamer0.10-0"]
+
+libgstreamer0.10-dev:
+    ubuntu: ["libgstreamer0.10-dev"]
+
+libgstreamer1.0-dev:
+    ubuntu: ["libgstreamer1.0-dev"]
+
+libgstrtspserver-1.0-0:
+    ubuntu: ["libgstrtspserver-1.0-0"]
+
+libgstrtspserver-1.0-dev:
+    ubuntu: ["libgstrtspserver-1.0-dev"]
+
+libgtkmm:
+    ubuntu: ["libgtkmm-2.4-dev"]
+
+libgtkmm3.0-dev:
+    ubuntu: ["libgtkmm-3.0-dev"]
+
+libgts:
+    ubuntu: ["libgts-dev"]
+
+libhal-dev:
+    ubuntu: ["libhal-dev"]
+
+libhdf5-dev:
+    ubuntu: ["libhdf5-dev"]
+
+libhidapi-dev:
+    ubuntu: ["libhidapi-dev"]
+
+libhpptools-dev:
+    ubuntu: ["libhpptools-dev"]
+
+libi2c-dev:
+    ubuntu: ["libi2c-dev"]
+
+libicu-dev:
+    ubuntu: ["libicu-dev"]
+
+libignition-common3:
+    ubuntu:
+        focal: ["libignition-common3"]
+
+libignition-common4:
+    ubuntu:
+        focal: ["libignition-common4"]
+
+libignition-fuel-tools4:
+    ubuntu:
+        focal: ["libignition-fuel-tools4"]
+
+libignition-fuel-tools6:
+    ubuntu:
+        focal: ["libignition-fuel-tools6"]
+
+libignition-gazebo3:
+    ubuntu:
+        focal: ["libignition-gazebo3"]
+
+libignition-gazebo5:
+    ubuntu:
+        focal: ["libignition-gazebo5"]
+
+libignition-gui3:
+    ubuntu:
+        focal: ["libignition-gui3"]
+
+libignition-gui5:
+    ubuntu:
+        focal: ["libignition-gui5"]
+
+libignition-launch2:
+    ubuntu:
+        focal: ["libignition-launch2"]
+
+libignition-launch4:
+    ubuntu:
+        focal: ["libignition-launch4"]
+
+libignition-math6:
+    ubuntu:
+        focal: ["libignition-math6"]
+
+libignition-msgs5:
+    ubuntu:
+        focal: ["libignition-msgs5"]
+
+libignition-msgs7:
+    ubuntu:
+        focal: ["libignition-msgs7"]
+
+libignition-physics2:
+    ubuntu:
+        focal: ["libignition-physics2"]
+
+libignition-physics4:
+    ubuntu:
+        focal: ["libignition-physics4"]
+
+libignition-rendering3:
+    ubuntu:
+        focal: ["libignition-rendering3"]
+
+libignition-rendering5:
+    ubuntu:
+        focal: ["libignition-rendering5"]
+
+libignition-sensors3:
+    ubuntu:
+        focal: ["libignition-sensors3"]
+
+libignition-sensors5:
+    ubuntu:
+        focal: ["libignition-sensors5"]
+
+libignition-transport10:
+    ubuntu:
+        focal: ["libignition-transport10"]
+
+libignition-transport8:
+    ubuntu:
+        focal: ["libignition-transport8"]
+
+libignition-utils1:
+    ubuntu:
+        focal: ["libignition-utils1"]
+
+libiio-dev:
+    ubuntu: ["libiio-dev"]
+
+libimage-exiftool-perl:
+    ubuntu: ["libimage-exiftool-perl"]
+
+libirrlicht-dev:
+    ubuntu: ["libirrlicht-dev"]
+
+libiw-dev:
+    ubuntu: ["libiw-dev"]
+
+libjack-dev:
+    ubuntu: ["libjack-dev"]
+
+libjackson-json-java:
+    ubuntu: ["libjackson-json-java"]
+
+libjansson-dev:
+    ubuntu: ["libjansson-dev"]
+
+libjchart2d-java:
+    ubuntu: ["libjchart2d-java"]
+
+libjpeg:
+    ubuntu: ["libjpeg-dev"]
+
+libjson-glib:
+    ubuntu: ["libjson-glib-dev"]
+
+libjson-java:
+    ubuntu: ["libjson-java"]
+
+libjson0-dev:
+    ubuntu: ["libjson0-dev"]
+
+libjsoncpp:
+    ubuntu:
+        default: ["libjsoncpp25"]
+        bionic: ["libjsoncpp1"]
+        focal: ["libjsoncpp1"]
+
+libjsoncpp-dev:
+    ubuntu: ["libjsoncpp-dev"]
+
+libjsonrpccpp-client0:
+    ubuntu: ["libjsonrpccpp-client0"]
+
+libjsonrpccpp-common0:
+    ubuntu: ["libjsonrpccpp-common0"]
+
+libjsonrpccpp-dev:
+    ubuntu: ["libjsonrpccpp-dev"]
+
+libjsonrpccpp-server0:
+    ubuntu: ["libjsonrpccpp-server0"]
+
+libjsonrpccpp-stub0:
+    ubuntu: ["libjsonrpccpp-stub0"]
+
+libjsonrpccpp-tools:
+    ubuntu: ["libjsonrpccpp-tools"]
+
+libkdtree++-dev:
+    ubuntu: ["libkdtree++-dev"]
+
+libkml-dev:
+    ubuntu: ["libkml-dev"]
+
+liblapack-dev:
+    ubuntu: ["liblapack-dev"]
+
+liblapacke-dev:
+    ubuntu: ["liblapacke-dev"]
+
+liblcm:
+    ubuntu:
+        default: ["liblcm1"]
+
+liblcm-dev:
+    ubuntu:
+        default: ["liblcm-dev"]
+
+libleptonica-dev:
+    ubuntu: ["libleptonica-dev"]
+
+liblinear-dev:
+    ubuntu: ["liblinear-dev"]
+
+liblinphone-dev:
+    ubuntu: ["liblinphone-dev"]
+
+liblmdb-dev:
+    ubuntu: ["liblmdb-dev"]
+
+liblttng-ctl-dev:
+    ubuntu: ["liblttng-ctl-dev"]
+
+liblttng-ust-dev:
+    ubuntu: ["liblttng-ust-dev"]
+
+liblz4:
+    ubuntu: ["liblz4-1"]
+
+liblz4-dev:
+    ubuntu: ["liblz4-dev"]
+
+liblzma-dev:
+    ubuntu: ["liblzma-dev"]
+
+libmagick:
+    ubuntu: ["libmagick++-dev"]
+
+libmarble-dev:
+    ubuntu: ["libmarble-dev"]
+
+libmbedtls-dev:
+    ubuntu: ["libmbedtls-dev"]
+
+libmicrohttpd:
+    ubuntu: ["libmicrohttpd-dev"]
+
+libmlpack-dev:
+    ubuntu: ["libmlpack-dev"]
+
+libmnl-dev:
+    ubuntu: ["libmnl-dev"]
+
+libmockito-java:
+    ubuntu: ["libmockito-java"]
+
+libmodbus-dev:
+    ubuntu: ["libmodbus-dev"]
+
+libmodbus5:
+    ubuntu: ["libmodbus5"]
+
+libmongoc-1.0-0:
+    ubuntu: ["libmongoc-1.0-0"]
+
+libmongoc-dev:
+    ubuntu: ["libmongoc-dev"]
+
+libmongoclient-dev:
+    ubuntu: ["libmongoclient-dev"]
+
+libmotif-dev:
+    ubuntu: ["libmotif-dev"]
+
+libmp3lame-dev:
+    ubuntu: ["libmp3lame-dev"]
+
+libmpg123-dev:
+    ubuntu: ["libmpg123-dev"]
+
+libmpich-dev:
+    ubuntu: ["libmpich-dev"]
+
+libmpich2-dev:
+    ubuntu: ["libmpich2-dev"]
+
+libmsgsl-dev:
+    ubuntu: ["libmsgsl-dev"]
+
+libmysql++-dev:
+    ubuntu: ["libmysql++-dev"]
+
+libmysql++3v5:
+    ubuntu:
+        focal: ["libmysql++3v5"]
+        jammy: ["libmysql++3v5"]
+
+libmysqlclient-dev:
+    ubuntu: ["libmysqlclient-dev"]
+
+libmysqlcppconn-dev:
+    ubuntu: ["libmysqlcppconn-dev"]
+
+libnanoflann-dev:
+    ubuntu:
+        default: ["libnanoflann-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libnanopb-dev:
+    ubuntu:
+        default: ["libnanopb-dev"]
+        bionic: nonexistent
+
+libncurses:
+    ubuntu: ["libncurses6"]
+
+libncurses-dev:
+    ubuntu: ["libncurses-dev"]
+
+libneon27-gnutls-dev:
+    ubuntu: ["libneon27-gnutls-dev"]
+
+libnewmat10-dev:
+    ubuntu: ["libnewmat10-dev"]
+
+libnl-3:
+    ubuntu: ["libnl-3-200", "libnl-genl-3-200", "libnl-route-3-200"]
+
+libnl-3-dev:
+    ubuntu: ["libnl-3-dev", "libnl-genl-3-dev", "libnl-route-3-dev"]
+
+libnl-dev:
+    ubuntu: ["libnl-dev"]
+
+libnlopt-cxx-dev:
+    ubuntu:
+        default: ["libnlopt-cxx-dev"]
+        bionic: nonexistent
+
+libnlopt-dev:
+    ubuntu: ["libnlopt-dev"]
+
+libnlopt0:
+    ubuntu: ["libnlopt0"]
+
+libnotify:
+    ubuntu: ["libnotify-dev"]
+
+libnss3-dev:
+    ubuntu: ["libnss3-dev"]
+
+liboctomap-dev:
+    ubuntu: ["liboctomap-dev"]
+
+libogg:
+    ubuntu: ["libogg-dev"]
+
+libogre:
+    ubuntu: ["libogre-1.9.0v5"]
+
+libogre-1.12-dev:
+    ubuntu:
+        focal: ["libogre-1.12-dev"]
+        jammy: ["libogre-1.12-dev"]
+
+libogre-dev:
+    ubuntu: ["libogre-1.9-dev"]
+
+libogre1.12.10:
+    ubuntu:
+        jammy: ["libogre1.12.10"]
+
+libois-dev:
+    ubuntu: ["libois-dev"]
+
+libomp-dev:
+    ubuntu: ["libomp-dev"]
+
+libopal-dev:
+    ubuntu: ["libopal-dev"]
+
+libopen3d-dev:
+    ubuntu:
+        default: ["libopen3d-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libopenal-dev:
+    ubuntu: ["libopenal-dev"]
+
+libopenblas-dev:
+    ubuntu: ["libopenblas-dev"]
+
+libopencv-contrib-dev:
+    ubuntu: ["libopencv-contrib-dev"]
+
+libopencv-dev:
+    ubuntu: ["libopencv-dev"]
+
+libopencv-imgproc-dev:
+    ubuntu: ["libopencv-imgproc-dev"]
+
+libopenexr-dev:
+    ubuntu: ["libopenexr-dev"]
+
+libopenni-dev:
+    ubuntu: ["libopenni-dev"]
+
+libopenni-sensor-primesense-dev:
+    ubuntu: ["libopenni-sensor-primesense-dev"]
+
+libopenni2-dev:
+    ubuntu: ["libopenni2-dev"]
+
+libopenscenegraph:
+    ubuntu: ["openscenegraph", "libopenscenegraph-dev"]
+
+libopensplice67:
+    ubuntu:
+        bionic: ["libopensplice67"]
+
+libopensplice69:
+    ubuntu:
+        bionic: ["libopensplice69"]
+
+libopenvdb:
+    ubuntu:
+        bionic: ["libopenvdb5.0"]
+        focal: ["libopenvdb6.2"]
+        jammy: ["libopenvdb8.1"]
+
+libopenvdb-dev:
+    ubuntu: ["libopenvdb-dev", "libilmbase-dev"]
+
+libopus-dev:
+    ubuntu: ["libopus-dev"]
+
+liborocos-bfl:
+    ubuntu:
+        default: ["liborocos-bfl0.8"]
+        bionic: nonexistent
+
+liborocos-bfl-dev:
+    ubuntu: ["liborocos-bfl-dev"]
+
+liborocos-kdl:
+    ubuntu:
+        default: ["liborocos-kdl1.5"]
+        bionic: ["liborocos-kdl1.3"]
+        focal: ["liborocos-kdl1.4"]
+
+liborocos-kdl-dev:
+    ubuntu: ["liborocos-kdl-dev"]
+
+libosmesa6-dev:
+    ubuntu: ["libosmesa6-dev"]
+
+libpaho-mqtt:
+    ubuntu:
+        default: ["libpaho-mqtt1.3"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpaho-mqtt-dev:
+    ubuntu:
+        default: ["libpaho-mqtt-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpaho-mqttpp:
+    ubuntu:
+        default: ["libpaho-mqttpp3-1"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpaho-mqttpp-dev:
+    ubuntu:
+        default: ["libpaho-mqttpp-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libpcap:
+    ubuntu: ["libpcap0.8-dev"]
+
+libpcl-all:
+    ubuntu:
+        bionic: ["libpcl-apps1.8", "libpcl-common1.8", "libpcl-features1.8", "libpcl-filters1.8", "libpcl-io1.8", "libpcl-kdtree1.8", "libpcl-keypoints1.8", "libpcl-ml1.8", "libpcl-octree1.8", "libpcl-outofcore1.8", "libpcl-people1.8", "libpcl-recognition1.8", "libpcl-registration1.8", "libpcl-sample-consensus1.8", "libpcl-search1.8", "libpcl-segmentation1.8", "libpcl-stereo1.8", "libpcl-surface1.8", "libpcl-tracking1.8", "libpcl-visualization1.8"]
+        focal: ["libpcl-apps1.10", "libpcl-common1.10", "libpcl-features1.10", "libpcl-filters1.10", "libpcl-io1.10", "libpcl-kdtree1.10", "libpcl-keypoints1.10", "libpcl-ml1.10", "libpcl-octree1.10", "libpcl-outofcore1.10", "libpcl-people1.10", "libpcl-recognition1.10", "libpcl-registration1.10", "libpcl-sample-consensus1.10", "libpcl-search1.10", "libpcl-segmentation1.10", "libpcl-stereo1.10", "libpcl-surface1.10", "libpcl-tracking1.10", "libpcl-visualization1.10"]
+        jammy: ["libpcl-apps1.12", "libpcl-common1.12", "libpcl-features1.12", "libpcl-filters1.12", "libpcl-io1.12", "libpcl-kdtree1.12", "libpcl-keypoints1.12", "libpcl-ml1.12", "libpcl-octree1.12", "libpcl-outofcore1.12", "libpcl-people1.12", "libpcl-recognition1.12", "libpcl-registration1.12", "libpcl-sample-consensus1.12", "libpcl-search1.12", "libpcl-segmentation1.12", "libpcl-stereo1.12", "libpcl-surface1.12", "libpcl-tracking1.12", "libpcl-visualization1.12"]
+        noble: ["libpcl-apps1.14", "libpcl-common1.14", "libpcl-features1.14", "libpcl-filters1.14", "libpcl-io1.14", "libpcl-kdtree1.14", "libpcl-keypoints1.14", "libpcl-ml1.14", "libpcl-octree1.14", "libpcl-outofcore1.14", "libpcl-people1.14", "libpcl-recognition1.14", "libpcl-registration1.14", "libpcl-sample-consensus1.14", "libpcl-search1.14", "libpcl-segmentation1.14", "libpcl-stereo1.14", "libpcl-surface1.14", "libpcl-tracking1.14", "libpcl-visualization1.14"]
+
+libpcl-all-dev:
+    ubuntu: ["libpcl-dev"]
+
+libpcl-apps:
+    ubuntu:
+        bionic: ["libpcl-apps1.8"]
+        focal: ["libpcl-apps1.10"]
+        jammy: ["libpcl-apps1.12"]
+        noble: ["libpcl-apps1.14"]
+
+libpcl-common:
+    ubuntu:
+        bionic: ["libpcl-common1.8"]
+        focal: ["libpcl-common1.10"]
+        jammy: ["libpcl-common1.12"]
+        noble: ["libpcl-common1.14"]
+
+libpcl-features:
+    ubuntu:
+        bionic: ["libpcl-features1.8"]
+        focal: ["libpcl-features1.10"]
+        jammy: ["libpcl-features1.12"]
+        noble: ["libpcl-features1.14"]
+
+libpcl-filters:
+    ubuntu:
+        bionic: ["libpcl-filters1.8"]
+        focal: ["libpcl-filters1.10"]
+        jammy: ["libpcl-filters1.12"]
+        noble: ["libpcl-filters1.14"]
+
+libpcl-io:
+    ubuntu:
+        bionic: ["libpcl-io1.8"]
+        focal: ["libpcl-io1.10"]
+        jammy: ["libpcl-io1.12"]
+        noble: ["libpcl-io1.14"]
+
+libpcl-kdtree:
+    ubuntu:
+        bionic: ["libpcl-kdtree1.8"]
+        focal: ["libpcl-kdtree1.10"]
+        jammy: ["libpcl-kdtree1.12"]
+        noble: ["libpcl-kdtree1.14"]
+
+libpcl-keypoints:
+    ubuntu:
+        bionic: ["libpcl-keypoints1.8"]
+        focal: ["libpcl-keypoints1.10"]
+        jammy: ["libpcl-keypoints1.12"]
+        noble: ["libpcl-keypoints1.14"]
+
+libpcl-ml:
+    ubuntu:
+        bionic: ["libpcl-ml1.8"]
+        focal: ["libpcl-ml1.10"]
+        jammy: ["libpcl-ml1.12"]
+        noble: ["libpcl-ml1.14"]
+
+libpcl-octree:
+    ubuntu:
+        bionic: ["libpcl-octree1.8"]
+        focal: ["libpcl-octree1.10"]
+        jammy: ["libpcl-octree1.12"]
+        noble: ["libpcl-octree1.14"]
+
+libpcl-outofcore:
+    ubuntu:
+        bionic: ["libpcl-outofcore1.8"]
+        focal: ["libpcl-outofcore1.10"]
+        jammy: ["libpcl-outofcore1.12"]
+        noble: ["libpcl-outofcore1.14"]
+
+libpcl-people:
+    ubuntu:
+        bionic: ["libpcl-people1.8"]
+        focal: ["libpcl-people1.10"]
+        jammy: ["libpcl-people1.12"]
+        noble: ["libpcl-people1.14"]
+
+libpcl-recognition:
+    ubuntu:
+        bionic: ["libpcl-recognition1.8"]
+        focal: ["libpcl-recognition1.10"]
+        jammy: ["libpcl-recognition1.12"]
+        noble: ["libpcl-recognition1.14"]
+
+libpcl-registration:
+    ubuntu:
+        bionic: ["libpcl-registration1.8"]
+        focal: ["libpcl-registration1.10"]
+        jammy: ["libpcl-registration1.12"]
+        noble: ["libpcl-registration1.14"]
+
+libpcl-sample-consensus:
+    ubuntu:
+        bionic: ["libpcl-sample-consensus1.8"]
+        focal: ["libpcl-sample-consensus1.10"]
+        jammy: ["libpcl-sample-consensus1.12"]
+        noble: ["libpcl-sample-consensus1.14"]
+
+libpcl-search:
+    ubuntu:
+        bionic: ["libpcl-search1.8"]
+        focal: ["libpcl-search1.10"]
+        jammy: ["libpcl-search1.12"]
+        noble: ["libpcl-search1.14"]
+
+libpcl-segmentation:
+    ubuntu:
+        bionic: ["libpcl-segmentation1.8"]
+        focal: ["libpcl-segmentation1.10"]
+        jammy: ["libpcl-segmentation1.12"]
+        noble: ["libpcl-segmentation1.14"]
+
+libpcl-stereo:
+    ubuntu:
+        bionic: ["libpcl-stereo1.8"]
+        focal: ["libpcl-stereo1.10"]
+        jammy: ["libpcl-stereo1.12"]
+        noble: ["libpcl-stereo1.14"]
+
+libpcl-surface:
+    ubuntu:
+        bionic: ["libpcl-surface1.8"]
+        focal: ["libpcl-surface1.10"]
+        jammy: ["libpcl-surface1.12"]
+        noble: ["libpcl-surface1.14"]
+
+libpcl-tracking:
+    ubuntu:
+        bionic: ["libpcl-tracking1.8"]
+        focal: ["libpcl-tracking1.10"]
+        jammy: ["libpcl-tracking1.12"]
+        noble: ["libpcl-tracking1.14"]
+
+libpcl-visualization:
+    ubuntu:
+        bionic: ["libpcl-visualization1.8"]
+        focal: ["libpcl-visualization1.10"]
+        jammy: ["libpcl-visualization1.12"]
+        noble: ["libpcl-visualization1.14"]
+
+libpcsclite-dev:
+    ubuntu: ["libpcsclite-dev"]
+
+libpcsclite1:
+    ubuntu: ["libpcsclite1"]
+
+libphonon:
+    ubuntu: ["libphonon4"]
+
+libphonon-dev:
+    ubuntu: ["libphonon-dev"]
+
+libpng++-dev:
+    ubuntu: ["libpng++-dev"]
+
+libpng-dev:
+    ubuntu:
+        default: ["libpng-dev"]
+
+libpng12-dev:
+    ubuntu: ["libpng12-dev"]
+
+libpoco-dev:
+    ubuntu: ["libpoco-dev"]
+
+libpocofoundation9:
+    ubuntu: ["libpocofoundation9"]
+
+libpopt-dev:
+    ubuntu: ["libpopt-dev"]
+
+libpq-dev:
+    ubuntu: ["libpq-dev"]
+
+libpqxx:
+    ubuntu:
+        bionic: ["libpqxx-4.0v5"]
+        focal: ["libpqxx-6.4"]
+
+libpqxx-dev:
+    ubuntu: ["libpqxx-dev"]
+
+libprocps-dev:
+    ubuntu: ["libprocps-dev"]
+
+libprocps6:
+    ubuntu:
+        bionic: ["libprocps6"]
+
+libpt-dev:
+    ubuntu: ["libpt-dev"]
+
+libpthread-stubs0-dev:
+    ubuntu: ["libpthread-stubs0-dev"]
+
+libpulse-dev:
+    ubuntu: ["libpulse-dev"]
+
+libqcustomplot-dev:
+    ubuntu: ["libqcustomplot-dev"]
+
+libqd-dev:
+    ubuntu: ["libqd-dev"]
+
+libqglviewer-dev-qt5:
+    ubuntu: ["libqglviewer-dev-qt5"]
+
+libqglviewer-qt4:
+    ubuntu:
+        bionic: ["libqglviewer2-qt4"]
+
+libqglviewer-qt4-dev:
+    ubuntu:
+        bionic: ["libqglviewer-dev-qt4"]
+
+libqglviewer2-qt5:
+    ubuntu: ["libqglviewer2-qt5"]
+
+libqhull:
+    ubuntu: ["libqhull-dev"]
+
+libqmi-glib-dev:
+    ubuntu: ["libqmi-glib-dev"]
+
+libqrencode:
+    ubuntu: ["libqrencode3"]
+
+libqrencode-dev:
+    ubuntu: ["libqrencode-dev"]
+
+libqt4:
+    ubuntu: ["libqt4-dbus", "libqt4-network", "libqt4-script", "libqt4-test", "libqt4-xml", "libqtcore4"]
+
+libqt4-dev:
+    ubuntu: ["libqt4-dev"]
+
+libqt4-opengl:
+    ubuntu: ["libqt4-opengl"]
+
+libqt4-opengl-dev:
+    ubuntu: ["libqt4-opengl-dev"]
+
+libqt4-sql-psql:
+    ubuntu: ["libqt4-sql-psql"]
+
+libqt5-charts-dev:
+    ubuntu: ["libqt5charts5-dev"]
+
+libqt5-concurrent:
+    ubuntu: ["libqt5concurrent5"]
+
+libqt5-core:
+    ubuntu: ["libqt5core5a"]
+
+libqt5-gstreamer-dev:
+    ubuntu: ["libqt5gstreamer-dev"]
+
+libqt5-gui:
+    ubuntu: ["libqt5gui5"]
+
+libqt5-multimedia:
+    ubuntu: ["libqt5multimedia5"]
+
+libqt5-network:
+    ubuntu: ["libqt5network5"]
+
+libqt5-opengl:
+    ubuntu: ["libqt5opengl5"]
+
+libqt5-opengl-dev:
+    ubuntu: ["libqt5opengl5-dev"]
+
+libqt5-printsupport:
+    ubuntu: ["libqt5printsupport5"]
+
+libqt5-qml:
+    ubuntu: ["libqt5qml5"]
+
+libqt5-quick:
+    ubuntu: ["libqt5quick5"]
+
+libqt5-serialport:
+    ubuntu: ["libqt5serialport5"]
+
+libqt5-serialport-dev:
+    ubuntu: ["libqt5serialport5-dev"]
+
+libqt5-sql:
+    ubuntu: ["libqt5sql5"]
+
+libqt5-svg:
+    ubuntu: ["libqt5svg5"]
+
+libqt5-svg-dev:
+    ubuntu: ["libqt5svg5-dev"]
+
+libqt5-websockets-dev:
+    ubuntu: ["libqt5websockets5-dev"]
+
+libqt5-widgets:
+    ubuntu: ["libqt5widgets5"]
+
+libqt5-xml:
+    ubuntu: ["libqt5xml5"]
+
+libqt5multimedia5-plugins:
+    ubuntu: ["libqt5multimedia5-plugins"]
+
+libqt5x11extras5-dev:
+    ubuntu: ["libqt5x11extras5-dev"]
+
+libqtgui4:
+    ubuntu: ["libqtgui4"]
+
+libqtwebkit-dev:
+    ubuntu: ["libqtwebkit-dev"]
+
+libqwt-qt5-dev:
+    ubuntu:
+        default: ["libqwt-qt5-dev"]
+
+libqwt5-qt4-dev:
+    ubuntu: ["libqwt5-qt4-dev"]
+
+libqwt6:
+    ubuntu: ["libqwt-dev"]
+
+libqwtplot3d-qt4-dev:
+    ubuntu: ["libqwtplot3d-qt4-dev"]
+
+librabbitmq-dev:
+    ubuntu: ["librabbitmq-dev"]
+
+librapidxml-dev:
+    ubuntu: ["librapidxml-dev"]
+
+libraw1394:
+    ubuntu: ["libraw1394-11"]
+
+libraw1394-dev:
+    ubuntu: ["libraw1394-dev"]
+
+librdkafka-dev:
+    ubuntu: ["librdkafka-dev"]
+
+libreadline:
+    ubuntu: ["libreadline-dev"]
+
+libreadline-dev:
+    ubuntu: ["libreadline-dev"]
+
+libreadline-java:
+    ubuntu: ["libreadline-java"]
+
+librtaudio-dev:
+    ubuntu: ["librtaudio-dev"]
+
+libsecp256k1-dev:
+    ubuntu: ["libsecp256k1-dev"]
+
+libsensors4-dev:
+    ubuntu: ["libsensors4-dev"]
+
+libserial-dev:
+    ubuntu: ["libserial-dev"]
+
+libshaderc-dev:
+    ubuntu:
+        default: ["libshaderc-dev"]
+        focal: nonexistent
+        jammy: nonexistent
+
+libsimage-dev:
+    ubuntu: ["libsimage-dev"]
+
+libsndfile1-dev:
+    ubuntu: ["libsndfile1-dev"]
+
+libsodium-dev:
+    ubuntu: ["libsodium-dev"]
+
+libsoqt4-dev:
+    ubuntu: ["libsoqt4-dev"]
+
+libsoundio-dev:
+    ubuntu: ["libsoundio-dev"]
+
+libsoup2-dev:
+    ubuntu: ["libsoup2.4-dev"]
+
+libspatialindex-dev:
+    ubuntu: ["libspatialindex-dev"]
+
+libspatialite:
+    ubuntu:
+        default: ["libsqlite3-mod-spatialite"]
+
+libspnav-dev:
+    ubuntu: ["libspnav-dev", "libx11-dev"]
+
+libsqlite3-dev:
+    ubuntu: ["libsqlite3-dev"]
+
+libsrtp0-dev:
+    ubuntu: ["libsrtp0-dev"]
+
+libssh-dev:
+    ubuntu: ["libssh-dev"]
+
+libssh2:
+    ubuntu: ["libssh2-1"]
+
+libssh2-dev:
+    ubuntu: ["libssh2-1-dev"]
+
+libssl-dev:
+    ubuntu: ["libssl-dev"]
+
+libstdc++5:
+    ubuntu: ["libstdc++5"]
+
+libstdc++6:
+    ubuntu: ["libstdc++6"]
+
+libsvm-dev:
+    ubuntu: ["libsvm-dev"]
+
+libsvm3:
+    ubuntu: ["libsvm3"]
+
+libsvn-dev:
+    ubuntu: ["libsvn-dev"]
+
+libswscale-dev:
+    ubuntu: ["libswscale-dev"]
+
+libsystemd-dev:
+    ubuntu:
+        default: ["libsystemd-dev"]
+
+libtclap-dev:
+    ubuntu: ["libtclap-dev"]
+
+libtesseract:
+    ubuntu: ["libtesseract-dev"]
+
+libtheora:
+    ubuntu: ["libtheora-dev"]
+
+libtiff-dev:
+    ubuntu: ["libtiff-dev"]
+
+libtiff4-dev:
+    ubuntu: ["libtiff4-dev"]
+
+libtins-dev:
+    ubuntu: ["libtins-dev"]
+
+libtool:
+    ubuntu: ["libtool", "libltdl-dev", "libtool-bin"]
+
+libttspico:
+    ubuntu: ["libttspico-dev", "libttspico-data", "libttspico-utils", "libttspico0"]
+
+libturbojpeg:
+    ubuntu:
+        default: ["libturbojpeg0-dev"]
+
+libudev-dev:
+    ubuntu: ["libudev-dev"]
+
+libunittest++:
+    ubuntu: ["libunittest++-dev"]
+
+libunwind:
+    ubuntu:
+        default: ["libunwind8"]
+
+libunwind-dev:
+    ubuntu:
+        default: ["libunwind-dev"]
+
+liburdfdom-dev:
+    ubuntu: ["liburdfdom-dev"]
+
+liburdfdom-headers-dev:
+    ubuntu: ["liburdfdom-headers-dev"]
+
+liburdfdom-tools:
+    ubuntu: ["liburdfdom-tools"]
+
+libusb:
+    ubuntu: ["libusb-0.1-4"]
+
+libusb-1.0:
+    ubuntu: ["libusb-1.0-0"]
+
+libusb-1.0-dev:
+    ubuntu: ["libusb-1.0-0-dev"]
+
+libusb-dev:
+    ubuntu: ["libusb-dev"]
+
+libuv-dev:
+    ubuntu:
+        bionic: ["libuv0.10-dev"]
+
+libuv1-dev:
+    ubuntu: ["libuv1-dev"]
+
+libuvc-dev:
+    ubuntu:
+        default: ["libuvc-dev"]
+
+libv4l-dev:
+    ubuntu: ["libv4l-dev"]
+
+libvlc:
+    ubuntu:
+        default: ["libvlc5", "vlc-bin"]
+
+libvlc-dev:
+    ubuntu: ["libvlc-dev"]
+
+libvlccore-dev:
+    ubuntu: ["libvlccore-dev"]
+
+libvorbis-dev:
+    ubuntu: ["libvorbis-dev"]
+
+libvpx-dev:
+    ubuntu: ["libvpx-dev"]
+
+libvtk:
+    ubuntu:
+        default: ["libvtk7-dev"]
+        bionic: ["libvtk6-dev"]
+
+libvtk-java:
+    ubuntu:
+        default: ["libvtk7-java"]
+        bionic: ["libvtk6-java"]
+
+libvtk-qt:
+    ubuntu:
+        default: ["libvtk7-qt-dev"]
+        bionic: ["libvtk6-qt-dev"]
+
+libvtk9-dev:
+    ubuntu:
+        default: ["libvtk9-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+libvulkan-dev:
+    ubuntu:
+        default: ["libvulkan-dev"]
+
+libwebp-dev:
+    ubuntu: ["libwebp-dev"]
+
+libwebp-tools:
+    ubuntu: ["webp"]
+
+libwebsocketpp-dev:
+    ubuntu: ["libwebsocketpp-dev"]
+
+libwebsockets-dev:
+    ubuntu: ["libwebsockets-dev"]
+
+libx11:
+    ubuntu: ["libx11-dev"]
+
+libx11-dev:
+    ubuntu: ["libx11-dev"]
+
+libx11-xcb-dev:
+    ubuntu: ["libx11-xcb-dev"]
+
+libx264-dev:
+    ubuntu: ["libx264-dev"]
+
+libxaw:
+    ubuntu: ["libxaw7-dev"]
+
+libxcb-randr0-dev:
+    ubuntu: ["libxcb-randr0-dev"]
+
+libxcursor-dev:
+    ubuntu: ["libxcursor-dev"]
+
+libxenomai-dev:
+    ubuntu: ["libxenomai-dev"]
+
+libxext:
+    ubuntu: ["libxext-dev"]
+
+libxft-dev:
+    ubuntu: ["libxft-dev"]
+
+libxi-dev:
+    ubuntu: ["libxi-dev"]
+
+libxinerama-dev:
+    ubuntu: ["libxinerama-dev"]
+
+libxkbcommon-dev:
+    ubuntu: ["libxkbcommon-dev"]
+
+libxml++-2.6:
+    ubuntu: ["libxml++2.6-dev"]
+
+libxml2:
+    ubuntu: ["libxml2-dev"]
+
+libxml2-utils:
+    ubuntu: ["libxml2-utils"]
+
+libxmlrpc-c++:
+    ubuntu: ["libxmlrpc-c++8-dev"]
+
+libxmu-dev:
+    ubuntu: ["libxmu-dev"]
+
+libxrandr:
+    ubuntu: ["libxrandr-dev"]
+
+libxslt:
+    ubuntu: ["libxslt1-dev"]
+
+libxss1:
+    ubuntu: ["libxss1"]
+
+libxt-dev:
+    ubuntu: ["libxt-dev"]
+
+libxtst-dev:
+    ubuntu: ["libxtst-dev"]
+
+libxxf86vm:
+    ubuntu: ["libxxf86vm-dev"]
+
+libyaml:
+    ubuntu: ["libyaml-0-2"]
+
+libyaml-dev:
+    ubuntu: ["libyaml-dev"]
+
+libzip-dev:
+    ubuntu: ["libzip-dev"]
+
+libzmq3-dev:
+    ubuntu:
+        default: ["libzmq3-dev", "cppzmq-dev"]
+        bionic: ["libzmq3-dev"]
+        focal: ["libzmq3-dev"]
+        jammy: ["libzmq3-dev"]
+
+libzmqpp-dev:
+    ubuntu: ["libzmqpp-dev"]
+
+libzmqpp3:
+    ubuntu: ["libzmqpp3"]
+
+libzstd-dev:
+    ubuntu:
+        default: ["libzstd-dev"]
+
+light-locker:
+    ubuntu: ["light-locker"]
+
+lighttpd:
+    ubuntu: ["lighttpd"]
+
+lilypond:
+    ubuntu: ["lilypond"]
+
+linphone:
+    ubuntu: ["linphone"]
+
+linux-headers-generic:
+    ubuntu: ["linux-headers-generic"]
+
+linux-kernel-headers:
+    ubuntu: ["linux-libc-dev"]
+
+llvm:
+    ubuntu: ["llvm"]
+
+llvm-7:
+    ubuntu:
+        bionic: ["llvm-7"]
+        focal: ["llvm-7"]
+
+llvm-7-dev:
+    ubuntu:
+        bionic: ["llvm-7-dev"]
+        focal: ["llvm-7-dev"]
+
+llvm-dev:
+    ubuntu: ["llvm-dev"]
+
+lm-sensors:
+    ubuntu: ["lm-sensors"]
+
+log4cplus:
+    ubuntu: ["liblog4cplus-dev"]
+
+log4cxx:
+    ubuntu:
+        default: ["liblog4cxx-dev"]
+
+lsb-release:
+    ubuntu: ["lsb-release"]
+
+lttng-modules:
+    ubuntu: ["lttng-modules-dkms"]
+
+lttng-tools:
+    ubuntu: ["lttng-tools"]
+
+lua-dev:
+    ubuntu: ["liblua5.1-0-dev"]
+
+lua5.2-dev:
+    ubuntu: ["liblua5.2-dev"]
+
+lz4:
+    ubuntu: ["liblz4-dev"]
+
+m2r:
+    ubuntu:
+        default: ["m2r"]
+        bionic: nonexistent
+
+m4:
+    ubuntu: ["m4"]
+
+mapnik-utils:
+    ubuntu: ["mapnik-utils"]
+
+matio:
+    ubuntu: ["libmatio-dev"]
+
+maven:
+    ubuntu: ["maven"]
+
+mayavi:
+    ubuntu: ["mayavi2"]
+
+meld:
+    ubuntu: ["meld"]
+
+mercurial:
+    ubuntu: ["mercurial"]
+
+mesa-common-dev:
+    ubuntu: ["mesa-common-dev"]
+
+mesa-utils:
+    ubuntu: ["mesa-utils"]
+
+meshlab:
+    ubuntu: ["meshlab"]
+
+mkdocs:
+    ubuntu:
+        bionic: ["mkdocs"]
+
+mkdocs-bootstrap:
+    ubuntu:
+        bionic: ["mkdocs-bootstrap"]
+
+mkdocs-bootswatch:
+    ubuntu:
+        bionic: ["mkdocs-bootswatch"]
+
+mongodb:
+    ubuntu:
+        bionic: ["mongodb"]
+        focal: ["mongodb"]
+
+mongodb-dev:
+    ubuntu: ["libmongoclient-dev"]
+
+mono-complete:
+    ubuntu: ["mono-complete"]
+
+mono-devel:
+    ubuntu: ["mono-devel"]
+
+mosquitto:
+    ubuntu: ["mosquitto"]
+
+mosquitto-clients:
+    ubuntu: ["mosquitto-clients"]
+
+mosquitto-dev:
+    ubuntu: ["libmosquitto-dev"]
+
+mosquittopp-dev:
+    ubuntu: ["libmosquittopp-dev"]
+
+mpfr:
+    ubuntu: ["libmpfr-dev"]
+
+mpg123:
+    ubuntu: ["mpg123"]
+
+mplayer:
+    ubuntu: ["mplayer"]
+
+mrpt:
+    ubuntu: ["libmrpt-dev"]
+
+msgpack:
+    ubuntu: ["libmsgpack-dev"]
+
+msr-tools:
+    ubuntu: ["msr-tools"]
+
+multistrap:
+    ubuntu: ["multistrap"]
+
+muparser:
+    ubuntu: ["libmuparser-dev"]
+
+nanobind-dev:
+    pip: ["nanobind"]
+    pip: ["nanobind"]
+
+nanoflann:
+    ubuntu:
+        default: ["libnanoflann-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+nasm:
+    ubuntu: ["nasm"]
+
+nbtscan:
+    ubuntu: ["nbtscan"]
+
+net-tools:
+    ubuntu: ["net-tools"]
+
+netcdf:
+    ubuntu: ["libnetcdf-dev"]
+
+netpbm:
+    ubuntu: ["libnetpbm10-dev"]
+
+network-manager:
+    ubuntu: ["network-manager"]
+
+ninja-build:
+    ubuntu: ["ninja-build"]
+
+nite-dev:
+    ubuntu: ["nite-dev"]
+
+nkf:
+    ubuntu: ["nkf"]
+
+nlohmann-json-dev:
+    ubuntu:
+        default: ["nlohmann-json3-dev"]
+        bionic: ["nlohmann-json-dev"]
+
+nmap:
+    ubuntu: ["nmap"]
+
+nodejs:
+    ubuntu: ["nodejs"]
+
+nodejs-legacy:
+    ubuntu: ["nodejs-legacy"]
+
+npm:
+    ubuntu: ["npm"]
+
+ntp:
+    ubuntu: ["ntp"]
+
+ntpdate:
+    ubuntu: ["ntpdate"]
+
+nvidia-cg:
+    ubuntu: ["nvidia-cg-toolkit"]
+
+nvidia-cuda:
+    ubuntu: ["nvidia-cuda-toolkit"]
+
+nvidia-cuda-dev:
+    ubuntu: ["nvidia-cuda-dev"]
+
+nvidia-cudnn:
+    ubuntu:
+        default: ["nvidia-cudnn"]
+        focal: nonexistent
+
+ocl-icd-opencl-dev:
+    ubuntu: ["ocl-icd-opencl-dev"]
+
+octave:
+    ubuntu: ["octave"]
+
+odb:
+    ubuntu:
+        default: ["odb"]
+
+omniidl:
+    ubuntu: ["omniidl", "omniorb-idl"]
+
+omniorb:
+    ubuntu: ["omniorb", "omniidl", "omniorb-idl", "omniorb-nameserver", "libomniorb4-dev"]
+
+opencascade:
+    ubuntu:
+        bionic: ["liboce-visualization-dev"]
+        focal: ["libocct-data-exchange-dev", "libocct-draw-dev"]
+
+opencl-headers:
+    ubuntu: ["opencl-headers"]
+
+opende:
+    ubuntu: ["libode-dev"]
+
+opengl:
+    ubuntu: ["libgl1-mesa-dev", "libglu1-mesa-dev"]
+
+openjdk-6-jdk:
+    ubuntu: ["openjdk-6-jdk"]
+
+openmpi:
+    ubuntu: []
+
+openni-dev:
+    ubuntu: ["libopenni-dev"]
+
+openocd:
+    ubuntu: ["openocd"]
+
+openssh-client:
+    ubuntu: ["openssh-client"]
+
+openssh-server:
+    ubuntu: ["openssh-server"]
+
+openssl:
+    ubuntu: ["openssl"]
+
+optipng:
+    ubuntu: ["optipng"]
+
+osm2pgsql:
+    ubuntu: ["osm2pgsql"]
+
+osmium:
+    ubuntu: ["libosmium2-dev"]
+
+pandoc:
+    ubuntu: ["pandoc"]
+
+patchelf:
+    ubuntu: ["patchelf"]
+
+pcre:
+    ubuntu: ["libpcre3-dev"]
+
+pcre-dev:
+    ubuntu: ["libpcre++-dev"]
+
+pcscd:
+    ubuntu: ["pcscd"]
+
+phantomjs:
+    ubuntu: ["phantomjs"]
+
+pigz:
+    ubuntu: ["pigz"]
+
+pkg-config:
+    ubuntu: ["pkg-config"]
+
+pmccabe:
+    ubuntu: ["pmccabe"]
+
+pmount:
+    ubuntu: ["pmount"]
+
+polyclipping-dev:
+    ubuntu: ["libpolyclipping-dev"]
+
+poppler-utils:
+    ubuntu: ["poppler-utils"]
+
+portaudio:
+    ubuntu: ["libportaudio-dev"]
+
+portaudio19-dev:
+    ubuntu: ["portaudio19-dev"]
+
+postfix:
+    ubuntu: ["postfix"]
+
+postgresql:
+    ubuntu: ["postgresql", "postgresql-contrib"]
+
+postgresql-client:
+    ubuntu: ["postgresql-client"]
+
+postgresql-postgis:
+    ubuntu:
+        bionic: ["postgresql-10-postgis-2.4", "postgresql-contrib", "postgresql-server-dev-all"]
+        focal: ["postgresql-12-postgis-3", "postgresql-contrib", "postgresql-server-dev-all"]
+
+potrace:
+    ubuntu: ["potrace"]
+
+powertop:
+    ubuntu: ["powertop"]
+
+procps:
+    ubuntu: ["procps"]
+
+proj:
+    ubuntu: ["libproj-dev"]
+
+protobuf:
+    ubuntu:
+        bionic: ["libprotobuf10"]
+        focal: ["libprotobuf17"]
+        jammy: ["libprotobuf23"]
+        noble: ["libprotobuf32"]
+
+protobuf-compiler-grpc:
+    ubuntu: ["protobuf-compiler-grpc"]
+
+protobuf-dev:
+    ubuntu: ["libprotobuf-dev", "protobuf-compiler", "libprotoc-dev"]
+
+ps-engine:
+    ubuntu: ["ps-engine"]
+
+psmisc:
+    ubuntu: ["psmisc"]
+
+pstoedit:
+    ubuntu: ["pstoedit"]
+
+psutils:
+    ubuntu: ["psutils"]
+
+pugixml-dev:
+    ubuntu: ["libpugixml-dev"]
+
+pybind11-dev:
+    ubuntu: ["pybind11-dev"]
+
+pybind11-json-dev:
+    ubuntu:
+        default: ["pybind11-json-dev"]
+        focal: nonexistent
+
+python-dev:
+    ubuntu:
+        default: ["python-dev"]
+        focal: ["python2-dev"]
+
+qemu-user-static:
+    ubuntu: ["qemu-user-static"]
+
+qhull-bin:
+    ubuntu: ["qhull-bin"]
+
+qml-module-qt-labs-folderlistmodel:
+    ubuntu: ["qml-module-qt-labs-folderlistmodel"]
+
+qml-module-qt-labs-platform:
+    ubuntu: ["qml-module-qt-labs-platform"]
+
+qml-module-qt-labs-settings:
+    ubuntu: ["qml-module-qt-labs-settings"]
+
+qml-module-qtcharts:
+    ubuntu: ["qml-module-qtcharts"]
+
+qml-module-qtgraphicaleffects:
+    ubuntu: ["qml-module-qtgraphicaleffects"]
+
+qml-module-qtlocation:
+    ubuntu: ["qml-module-qtlocation"]
+
+qml-module-qtmultimedia:
+    ubuntu: ["qml-module-qtmultimedia"]
+
+qml-module-qtpositioning:
+    ubuntu: ["qml-module-qtpositioning"]
+
+qml-module-qtquick-controls:
+    ubuntu: ["qml-module-qtquick-controls"]
+
+qml-module-qtquick-controls2:
+    ubuntu: ["qml-module-qtquick-controls2"]
+
+qml-module-qtquick-dialogs:
+    ubuntu: ["qml-module-qtquick-dialogs"]
+
+qml-module-qtquick-extras:
+    ubuntu: ["qml-module-qtquick-extras"]
+
+qml-module-qtquick-layouts:
+    ubuntu: ["qml-module-qtquick-layouts"]
+
+qml-module-qtquick-templates2:
+    ubuntu: ["qml-module-qtquick-templates2"]
+
+qml-module-qtquick-window2:
+    ubuntu: ["qml-module-qtquick-window2"]
+
+qml-module-qtquick2:
+    ubuntu: ["qml-module-qtquick2"]
+
+qrencode:
+    ubuntu: ["qrencode"]
+
+qt4-dev-tools:
+    ubuntu: ["qt4-dev-tools"]
+
+qt4-linguist-tools:
+    ubuntu:
+        default: nonexistent
+        bionic: ["qt4-linguist-tools"]
+
+qt4-qmake:
+    ubuntu: ["qt4-qmake"]
+
+qt5-image-formats-plugins:
+    ubuntu: ["qt5-image-formats-plugins"]
+
+qt5-qmake:
+    ubuntu: ["qt5-qmake"]
+
+qtbase5-dev:
+    ubuntu: ["qtbase5-dev"]
+
+qtbase5-private-dev:
+    ubuntu: ["qtbase5-private-dev"]
+
+qtdeclarative5-dev:
+    ubuntu: ["qtdeclarative5-dev"]
+
+qtmobility-dev:
+    ubuntu: ["qtmobility-dev"]
+
+qtmultimedia5-dev:
+    ubuntu: ["qtmultimedia5-dev"]
+
+qtpositioning5-dev:
+    ubuntu: ["qtpositioning5-dev"]
+
+qtquickcontrols2-5-dev:
+    ubuntu: ["qtquickcontrols2-5-dev"]
+
+qttools5-dev:
+    ubuntu: ["qttools5-dev"]
+
+qttools5-dev-tools:
+    ubuntu: ["qttools5-dev-tools"]
+
+qtwebengine5-dev:
+    ubuntu: ["qtwebengine5-dev"]
+
+r-base:
+    ubuntu: ["r-base"]
+
+r-base-dev:
+    ubuntu: ["r-base-dev"]
+
+range-v3:
+    ubuntu:
+        default: ["librange-v3-dev"]
+
+rapidjson-dev:
+    ubuntu: ["rapidjson-dev"]
+
+readline-dev:
+    ubuntu: ["libreadline-dev"]
+
+recode:
+    ubuntu: ["recode"]
+
+recordmydesktop:
+    ubuntu: ["recordmydesktop"]
+
+redis-server:
+    ubuntu: ["redis-server"]
+
+robin-map-dev:
+    ubuntu: ["robin-map-dev"]
+
+robotino-api2:
+    ubuntu: ["robotino-api2"]
+
+rsync:
+    ubuntu: ["rsync"]
+
+rsyslog:
+    ubuntu: ["rsyslog"]
+
+rt-tests:
+    ubuntu: ["rt-tests"]
+
+rti-connext-dds-5.3.1:
+    ubuntu:
+        bionic: ["rti-connext-dds-5.3.1"]
+        focal: ["rti-connext-dds-5.3.1"]
+
+rti-connext-dds-6.0.1:
+    ubuntu:
+        default: ["rti-connext-dds-6.0.1"]
+        bionic: nonexistent
+
+rtmidi:
+    ubuntu: ["librtmidi-dev"]
+
+rustc:
+    ubuntu: ["rustc"]
+
+sbcl:
+    ubuntu: ["sbcl"]
+
+scons:
+    ubuntu: ["scons"]
+
+screen:
+    ubuntu: ["screen"]
+
+sdformat:
+    ubuntu:
+        bionic: ["libsdformat6-dev"]
+        focal: ["libsdformat9-dev"]
+        jammy: ["libsdformat-dev"]
+
+sdformat11:
+    ubuntu:
+        focal: ["libsdformat11-dev"]
+
+sdformat12:
+    ubuntu:
+        focal: ["libsdformat12-dev"]
+        jammy: ["libsdformat12-dev"]
+
+sdl:
+    ubuntu: ["libsdl1.2-dev"]
+
+sdl-gfx:
+    ubuntu: ["libsdl-gfx1.2-dev"]
+
+sdl-image:
+    ubuntu: ["libsdl-image1.2-dev"]
+
+sdl-mixer:
+    ubuntu: ["libsdl-mixer1.2-dev"]
+
+sdl-ttf:
+    ubuntu: ["libsdl-ttf2.0-dev"]
+
+sdl2:
+    ubuntu: ["libsdl2-dev"]
+
+sdl2-image:
+    ubuntu: ["libsdl2-image-dev"]
+
+sdl2-mixer:
+    ubuntu: ["libsdl2-mixer-dev"]
+
+sdl2-ttf:
+    ubuntu: ["libsdl2-ttf-dev"]
+
+semgrep:
+    pip: ["semgrep"]
+
+setserial:
+    ubuntu: ["setserial"]
+
+sfml-dev:
+    ubuntu: ["libsfml-dev"]
+
+simde:
+    ubuntu:
+        default: ["libsimde-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+sixad:
+    ubuntu: ["sixad"]
+
+slime:
+    ubuntu: ["slime"]
+
+smartmontools:
+    ubuntu: ["smartmontools"]
+
+smbclient:
+    ubuntu: ["smbclient"]
+
+snappy:
+    ubuntu: ["libsnappy-dev"]
+
+socat:
+    ubuntu: ["socat"]
+
+sound-theme-freedesktop:
+    ubuntu: ["sound-theme-freedesktop"]
+
+sox:
+    ubuntu: ["sox"]
+
+spacenavd:
+    ubuntu: ["spacenavd"]
+
+sparsehash:
+    ubuntu: ["libsparsehash-dev"]
+
+spdlog:
+    ubuntu: ["libspdlog-dev"]
+
+speech-dispatcher:
+    ubuntu: ["speech-dispatcher"]
+
+spirv-headers:
+    ubuntu:
+        default: ["spirv-headers"]
+        bionic: nonexistent
+
+spirv-tools:
+    ubuntu:
+        default: ["spirv-tools"]
+        bionic: nonexistent
+
+sqlite3:
+    ubuntu: ["sqlite3"]
+
+ssh-askpass:
+    ubuntu: ["ssh-askpass"]
+
+ssh-askpass-gnome:
+    ubuntu: ["ssh-askpass-gnome"]
+
+sshpass:
+    ubuntu: ["sshpass"]
+
+stress:
+    ubuntu: ["stress"]
+
+stress-ng:
+    ubuntu: ["stress-ng"]
+
+subversion:
+    ubuntu: ["subversion"]
+
+suitesparse:
+    ubuntu: ["libsuitesparse-dev"]
+
+supervisor:
+    ubuntu: ["supervisor"]
+
+swi-prolog:
+    ubuntu: ["swi-prolog"]
+
+swi-prolog-java:
+    ubuntu: ["swi-prolog-java"]
+
+swi-prolog-odbc:
+    ubuntu: ["swi-prolog-odbc"]
+
+swig:
+    ubuntu: ["swig"]
+
+sysbench:
+    ubuntu: ["sysbench"]
+
+sysstat:
+    ubuntu: ["sysstat"]
+
+systemd:
+    ubuntu: ["systemd"]
+
+tango-icon-theme:
+    ubuntu: ["tango-icon-theme"]
+
+tar:
+    ubuntu: ["libtar-dev"]
+
+tbb:
+    ubuntu: ["libtbb-dev"]
+
+tcsh:
+    ubuntu: ["tcsh"]
+
+terminator:
+    ubuntu: ["terminator"]
+
+tesseract-ocr:
+    ubuntu: ["tesseract-ocr"]
+
+tesseract-ocr-jpn:
+    ubuntu: ["tesseract-ocr-jpn"]
+
+texlive-fonts-extra:
+    ubuntu: ["texlive-fonts-extra"]
+
+texlive-fonts-recommended:
+    ubuntu: ["texlive-fonts-recommended"]
+
+texlive-full:
+    ubuntu: ["texlive-full"]
+
+texlive-latex-base:
+    ubuntu: ["texlive-latex-base"]
+
+texlive-latex-extra:
+    ubuntu: ["texlive-latex-extra"]
+
+texlive-latex-recommended:
+    ubuntu: ["texlive-latex-recommended"]
+
+texmaker:
+    ubuntu: ["texmaker"]
+
+tiled:
+    ubuntu: ["tiled"]
+
+time:
+    ubuntu: ["time"]
+
+tinyxml:
+    ubuntu: ["libtinyxml-dev"]
+
+tinyxml2:
+    ubuntu: ["libtinyxml2-dev"]
+
+tix:
+    ubuntu: ["tix"]
+
+tmux:
+    ubuntu: ["tmux"]
+
+touchegg:
+    ubuntu: ["touchegg"]
+
+trang:
+    ubuntu: ["trang"]
+
+tree:
+    ubuntu: ["tree"]
+
+tshark:
+    ubuntu: ["tshark"]
+
+ttf-kochi-gothic:
+    ubuntu: ["ttf-kochi-gothic"]
+
+ttf-kochi-mincho:
+    ubuntu: ["ttf-kochi-mincho"]
+
+ttf-sazanami-gothic:
+    ubuntu: ["ttf-sazanami-gothic"]
+
+ttf-sazanami-mincho:
+    ubuntu: ["ttf-sazanami-mincho"]
+
+udev:
+    ubuntu: ["udev"]
+
+udhcpc:
+    ubuntu: ["udhcpc"]
+
+unclutter:
+    ubuntu: ["unclutter"]
+
+uncrustify:
+    ubuntu: ["uncrustify"]
+
+unison:
+    ubuntu: ["unison"]
+
+unison-gui:
+    ubuntu: ["unison-gtk"]
+
+unoconv:
+    ubuntu: ["unoconv"]
+
+unrar:
+    ubuntu: ["unrar"]
+
+unzip:
+    ubuntu: ["unzip"]
+
+usbutils:
+    ubuntu: ["usbutils"]
+
+util-linux:
+    ubuntu:
+        default: ["util-linux"]
+        bionic: ["setpriv", "util-linux"]
+
+uuid:
+    ubuntu: ["uuid-dev"]
+
+uvcdynctrl:
+    ubuntu: ["uvcdynctrl"]
+
+v4l-utils:
+    ubuntu: ["v4l-utils"]
+
+valgrind:
+    ubuntu: ["valgrind"]
+
+vim:
+    ubuntu: ["vim"]
+
+vlc:
+    ubuntu: ["vlc"]
+
+vorbis-tools:
+    ubuntu: ["vorbis-tools"]
+
+wayland:
+    ubuntu: ["libwayland-client0", "libwayland-cursor0", "libwayland-egl1"]
+
+wayland-dev:
+    ubuntu: ["libwayland-dev", "wayland-protocols"]
+
+wget:
+    ubuntu: ["wget"]
+
+wireguard:
+    ubuntu:
+        default: ["wireguard"]
+        bionic: nonexistent
+
+wireless-tools:
+    ubuntu: ["wireless-tools"]
+
+wireshark:
+    ubuntu: ["wireshark"]
+
+wireshark-common:
+    ubuntu: ["wireshark-common"]
+
+wkhtmltopdf:
+    ubuntu: ["wkhtmltopdf"]
+
+wmctrl:
+    ubuntu: ["wmctrl"]
+
+workrave:
+    ubuntu: ["workrave", "workrave-data"]
+
+wx-common:
+    ubuntu: ["wx-common"]
+
+wxwidgets:
+    ubuntu:
+        default: ["libwxgtk3.2-dev"]
+        bionic: ["libwxgtk3.0-dev"]
+        focal: ["libwxgtk3.0-gtk3-dev"]
+        jammy: ["libwxgtk3.0-gtk3-dev"]
+
+x11proto-dri2-dev:
+    ubuntu: ["x11proto-dri2-dev"]
+
+x11proto-gl-dev:
+    ubuntu: ["x11proto-gl-dev"]
+
+x11proto-print-dev:
+    ubuntu: ["x11proto-print-dev"]
+
+xclip:
+    ubuntu: ["xclip"]
+
+xdg-utils:
+    ubuntu: ["xdg-utils"]
+
+xdotool:
+    ubuntu: ["xdotool"]
+
+xerces:
+    ubuntu: ["libxerces-c-dev"]
+
+xfonts-100dpi:
+    ubuntu: ["xfonts-100dpi"]
+
+xfonts-75dpi:
+    ubuntu: ["xfonts-75dpi"]
+
+xpath-perl:
+    ubuntu: ["libxml-xpath-perl"]
+
+xsimd:
+    ubuntu:
+        default: ["libxsimd-dev"]
+        bionic: nonexistent
+        focal: nonexistent
+
+xsltproc:
+    ubuntu: ["xsltproc"]
+
+xtensor:
+    ubuntu:
+        default: ["libxtensor-dev"]
+        focal: nonexistent
+
+xterm:
+    ubuntu: ["xterm"]
+
+xulrunner-1.9.2:
+    ubuntu:
+        karmic: ["xulrunner-1.9.2"]
+
+xulrunner-dev:
+    ubuntu: ["libv8-dev"]
+
+xvfb:
+    ubuntu: ["xvfb"]
+
+xz-utils:
+    ubuntu: ["xz-utils"]
+
+yaml:
+    ubuntu: ["libyaml-dev"]
+
+yaml-cpp:
+    ubuntu: ["libyaml-cpp-dev"]
+
+yamllint:
+    ubuntu: ["yamllint"]
+
+yarn:
+    ubuntu:
+        default: ["yarnpkg"]
+        bionic: nonexistent
+
+yasm:
+    ubuntu: ["yasm"]
+
+zbar:
+    ubuntu: ["libzbar-dev"]
+
+zenity:
+    ubuntu: ["zenity"]
+
+zeromq3:
+    ubuntu: ["libzmq5"]
+
+zip:
+    ubuntu: ["zip"]
+
+zlib:
+    ubuntu: ["zlib1g-dev"]
+
+zsh:
+    ubuntu: ["zsh"]
+
+zziplib:
+    ubuntu: ["libzzip-dev"]
+
+adafruit-ads1x15-pip:
+    pip: ["Adafruit-ADS1x15"]
+
+adafruit-gpio-pip:
+    pip: ["Adafruit-GPIO"]
+
+adafruit-mcp3008-pip:
+    pip: ["Adafruit-MCP3008"]
+
+adafruit-pca9685-pip:
+    pip: ["adafruit-pca9685"]
+
+autograd-pip:
+    pip: ["autograd"]
+
+autolab-core-pip:
+    pip: ["autolab-core"]
+
+autolab-perception-pip:
+    pip: ["autolab_perception"]
+
+autolab-visualization-pip:
+    pip: ["visualization"]
+
+awsiotpythonsdk-pip:
+    pip: ["awsiotpythonsdk"]
+
+azure-core-pip:
+    pip: ["azure-core"]
+
+azure-iothub-device-client-pip:
+    pip: ["azure-iothub-device-client"]
+
+azure-mgmt-storage-pip:
+    pip: ["azure-mgmt-storage"]
+
+azure-storage-file-share-pip:
+    pip: ["azure-storage-file-share"]
+
+black:
+    ubuntu:
+        default: ["black"]
+        bionic: nonexistent
+
+canopen-pip:
+    pip: ["canopen"]
+
+carla-pip:
+    pip: ["carla"]
+
+casadi-pip:
+    pip: ["casadi"]
+
+cmakelint-pip:
+    pip: ["cmakelint"]
+
+cppcheck-junit-pip:
+    pip: ["cppcheck-junit"]
+
+cython:
+    ubuntu: ["cython"]
+
+cython3:
+    ubuntu: ["cython3"]
+
+dpath-pip:
+    pip: ["dpath"]
+
+ds4drv-pip:
+    pip: ["ds4drv"]
+
+epydoc:
+    ubuntu: ["python-epydoc"]
+
+exhale-pip:
+    pip: ["exhale"]
+
+gunicorn:
+    ubuntu: ["gunicorn"]
+
+gym-pip:
+    pip: ["gym"]
+
+imgaug-pip:
+    pip: ["imgaug"]
+
+intelhex-pip:
+    pip: ["intelhex"]
+
+ipython:
+    ubuntu: ["ipython"]
+
+ipython3:
+    ubuntu: ["ipython3"]
+
+jupyter-nbconvert:
+    ubuntu:
+        default: ["jupyter-nbconvert"]
+
+jupyter-notebook:
+    ubuntu:
+        default: ["jupyter-notebook"]
+
+libgv-python:
+    ubuntu: ["libgv-python"]
+
+libshiboken2-dev:
+    ubuntu: ["libshiboken2-dev"]
+
+mcap-ros2-support:
+    pip: ["mcap-ros2-support"]
+
+meson:
+    ubuntu: ["meson"]
+
+nuitka:
+    ubuntu: ["nuitka"]
+
+onvif_zeep:
+    pip: ["onvif_zeep"]
+
+opcua-pip:
+    pip: ["opcua"]
+
+paramiko:
+    ubuntu: ["python-paramiko"]
+
+pi-ina219-pip:
+    pip: ["pi-ina219"]
+
+pika:
+    ubuntu: ["python-pika"]
+
+pydocstyle:
+    ubuntu: ["pydocstyle"]
+
+pydrive-pip:
+    pip: ["PyDrive"]
+
+pyflakes3:
+    ubuntu: ["pyflakes3"]
+
+pymap3d-pip:
+    pip: ["pymap3d"]
+    pip: ["pymap3d"]
+
+pymodbustcp-pip:
+    pip: ["pyModbusTCP"]
+
+pynput-pip:
+    pip: ["pynput"]
+
+pyosmium:
+    ubuntu: ["python-pyosmium"]
+
+pyper-pip:
+    pip: ["pyper"]
+
+pyqt4-dev-tools:
+    ubuntu: ["pyqt4-dev-tools"]
+
+pyqt5-dev-tools:
+    ubuntu: ["pyqt5-dev-tools"]
+
+pyqt6-dev-tools:
+    ubuntu:
+        default: ["pyqt6-dev-tools"]
+        focal: nonexistent
+        jammy: nonexistent
+
+pyrebase-pip:
+    pip: ["pyrebase"]
+
+pyro4:
+    ubuntu: ["python2-pyro4"]
+
+pyros-setup-pip:
+    pip: ["pyros-setup"]
+
+pyside-tools:
+    ubuntu: ["pyside-tools"]
+
+python:
+    ubuntu:
+        bionic: ["python-dev"]
+
+python-absl-py-pip:
+    pip: ["absl-py"]
+
+python-adafruit-bno055-pip:
+    pip: ["adafruit_bno055"]
+
+python-alembic:
+    ubuntu:
+        default: ["python-alembic"]
+
+python-amqp:
+    ubuntu: ["python-amqp"]
+
+python-aniso8601:
+    ubuntu:
+        bionic: ["python-aniso8601"]
+
+python-annoy-pip:
+    pip: ["annoy"]
+
+python-anyjson:
+    ubuntu: ["python-anyjson"]
+
+python-apparmor:
+    ubuntu: ["python-apparmor"]
+
+python-argcomplete:
+    ubuntu: ["python-argcomplete"]
+
+python-argh:
+    ubuntu: ["python-argh"]
+
+python-argparse:
+    ubuntu:
+        default: []
+
+python-astor-pip:
+    pip: ["astor"]
+
+python-attrs:
+    ubuntu:
+        bionic: ["python-attr"]
+        focal: ["python-attr"]
+
+python-autobahn:
+    ubuntu:
+        default: ["python-autobahn"]
+
+python-avahi:
+    ubuntu: ["python-avahi"]
+
+python-babel:
+    ubuntu: ["python-babel"]
+
+python-backoff-pip:
+    pip: ["backoff"]
+
+python-backports.ssl-match-hostname:
+    ubuntu:
+        bionic: ["python-backports.ssl-match-hostname"]
+
+python-bcrypt:
+    ubuntu: ["python-bcrypt"]
+
+python-beautifulsoup:
+    ubuntu: ["python-beautifulsoup"]
+
+python-bitarray:
+    ubuntu: ["python-bitarray"]
+
+python-bitstring:
+    ubuntu:
+        bionic: ["python-bitstring"]
+
+python-bitstring-pip:
+    pip: ["bitstring"]
+
+python-blinker:
+    ubuntu: ["python-blinker"]
+
+python-bloom:
+    ubuntu:
+        default: ["python-bloom"]
+
+python-bluez:
+    ubuntu: ["python-bluez"]
+
+python-bokeh-pip:
+    pip: ["bokeh"]
+
+python-boltons:
+    ubuntu:
+        default: ["python-boltons"]
+
+python-boto3:
+    ubuntu:
+        default: ["python-boto3"]
+
+python-bottle:
+    ubuntu: ["python-bottle"]
+
+python-box2d:
+    ubuntu: ["python-box2d"]
+
+python-breathe:
+    ubuntu: ["python-breathe"]
+
+python-bs4:
+    ubuntu: ["python-bs4"]
+
+python-bson:
+    ubuntu: ["python-bson"]
+
+python-cairo:
+    ubuntu: ["python-cairo"]
+
+python-cairosvg:
+    ubuntu: ["python-cairosvg"]
+
+python-can:
+    ubuntu:
+        bionic: ["python-can"]
+
+python-cantools-pip:
+    pip: ["cantools"]
+
+python-catkin-lint:
+    ubuntu: ["python-catkin-lint"]
+
+python-catkin-pkg:
+    ubuntu:
+        bionic: ["python-catkin-pkg"]
+
+python-catkin-pkg-modules:
+    ubuntu: ["python-catkin-pkg-modules"]
+
+python-catkin-sphinx:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-catkin-sphinx"]
+
+python-catkin-tools:
+    ubuntu: ["python-catkin-tools"]
+
+python-cbor:
+    ubuntu: ["python-cbor"]
+
+python-celery:
+    ubuntu: ["python-celery"]
+
+python-certifi:
+    ubuntu:
+        bionic: ["python-certifi"]
+
+python-chainer-mask-rcnn-pip:
+    pip: ["chainer-mask-rcnn"]
+
+python-chainer-pip:
+    pip: ["chainer"]
+
+python-chainercv-pip:
+    pip: ["chainercv"]
+
+python-cheetah:
+    ubuntu: ["python-cheetah"]
+
+python-cherrypy:
+    ubuntu: ["python-cherrypy3"]
+
+python-clearsilver:
+    ubuntu: ["python-clearsilver"]
+
+python-click:
+    ubuntu:
+        bionic: ["python-click"]
+
+python-cobs-pip:
+    pip: ["cobs"]
+
+python-collada:
+    ubuntu: ["python-collada"]
+
+python-colorama:
+    ubuntu: ["python-colorama"]
+
+python-concurrent.futures:
+    ubuntu: ["python-concurrent.futures"]
+
+python-configparser:
+    ubuntu: ["python-configparser"]
+
+python-construct:
+    ubuntu:
+        bionic: ["python-construct"]
+
+python-construct-pip:
+    pip: ["construct"]
+
+python-control-pip:
+    pip: ["control"]
+
+python-cookiecutter:
+    ubuntu: ["python-cookiecutter"]
+
+python-cookiecutter-pip:
+    pip: ["cookiecutter"]
+
+python-couchdb:
+    ubuntu: ["python-couchdb"]
+
+python-coverage:
+    ubuntu:
+        bionic: ["python-coverage"]
+
+python-cpplint:
+    pip: ["cpplint"]
+
+python-crccheck-pip:
+    pip: ["crccheck"]
+
+python-crcmod:
+    ubuntu:
+        bionic: ["python-crcmod"]
+
+python-crypto:
+    ubuntu:
+        bionic: ["python-crypto"]
+
+python-cryptography:
+    ubuntu: ["python-cryptography"]
+
+python-cvxopt:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-cvxopt"]
+
+python-cvxpy-pip:
+    pip: ["cvxpy"]
+
+python-cwiid:
+    ubuntu: ["python-cwiid"]
+
+python-cython-pip:
+    pip: ["cython"]
+
+python-datadog-pip:
+    pip: ["datadog"]
+
+python-dateutil:
+    ubuntu: ["python-dateutil"]
+
+python-deap-pip:
+    pip: ["deap"]
+
+python-debian:
+    ubuntu:
+        bionic: ["python-debian"]
+
+python-decorator:
+    ubuntu: ["python-decorator"]
+
+python-deepdiff-pip:
+    pip: ["deepdiff"]
+
+python-defer-pip:
+    pip: ["defer"]
+
+python-defusedxml:
+    ubuntu: ["python-defusedxml"]
+
+python-dialogflow-pip:
+    pip: ["dialogflow"]
+
+python-django:
+    ubuntu: ["python-django"]
+
+python-django-cors-headers:
+    ubuntu: ["python-django-cors-headers"]
+
+python-django-extensions:
+    ubuntu: ["python-django-extensions"]
+
+python-django-extra-views:
+    ubuntu: ["python-django-extra-views"]
+
+python-djangorestframework:
+    ubuntu: ["python-djangorestframework"]
+
+python-dlib:
+    pip: ["dlib"]
+
+python-docker:
+    ubuntu: ["python-docker"]
+
+python-docopt:
+    ubuntu: ["python-docopt"]
+
+python-docutils:
+    ubuntu:
+        bionic: ["python-docutils"]
+
+python-docx:
+    pip: ["python-docx"]
+
+python-dt-apriltags-pip:
+    pip: ["dt-apriltags"]
+
+python-dxfgrabber-pip:
+    pip: ["dxfgrabber"]
+
+python-easygui:
+    ubuntu: ["python-easygui"]
+
+python-elasticsearch:
+    ubuntu:
+        bionic: ["python-elasticsearch"]
+
+python-empy:
+    ubuntu: ["python-empy"]
+
+python-enum:
+    ubuntu: ["python-enum"]
+
+python-enum34:
+    ubuntu: ["python-enum34"]
+
+python-enum34-pip:
+    pip: ["enum34"]
+
+python-evdev:
+    ubuntu: ["python-evdev"]
+
+python-expiringdict:
+    ubuntu: ["python-expiringdict"]
+
+python-face-alignment-pip:
+    pip: ["face-alignment"]
+
+python-face-recognition-pip:
+    pip: ["face_recognition"]
+
+python-falcon:
+    ubuntu: ["python-falcon"]
+
+python-fastdtw-pip:
+    pip: ["python-fastdtw"]
+
+python-fcl-pip:
+    pip: ["python-fcl"]
+
+python-fcn-pip:
+    pip: ["fcn"]
+
+python-filterpy-pip:
+    pip: ["filterpy"]
+
+python-fixtures:
+    ubuntu: ["python-fixtures"]
+
+python-flake8:
+    ubuntu:
+        bionic: ["python-flake8"]
+
+python-flask:
+    ubuntu:
+        default: ["python-flask"]
+
+python-flask-appbuilder-pip:
+    pip: ["flask-appbuilder"]
+
+python-flask-cors-pip:
+    pip: ["flask-cors"]
+
+python-flatdict-pip:
+    pip: ["flatdict"]
+
+python-freezegun-pip:
+    pip: ["freezegun"]
+
+python-frozendict:
+    ubuntu: ["python-frozendict"]
+
+python-ftdi1:
+    ubuntu: ["python-ftdi1"]
+
+python-funcsigs:
+    ubuntu: ["python-funcsigs"]
+
+python-future:
+    ubuntu:
+        bionic: ["python-future"]
+
+python-fuzzywuzzy-pip:
+    pip: ["fuzzywuzzy"]
+
+python-fysom:
+    pip: ["fysom"]
+
+python-gTTS-pip:
+    pip: ["gTTS"]
+
+python-gcloud-pip:
+    pip: ["gcloud"]
+
+python-gdal:
+    ubuntu:
+        bionic: ["python-gdal"]
+
+python-gdown-pip:
+    pip: ["gdown"]
+
+python-genshi:
+    ubuntu: ["python-genshi"]
+
+python-geocoder-pip:
+    pip: ["geocoder"]
+
+python-geographiclib:
+    ubuntu: ["python-geographiclib"]
+
+python-geopy:
+    ubuntu: ["python-geopy"]
+
+python-gevent:
+    ubuntu: ["python-gevent"]
+
+python-gi:
+    ubuntu: ["python-gi"]
+
+python-gi-cairo:
+    ubuntu: ["python-gi-cairo"]
+
+python-git:
+    ubuntu: ["python-git"]
+
+python-github-pip:
+    pip: ["PyGithub"]
+
+python-gitlab:
+    ubuntu:
+        bionic: ["python-gitlab"]
+
+python-gitpython-pip:
+    pip: ["gitpython"]
+
+python-glpk-pip:
+    pip: ["glpk"]
+
+python-gnupg:
+    ubuntu: ["python-gnupg"]
+
+python-gobject:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-gobject"]
+        focal: ["python-gobject"]
+
+python-google-cloud-bigquery-pip:
+    pip: ["google-cloud-bigquery"]
+
+python-google-cloud-speech-pip:
+    pip: ["google-cloud-speech"]
+
+python-google-cloud-storage-pip:
+    pip: ["google-cloud-storage"]
+
+python-google-cloud-texttospeech-pip:
+    pip: ["google-cloud-texttospeech"]
+
+python-google-cloud-vision-pip:
+    pip: ["google-cloud-vision"]
+
+python-googleapi:
+    ubuntu:
+        bionic: ["python-googleapi"]
+
+python-gpiozero:
+    ubuntu:
+        bionic: ["python-gpiozero"]
+
+python-gputil-pip:
+    pip: ["gputil"]
+
+python-gpxpy:
+    ubuntu:
+        bionic: ["python-gpxpy"]
+
+python-graphitesend-pip:
+    pip: ["graphitesend"]
+
+python-graphviz-pip:
+    pip: ["graphviz"]
+
+python-grpc-tools:
+    pip: ["grpcio-tools"]
+
+python-grpcio:
+    pip: ["grpcio"]
+
+python-gst-1.0:
+    ubuntu: ["python-gst-1.0"]
+
+python-gtk2:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-gtk2"]
+
+python-gurobipy-pip:
+    pip: ["gurobipy"]
+
+python-h5py:
+    ubuntu:
+        default: ["python-h5py"]
+
+python-httplib2:
+    ubuntu:
+        default: ["python-httplib2"]
+
+python-hypothesis:
+    ubuntu:
+        default: ["python-hypothesis"]
+
+python-imageio:
+    ubuntu:
+        bionic: ["python-imageio"]
+
+python-imaging:
+    ubuntu:
+        default: ["python-pil"]
+
+python-imaging-imagetk:
+    ubuntu: ["python-pil.imagetk"]
+
+python-impacket:
+    ubuntu: ["python-impacket"]
+
+python-influxdb:
+    ubuntu:
+        bionic: ["python-influxdb"]
+
+python-inject-pip:
+    pip: ["inject"]
+
+python-inotify-simple-pip:
+    pip: ["inotify-simple"]
+
+python-inputs-pip:
+    pip: ["inputs"]
+
+python-ipdb:
+    ubuntu: ["python-ipdb"]
+
+python-is-python3:
+    ubuntu:
+        default: ["python-is-python3"]
+        bionic: nonexistent
+
+python-itsdangerous:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-itsdangerous"]
+
+python-j1939-pip:
+    pip: ["j1939"]
+
+python-jasmine-pip:
+    pip: ["jasmine"]
+
+python-jetson-gpio-pip:
+    pip: ["Jetson.GPIO"]
+
+python-jetson-stats-pip:
+    pip: ["jetson-stats"]
+
+python-jinja2:
+    ubuntu: ["python-jinja2"]
+
+python-jira-pip:
+    pip: ["jira"]
+
+python-jmespath:
+    ubuntu: ["python-jmespath"]
+
+python-joblib:
+    ubuntu: ["python-joblib"]
+
+python-jsonpickle:
+    ubuntu: ["python-jsonpickle"]
+
+python-jsonpyes-pip:
+    pip: ["jsonpyes"]
+
+python-jsonref-pip:
+    pip: ["jsonref"]
+
+python-jsonschema:
+    ubuntu: ["python-jsonschema"]
+
+python-jsonschema-pip:
+    pip: ["jsonschema"]
+
+python-jwt:
+    ubuntu: ["python-jwt"]
+
+python-kdtree:
+    pip: ["kdtree"]
+
+python-keras-pip:
+    pip: ["keras"]
+
+python-keras-rl-pip:
+    pip: ["keras-rl"]
+
+python-kitchen:
+    ubuntu: ["python-kitchen"]
+
+python-kml:
+    ubuntu: ["python-kml"]
+
+python-kombu:
+    ubuntu: ["python-kombu"]
+
+python-kombu-pip:
+    pip: ["kombu"]
+
+python-levenshtein:
+    ubuntu: ["python-levenshtein"]
+
+python-libpcap:
+    ubuntu: ["python-libpcap"]
+
+python-libpgm-pip:
+    pip: ["libpgm"]
+
+python-librabbitmq-pip:
+    pip: ["librabbitmq"]
+
+python-lindypy-pip:
+    pip: ["lindypy"]
+
+python-lttngust:
+    pip: ["python-lttngust"]
+
+python-luis-pip:
+    pip: ["luis"]
+
+python-lxml:
+    ubuntu:
+        bionic: ["python-lxml"]
+        focal: ["python-lxml"]
+
+python-lzf-pip:
+    pip: ["python-lzf"]
+
+python-mahotas:
+    pip: ["mahotas"]
+
+python-mako:
+    ubuntu: ["python-mako"]
+
+python-mapnik:
+    ubuntu: ["python-mapnik"]
+
+python-marisa:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-marisa"]
+
+python-markdown:
+    ubuntu: ["python-markdown"]
+
+python-marshmallow:
+    pip: ["marshmallow"]
+
+python-math3d-pip:
+    pip: ["math3d"]
+
+python-matplotlib:
+    ubuntu:
+        bionic: ["python-matplotlib"]
+
+python-mechanize:
+    ubuntu: ["python-mechanize"]
+
+python-mistune:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-mistune"]
+
+python-mock:
+    ubuntu:
+        bionic: ["python-mock"]
+
+python-monotonic:
+    ubuntu: ["python-monotonic"]
+
+python-more-itertools:
+    ubuntu:
+        default: ["python-more-itertools"]
+
+python-msgpack:
+    ubuntu: ["python-msgpack"]
+
+python-multicast:
+    pip: ["py-multicast"]
+
+python-multiprocess-pip:
+    pip: ["multiprocess"]
+
+python-mysqldb:
+    ubuntu: ["python-mysqldb"]
+
+python-namedlist-pip:
+    pip: ["namedlist"]
+
+python-nclib-pip:
+    pip: ["nclib"]
+
+python-netaddr:
+    ubuntu:
+        bionic: ["python-netaddr"]
+
+python-netcdf4:
+    ubuntu: ["python-netcdf4"]
+
+python-netifaces:
+    ubuntu:
+        bionic: ["python-netifaces"]
+
+python-networkmanager:
+    ubuntu: ["python-networkmanager"]
+
+python-networkx:
+    ubuntu:
+        default: ["python-networkx"]
+
+python-nose:
+    ubuntu:
+        default: ["python-nose"]
+
+python-ntplib:
+    ubuntu: ["python-ntplib"]
+
+python-numpy:
+    ubuntu:
+        bionic: ["python-numpy"]
+        focal: ["python-numpy"]
+
+python-numpy-quaternion-pip:
+    pip: ["numpy-quaternion"]
+
+python-numpy-stl-pip:
+    pip: ["numpy-stl"]
+
+python-numpydoc:
+    ubuntu: ["python-numpydoc"]
+
+python-oauth2client:
+    ubuntu: ["python-oauth2client"]
+
+python-objectpath-pip:
+    pip: ["objectpath"]
+
+python-omniorb:
+    ubuntu:
+        focal: ["python-omniorb", "python-omniorb-omg", "omniidl-python"]
+
+python-open3d-pip:
+    pip: ["open3d-python"]
+
+python-opencv:
+    ubuntu: ["python-opencv"]
+
+python-opencv-contrib-pip:
+    pip: ["opencv-contrib-python"]
+
+python-opengl:
+    ubuntu:
+        bionic: ["python-opengl"]
+
+python-openssl:
+    ubuntu: ["python-openssl"]
+
+python-oyaml-pip:
+    pip: ["oyaml"]
+
+python-packaging:
+    ubuntu: ["python-packaging"]
+
+python-paho-mqtt:
+    ubuntu:
+        bionic: ["python-paho-mqtt"]
+
+python-paho-mqtt-pip:
+    pip: ["paho-mqtt"]
+
+python-pandacan-pip:
+    pip: ["pandacan"]
+
+python-pandas:
+    ubuntu: ["python-pandas"]
+
+python-parameterized:
+    ubuntu:
+        bionic: ["python-parameterized"]
+
+python-paramiko:
+    ubuntu: ["python-paramiko"]
+
+python-parse:
+    ubuntu: ["python-parse"]
+
+python-parso:
+    ubuntu:
+        bionic: ["python-parso"]
+
+python-passlib:
+    ubuntu: ["python-passlib"]
+
+python-pastedeploy:
+    ubuntu: ["python-pastedeploy"]
+
+python-path.py:
+    pip: ["path.py"]
+
+python-pathlib:
+    ubuntu: ["python-pathlib"]
+
+python-pathlib2:
+    ubuntu:
+        default: ["python-pathlib2"]
+
+python-pathos-pip:
+    pip: ["pathos"]
+
+python-pbr:
+    ubuntu: ["python-pbr"]
+
+python-pcapy:
+    ubuntu: ["python-pcapy"]
+
+python-pcg-gazebo-pip:
+    pip: ["pcg-gazebo"]
+
+python-pep8:
+    ubuntu:
+        default: ["python-pep8"]
+
+python-percol:
+    pip: ["percol"]
+
+python-periphery-pip:
+    pip: ["python-periphery"]
+
+python-persist-queue-pip:
+    pip: ["persist-queue"]
+
+python-pexpect:
+    ubuntu: ["python-pexpect"]
+
+python-pip:
+    ubuntu: ["python-pip"]
+
+python-pixel-ring-pip:
+    pip: ["pixel-ring"]
+
+python-pkg-resources:
+    ubuntu: ["python-pkg-resources"]
+
+python-planar-pip:
+    pip: ["planar"]
+
+python-plyfile-pip:
+    pip: ["plyfile"]
+
+python-poster:
+    ubuntu: ["python-poster"]
+
+python-pqdict-pip:
+    pip: ["pqdict"]
+
+python-prettytable:
+    ubuntu: ["python-prettytable"]
+
+python-progressbar:
+    ubuntu:
+        bionic: ["python-progressbar"]
+
+python-progressbar2-pip:
+    pip: ["progressbar2"]
+
+python-protobuf:
+    ubuntu: ["python-protobuf"]
+
+python-psutil:
+    ubuntu:
+        default: ["python-psutil"]
+
+python-pulsectl-pip:
+    pip: ["pulsectl"]
+
+python-pyassimp:
+    ubuntu:
+        bionic: ["python-pyassimp"]
+
+python-pyaudio:
+    ubuntu: ["python-pyaudio"]
+
+python-pycodestyle:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python-pycodestyle"]
+
+python-pycpd-pip:
+    pip: ["pycpd"]
+
+python-pycryptodome:
+    ubuntu: ["python-pycryptodome"]
+
+python-pycurl:
+    ubuntu: ["python-pycurl"]
+
+python-pydbus:
+    ubuntu:
+        bionic: ["python-pydbus"]
+
+python-pydot:
+    ubuntu: ["python-pydot"]
+
+python-pyexiv2:
+    ubuntu: ["python-pyexiv2"]
+
+python-pyftpdlib:
+    ubuntu: ["python-pyftpdlib"]
+
+python-pygame:
+    ubuntu: ["python-pygame"]
+
+python-pygithub3:
+    pip: ["pygithub3"]
+
+python-pygps-pip:
+    pip: ["pyGPs"]
+
+python-pygraph:
+    ubuntu: ["python-pygraph"]
+
+python-pygraphviz:
+    ubuntu: ["python-pygraphviz"]
+
+python-pyinotify:
+    ubuntu: ["python-pyinotify"]
+
+python-pykalman:
+    pip: ["pykalman"]
+
+python-pylibftdi-pip:
+    pip: ["pylibftdi"]
+
+python-pylint:
+    ubuntu: ["pylint"]
+
+python-pylint3:
+    ubuntu:
+        default: ["pylint"]
+        bionic: ["pylint3"]
+
+python-pymavlink:
+    pip: ["pymavlink"]
+
+python-pymodbus:
+    ubuntu:
+        bionic: ["python-pymodbus"]
+
+python-pymodbus-pip:
+    pip: ["pymodbus"]
+
+python-pymongo:
+    ubuntu:
+        default: ["python-pymongo"]
+
+python-pymouse:
+    pip: ["pymouse"]
+
+python-pynfft:
+    ubuntu: ["python-pynfft"]
+
+python-pynmea2:
+    pip: ["pynmea2"]
+
+python-pypcd-pip:
+    pip: ["pypcd"]
+
+python-pypng:
+    ubuntu:
+        bionic: ["python-png"]
+
+python-pypozyx-pip:
+    pip: ["pypozyx"]
+
+python-pyproj:
+    ubuntu: ["python-pyproj"]
+
+python-pyqrcode:
+    ubuntu:
+        bionic: ["python-pyqrcode"]
+
+python-pyqtgraph:
+    ubuntu:
+        bionic: ["python-pyqtgraph"]
+
+python-pyquery:
+    ubuntu: ["python-pyquery"]
+
+python-pyramid:
+    ubuntu: ["python-pyramid"]
+
+python-pyrealsense2-pip:
+    pip: ["pyrealsense2"]
+
+python-pysimplegui27-pip:
+    pip: ["pysimplegui27"]
+
+python-pysnmp:
+    ubuntu: ["python-pysnmp4"]
+
+python-pytesseract-pip:
+    pip: ["pytesseract"]
+
+python-pytest:
+    ubuntu: ["python-pytest"]
+
+python-pytest-cov:
+    ubuntu: ["python-pytest-cov"]
+
+python-pytest-dependency-pip:
+    pip: ["pytest-dependency"]
+
+python-pytest-mock:
+    ubuntu: ["python-pytest-mock"]
+
+python-pytest-qt-pip:
+    pip: ["pytest-qt"]
+
+python-pytides-pip:
+    pip: ["pytides"]
+
+python-pytorch-pip:
+    pip: ["torch", "torchvision"]
+
+python-pytz-pip:
+    pip: ["pytz"]
+
+python-pyudev:
+    ubuntu:
+        default: ["python-pyudev"]
+
+python-pyusb-pip:
+    pip: ["pyusb"]
+
+python-pyuserinput:
+    pip: ["PyUserInput"]
+
+python-pyvirtualdisplay-pip:
+    pip: ["pyvirtualdisplay"]
+
+python-pyxhook-pip:
+    pip: ["pyxhook"]
+
+python-pyzbar-pip:
+    pip: ["pyzbar"]
+
+python-qrencode:
+    ubuntu: ["python-qrencode"]
+
+python-qt-bindings:
+    ubuntu:
+        default: ["python-pyside", "libpyside-dev", "libshiboken-dev", "shiboken", "python-qt4", "python-qt4-dev", "python-sip-dev"]
+
+python-qt-bindings-gl:
+    ubuntu: ["python-qt4-gl"]
+
+python-qt-bindings-qwt5:
+    ubuntu: ["python-qwt5-qt4"]
+
+python-qt-bindings-webkit:
+    ubuntu: ["python-qt4"]
+
+python-qt4-gl:
+    ubuntu: ["python-qt4-gl"]
+
+python-qt5-bindings:
+    ubuntu:
+        bionic: ["pyqt5-dev", "python-pyqt5", "python-pyqt5.qtsvg", "python-sip-dev"]
+
+python-qt5-bindings-gl:
+    ubuntu:
+        bionic: ["python-pyqt5.qtopengl"]
+
+python-qt5-bindings-qsci:
+    ubuntu: ["python-pyqt5.qsci"]
+
+python-qt5-bindings-quick:
+    ubuntu: ["python-pyqt5.qtquick"]
+
+python-qt5-bindings-webkit:
+    ubuntu:
+        bionic: ["python-pyqt5.qtwebkit"]
+
+python-qtpy:
+    ubuntu: ["python-qtpy"]
+
+python-qwt5-qt4:
+    ubuntu: ["python-qwt5-qt4"]
+
+python-rdflib:
+    ubuntu: ["python-rdflib"]
+
+python-readchar-pip:
+    pip: ["readchar"]
+
+python-redis:
+    ubuntu: ["python-redis"]
+
+python-redis-pip:
+    pip: ["redis"]
+
+python-requests:
+    ubuntu:
+        default: ["python-requests"]
+
+python-requests-oauthlib:
+    ubuntu: ["python-requests-oauthlib"]
+
+python-responses-pip:
+    pip: ["responses"]
+
+python-rosdep:
+    ubuntu:
+        bionic: ["python-rosdep"]
+
+python-rosdep-modules:
+    ubuntu: ["python-rosdep-modules"]
+
+python-rosinstall:
+    ubuntu:
+        default: ["python-rosinstall"]
+
+python-rosinstall-generator:
+    ubuntu: ["python-rosinstall-generator"]
+
+python-rospkg:
+    ubuntu:
+        default: ["python-rospkg"]
+
+python-rospkg-modules:
+    ubuntu: ["python-rospkg-modules"]
+
+python-rpi.gpio:
+    ubuntu:
+        bionic: ["python-rpi.gpio"]
+
+python-rpi.gpio-pip:
+    pip: ["RPi.GPIO"]
+
+python-rtree:
+    ubuntu: ["python-rtree"]
+
+python-ruamel.yaml:
+    ubuntu:
+        bionic: ["python-ruamel.yaml"]
+
+python-rx-pip:
+    pip: ["rx"]
+
+python-sbp-pip:
+    pip: ["sbp"]
+
+python-scapy:
+    ubuntu: ["python-scapy"]
+
+python-schedule:
+    ubuntu: ["python-schedule"]
+
+python-scipy:
+    ubuntu:
+        default: ["python-scipy"]
+
+python-scp:
+    ubuntu: ["python-scp"]
+
+python-seaborn:
+    ubuntu:
+        bionic: ["python-seaborn"]
+
+python-selectors2-pip:
+    pip: ["selectors2"]
+
+python-selenium-pip:
+    pip: ["selenium"]
+
+python-semantic-version:
+    ubuntu:
+        bionic: ["python-semantic-version"]
+
+python-semver:
+    ubuntu: ["python-semver"]
+
+python-serial:
+    ubuntu:
+        bionic: ["python-serial"]
+
+python-setproctitle:
+    ubuntu: ["python-setproctitle"]
+
+python-setuptools:
+    ubuntu:
+        bionic: ["python-setuptools"]
+
+python-sexpdata:
+    pip: ["sexpdata"]
+
+python-sh:
+    ubuntu:
+        bionic: ["python-sh"]
+
+python-shapely:
+    ubuntu:
+        default: ["python-shapely"]
+
+python-simplejson:
+    ubuntu: ["python-simplejson"]
+
+python-singledispatch:
+    ubuntu: ["python-singledispatch"]
+
+python-sip:
+    ubuntu:
+        default: ["python-sip-dev"]
+
+python-six:
+    ubuntu: ["python-six"]
+
+python-skimage:
+    ubuntu:
+        bionic: ["python-skimage"]
+
+python-skimage-pip:
+    pip: ["scikit-image"]
+
+python-sklearn:
+    ubuntu:
+        default: ["python-sklearn"]
+
+python-slackclient-pip:
+    pip: ["slackclient"]
+
+python-slacker-cli:
+    pip: ["slacker-cli"]
+
+python-slycot-pip:
+    pip: ["slycot"]
+
+python-smbus:
+    ubuntu: ["python-smbus"]
+
+python-sortedcontainers-pip:
+    pip: ["sortedcontainers"]
+
+python-sparqlwrapper:
+    ubuntu: ["python-sparqlwrapper"]
+
+python-speechrecognition-pip:
+    pip: ["speechrecognition"]
+
+python-sphinx:
+    ubuntu:
+        default: ["python-sphinx"]
+
+python-sphinx-argparse:
+    ubuntu:
+        bionic: ["python-sphinx-argparse"]
+
+python-sphinx-rtd-theme:
+    ubuntu:
+        bionic: ["python-sphinx-rtd-theme"]
+
+python-spidev-pip:
+    pip: ["spidev"]
+
+python-sqlalchemy:
+    ubuntu:
+        bionic: ["python-sqlalchemy"]
+
+python-sqlite:
+    ubuntu: ["python-sqlite"]
+
+python-statistics-pip:
+    pip: ["statistics"]
+
+python-statsd:
+    ubuntu: ["python-statsd"]
+
+python-subprocess32:
+    ubuntu:
+        default: ["python-subprocess32"]
+
+python-support:
+    ubuntu: ["python-support"]
+
+python-svg.path:
+    ubuntu:
+        bionic: ["python-svg.path"]
+
+python-svn:
+    ubuntu: ["python-svn"]
+
+python-sympy:
+    ubuntu:
+        bionic: ["python-sympy"]
+
+python-systemd:
+    ubuntu:
+        bionic: ["python-systemd"]
+
+python-sysv-ipc:
+    ubuntu: ["python-sysv-ipc"]
+
+python-tablib:
+    ubuntu: ["python-tablib"]
+
+python-tablib-pip:
+    pip: ["tablib"]
+
+python-tabulate:
+    ubuntu:
+        bionic: ["python-tabulate"]
+
+python-tabulate-pip:
+    pip: ["tabulate"]
+
+python-tblib:
+    ubuntu: ["python-tblib"]
+
+python-telegram-bot:
+    pip: ["python-telegram-bot"]
+
+python-tensorboard-pip:
+    pip: ["tensorboard"]
+
+python-tensorboardX-pip:
+    pip: ["tensorboardX"]
+
+python-tensorflow-gpu-pip:
+    pip: ["tensorflow-gpu"]
+
+python-tensorflow-hub-pip:
+    pip: ["tensorflow-hub"]
+
+python-tensorflow-pip:
+    pip: ["tensorflow"]
+
+python-tensorflow-serving-api-pip:
+    pip: ["tensorflow-serving-api"]
+
+python-termcolor:
+    ubuntu:
+        default: ["python-termcolor"]
+
+python-testscenarios:
+    ubuntu: ["python-testscenarios"]
+
+python-testtools:
+    ubuntu: ["python-testtools"]
+
+python-texttable:
+    ubuntu:
+        bionic: ["python-texttable"]
+
+python-tftpy:
+    ubuntu: ["python-tftpy"]
+
+python-tilestache:
+    ubuntu: ["tilestache"]
+
+python-tk:
+    ubuntu:
+        default: ["python-tk"]
+
+python-toml:
+    ubuntu: ["python-toml"]
+
+python-tornado:
+    ubuntu: ["python-tornado"]
+
+python-tornado-couchdb-pip:
+    pip: ["tornado-couchdb"]
+
+python-tornado-pip:
+    pip: ["tornado"]
+
+python-tqdm:
+    ubuntu:
+        bionic: ["python-tqdm"]
+
+python-transforms3d-pip:
+    pip: ["transforms3d"]
+
+python-transitions:
+    ubuntu:
+        bionic: ["python-transitions"]
+
+python-trep:
+    pip: ["trep"]
+
+python-triangle-pip:
+    pip: ["triangle"]
+
+python-trimesh-pip:
+    pip: ["trimesh"]
+
+python-twilio-pip:
+    pip: ["twilio"]
+
+python-twisted-bin:
+    ubuntu: ["python-twisted-bin"]
+
+python-twisted-core:
+    ubuntu: ["python-twisted-core"]
+
+python-twisted-web:
+    ubuntu: ["python-twisted-web"]
+
+python-twitter:
+    ubuntu: ["python-twitter"]
+
+python-typing:
+    ubuntu:
+        default: ["python-typing"]
+
+python-typing-pip:
+    pip: ["typing"]
+
+python-tz:
+    ubuntu: ["python-tz"]
+
+python-tzlocal-pip:
+    pip: ["tzlocal"]
+
+python-ubjson:
+    ubuntu:
+        bionic: ["python-ubjson"]
+
+python-ujson:
+    ubuntu:
+        bionic: ["python-ujson"]
+
+python-unittest2:
+    ubuntu: ["python-unittest2"]
+
+python-urlgrabber:
+    ubuntu: ["python-urlgrabber"]
+
+python-urllib3:
+    ubuntu: ["python-urllib3"]
+
+python-usb:
+    ubuntu: ["python-usb"]
+
+python-utm-pip:
+    pip: ["utm"]
+
+python-validictory-pip:
+    pip: ["validictory"]
+
+python-vcstool:
+    ubuntu: ["python-vcstool"]
+
+python-vedo-pip:
+    pip: ["vedo"]
+
+python-vine-pip:
+    pip: ["vine"]
+
+python-virtualenv:
+    ubuntu: ["python-virtualenv"]
+
+python-visual:
+    ubuntu: ["python-visual"]
+
+python-vlc-pip:
+    pip: ["python-vlc"]
+
+python-voluptuous:
+    ubuntu: ["python-voluptuous"]
+
+python-vtk:
+    ubuntu:
+        bionic: ["python-vtk6"]
+
+python-w1thermsensor-pip:
+    pip: ["w1thermsensor"]
+
+python-waitress:
+    ubuntu: ["python-waitress"]
+
+python-walrus-pip:
+    pip: ["walrus"]
+
+python-watchdog:
+    ubuntu:
+        bionic: ["python-watchdog"]
+
+python-webob:
+    ubuntu: ["python-webob"]
+
+python-webpy:
+    ubuntu: ["python-webpy"]
+
+python-webrtcvad-pip:
+    pip: ["webrtcvad"]
+
+python-websocket:
+    ubuntu:
+        bionic: ["python-websocket"]
+
+python-webtest:
+    ubuntu: ["python-webtest"]
+
+python-werkzeug:
+    ubuntu: ["python-werkzeug"]
+
+python-wheel:
+    ubuntu: ["python-wheel"]
+
+python-whichcraft:
+    ubuntu: ["python-whichcraft"]
+
+python-wrapt:
+    ubuntu: ["python-wrapt"]
+
+python-ws4py:
+    ubuntu: ["python-ws4py"]
+
+python-ws4py-pip:
+    pip: ["ws4py"]
+
+python-wstool:
+    ubuntu: ["python-wstool"]
+
+python-wtforms:
+    ubuntu: ["python-wtforms"]
+
+python-wxtools:
+    ubuntu: ["python-wxtools"]
+
+python-xdot:
+    ubuntu: ["xdot"]
+
+python-xlib:
+    ubuntu: ["python-xlib"]
+
+python-xlrd:
+    ubuntu: ["python-xlrd"]
+
+python-xmlplain-pip:
+    pip: ["xmlplain"]
+
+python-xmltodict:
+    ubuntu:
+        bionic: ["python-xmltodict"]
+
+python-yamale-pip:
+    pip: ["yamale"]
+
+python-yaml:
+    ubuntu:
+        bionic: ["python-yaml"]
+        focal: ["python-yaml"]
+
+python-zbar:
+    ubuntu: ["python-zbar"]
+
+python-zmq:
+    ubuntu:
+        default: ["python-zmq"]
+
+python3:
+    ubuntu: ["python3-dev"]
+
+python3-adafruit-blinka-pip:
+    pip: ["Adafruit-Blinka"]
+
+python3-adafruit-circuitpython-ads1x15-pip:
+    pip: ["adafruit-circuitpython-ads1x15"]
+
+python3-adafruit-circuitpython-bno055-pip:
+    pip: ["adafruit-circuitpython-bno055"]
+
+python3-adafruit-circuitpython-bno08x-pip:
+    pip: ["adafruit-circuitpython-bno08x"]
+
+python3-adafruit-circuitpython-lsm9ds0-pip:
+    pip: ["adafruit-circuitpython-lsm9ds0"]
+
+python3-adafruit-circuitpython-mcp230xx-pip:
+    pip: ["adafruit-circuitpython-mcp230xx"]
+
+python3-adafruit-circuitpython-mpu6050-pip:
+    pip: ["adafruit-circuitpython-mpu6050"]
+
+python3-adapt-parser-pip:
+    pip: ["adapt-parser"]
+
+python3-ahrs-pip:
+    pip: ["ahrs"]
+
+python3-aio-pika-pip:
+    pip: ["aio-pika"]
+
+python3-aiohttp:
+    ubuntu: ["python3-aiohttp"]
+
+python3-aiohttp-cors:
+    ubuntu: ["python3-aiohttp-cors"]
+
+python3-aiortc:
+    ubuntu:
+        jammy: ["python3-aiortc"]
+
+python3-albumentations-pip:
+    pip: ["albumentations"]
+
+python3-alembic:
+    ubuntu: ["python3-alembic"]
+
+python3-alsaaudio:
+    ubuntu: ["python3-alsaaudio"]
+
+python3-ansible-runner-pip:
+    pip: ["ansible-runner"]
+
+python3-antlr4:
+    ubuntu:
+        default: ["python3-antlr4"]
+        focal: nonexistent
+
+python3-anytree-pip:
+    pip: ["anytree"]
+
+python3-apa102-pi-pip:
+    pip: ["apa102-pi"]
+
+python3-argcomplete:
+    ubuntu: ["python3-argcomplete"]
+
+python3-astropy-pip:
+    pip: ["astropy"]
+
+python3-asyncssh:
+    ubuntu: ["python3-asyncssh"]
+
+python3-attrs:
+    ubuntu: ["python3-attr"]
+
+python3-autobahn:
+    ubuntu: ["python3-autobahn"]
+
+python3-awsiotsdk-pip:
+    pip: ["awsiotsdk"]
+
+python3-babel:
+    ubuntu: ["python3-babel"]
+
+python3-babeltrace:
+    ubuntu: ["python3-babeltrace"]
+
+python3-backoff-pip:
+    pip: ["backoff"]
+
+python3-bcrypt:
+    ubuntu: ["python3-bcrypt"]
+
+python3-beartype:
+    ubuntu:
+        default: ["python3-beartype"]
+        focal: nonexistent
+        jammy: nonexistent
+
+python3-bidict:
+    ubuntu:
+        default: ["python3-bidict"]
+        bionic: nonexistent
+
+python3-bitarray:
+    ubuntu: ["python3-bitarray"]
+
+python3-bitstring:
+    ubuntu: ["python3-bitstring"]
+
+python3-bloom:
+    ubuntu: ["python3-bloom"]
+
+python3-bluerobotics-ping-pip:
+    pip: ["bluerobotics-ping"]
+
+python3-bluez:
+    ubuntu:
+        default: ["python3-bluez"]
+        bionic: nonexistent
+
+python3-bokeh-pip:
+    pip: ["bokeh"]
+
+python3-bosdyn-api-pip:
+    pip: ["bosdyn-api", "bosdyn-choreography-protos"]
+
+python3-bosdyn-client-pip:
+    pip: ["bosdyn-client", "bosdyn-choreography-client"]
+
+python3-bosdyn-core-pip:
+    pip: ["bosdyn-core"]
+
+python3-bosdyn-mission-pip:
+    pip: ["bosdyn-mission"]
+
+python3-boto3:
+    ubuntu: ["python3-boto3"]
+
+python3-bottle:
+    ubuntu: ["python3-bottle"]
+
+python3-box:
+    pip: ["python-box"]
+    pip: ["python-box"]
+
+python3-breathe:
+    ubuntu: ["python3-breathe"]
+
+python3-bs4:
+    ubuntu: ["python3-bs4"]
+
+python3-bson:
+    ubuntu: ["python3-bson"]
+
+python3-build:
+    ubuntu:
+        default: ["python3-build"]
+        focal: nonexistent
+
+python3-cairo:
+    ubuntu: ["python3-cairo"]
+
+python3-cairosvg:
+    ubuntu: ["python3-cairosvg"]
+
+python3-can:
+    ubuntu:
+        default: ["python3-can"]
+
+python3-can-j1939-pip:
+    pip: ["can-j1939"]
+
+python3-cantools-pip:
+    pip: ["cantools"]
+
+python3-catkin-lint:
+    ubuntu:
+        default: ["catkin-lint"]
+        bionic: nonexistent
+
+python3-catkin-pkg:
+    ubuntu: ["python3-catkin-pkg"]
+
+python3-catkin-pkg-modules:
+    ubuntu: ["python3-catkin-pkg-modules"]
+
+python3-catkin-sphinx:
+    ubuntu:
+        default: nonexistent
+        focal: ["python3-catkin-sphinx"]
+
+python3-catkin-tools:
+    ubuntu: ["python3-catkin-tools"]
+
+python3-cbor2:
+    pip: ["cbor2"]
+    pip: ["cbor2"]
+
+python3-certifi:
+    ubuntu: ["python3-certifi"]
+
+python3-cffi:
+    ubuntu: ["python3-cffi"]
+
+python3-chainer-pip:
+    pip: ["chainer"]
+
+python3-charisma-sdk-pip:
+    pip: ["charisma-sdk"]
+
+python3-cherrypy3:
+    ubuntu: ["python3-cherrypy3"]
+
+python3-click:
+    ubuntu: ["python3-click"]
+
+python3-colcon-common-extensions:
+    ubuntu: ["python3-colcon-common-extensions"]
+
+python3-colcon-meson:
+    ubuntu:
+        jammy: ["python3-colcon-meson"]
+
+python3-collada:
+    ubuntu:
+        default: ["python3-collada"]
+        bionic: nonexistent
+
+python3-collada-pip:
+    pip: ["pycollada"]
+
+python3-colorama:
+    ubuntu: ["python3-colorama"]
+
+python3-colorcet:
+    pip: ["colorcet"]
+    pip: ["colorcet"]
+
+python3-conan-pip:
+    pip: ["conan"]
+
+python3-connexion-pip:
+    pip: ["connexion"]
+
+python3-construct:
+    ubuntu: ["python3-construct"]
+
+python3-cookiecutter:
+    ubuntu:
+        default: ["python3-cookiecutter"]
+        focal: nonexistent
+
+python3-coverage:
+    ubuntu: ["python3-coverage"]
+
+python3-crc16-pip:
+    pip: ["crc16"]
+
+python3-crcmod:
+    ubuntu: ["python3-crcmod"]
+
+python3-cryptography:
+    ubuntu: ["python3-cryptography"]
+
+python3-cvxopt:
+    ubuntu: ["python3-cvxopt"]
+
+python3-cvxpy-pip:
+    pip: ["cvxpy"]
+
+python3-cycler:
+    ubuntu: ["python3-cycler"]
+
+python3-dataclasses-json:
+    ubuntu:
+        default: ["python3-dataclasses-json"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-datadog-pip:
+    pip: ["datadog"]
+
+python3-dateutil:
+    ubuntu: ["python3-dateutil"]
+
+python3-dbus:
+    ubuntu: ["python3-dbus"]
+
+python3-decorator:
+    ubuntu: ["python3-decorator"]
+
+python3-deepdiff:
+    pip: ["deepdiff"]
+
+python3-defusedxml:
+    ubuntu: ["python3-defusedxml"]
+
+python3-deprecated:
+    ubuntu:
+        default: ["python3-deprecated"]
+        bionic: nonexistent
+
+python3-depthai-pip:
+    pip: ["depthai"]
+
+python3-dev:
+    ubuntu: ["python3-dev"]
+
+python3-dill:
+    ubuntu: ["python3-dill"]
+
+python3-distro:
+    ubuntu: ["python3-distro"]
+
+python3-distutils:
+    ubuntu:
+        default: nonexistent
+        bionic: ["python3-distutils"]
+        focal: ["python3-distutils"]
+        jammy: ["python3-distutils"]
+
+python3-django:
+    ubuntu: ["python3-django"]
+
+python3-django-cors-headers:
+    ubuntu: ["python3-django-cors-headers"]
+
+python3-django-extensions:
+    ubuntu: ["python3-django-extensions"]
+
+python3-django-extra-views:
+    ubuntu: ["python3-django-extra-views"]
+
+python3-djangorestframework:
+    ubuntu: ["python3-djangorestframework"]
+
+python3-dlib-pip:
+    pip: ["dlib"]
+
+python3-do-mpc-pip:
+    pip: ["do-mpc"]
+
+python3-docker:
+    ubuntu: ["python3-docker"]
+
+python3-docopt:
+    ubuntu: ["python3-docopt"]
+
+python3-docutils:
+    ubuntu: ["python3-docutils"]
+
+python3-dubins-pip:
+    pip: ["dubins"]
+
+python3-easydict:
+    pip: ["easydict"]
+    pip: ["easydict"]
+
+python3-elasticsearch:
+    ubuntu: ["python3-elasticsearch"]
+
+python3-emoji:
+    pip: ["emoji"]
+    pip: ["emoji"]
+
+python3-empy:
+    ubuntu: ["python3-empy"]
+
+python3-environs-pip:
+    pip: ["environs"]
+
+python3-evdev:
+    ubuntu: ["python3-evdev"]
+
+python3-events-pip:
+    pip: ["Events"]
+
+python3-expiringdict:
+    ubuntu: ["python3-expiringdict"]
+
+python3-ezdxf:
+    pip: ["ezdxf"]
+    pip: ["ezdxf"]
+
+python3-fabric:
+    ubuntu: ["python3-fabric"]
+
+python3-falcon:
+    ubuntu: ["python3-falcon"]
+
+python3-fann2:
+    ubuntu: ["python3-fann2"]
+
+python3-fastapi:
+    pip: ["fastapi"]
+    pip: ["fastapi"]
+
+python3-fasteners-pip:
+    pip: ["fasteners"]
+
+python3-fastjsonschema:
+    ubuntu:
+        default: ["python3-fastjsonschema"]
+        focal: nonexistent
+
+python3-fastkml:
+    ubuntu: ["python3-fastkml"]
+
+python3-fastnumbers-pip:
+    pip: ["fastnumbers"]
+
+python3-fcn-pip:
+    pip: ["fcn"]
+
+python3-filetype-pip:
+    pip: ["filetype"]
+
+python3-filfinder-pip:
+    pip: ["fil_finder"]
+
+python3-fiona:
+    ubuntu: ["python3-fiona"]
+
+python3-flake8:
+    ubuntu: ["python3-flake8"]
+
+python3-flake8-black:
+    pip: ["flake8-black"]
+
+python3-flake8-blind-except:
+    ubuntu:
+        default: ["python3-flake8-blind-except"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-blind-except-pip:
+    pip: ["flake8-blind-except"]
+
+python3-flake8-builtins:
+    ubuntu:
+        default: ["python3-flake8-builtins"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-builtins-pip:
+    pip: ["flake8-builtins"]
+
+python3-flake8-class-newline:
+    ubuntu:
+        default: ["python3-flake8-class-newline"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-class-newline-pip:
+    pip: ["flake8-class-newline"]
+
+python3-flake8-comprehensions:
+    ubuntu:
+        default: ["python3-flake8-comprehensions"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-comprehensions-pip:
+    pip: ["flake8-comprehensions"]
+
+python3-flake8-deprecated:
+    ubuntu:
+        default: ["python3-flake8-deprecated"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-deprecated-pip:
+    pip: ["flake8-deprecated"]
+
+python3-flake8-docstrings:
+    ubuntu: ["python3-flake8-docstrings"]
+
+python3-flake8-docstrings-pip:
+    pip: ["flake8-docstrings"]
+
+python3-flake8-import-order:
+    ubuntu:
+        default: ["python3-flake8-import-order"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-import-order-pip:
+    pip: ["flake8-import-order"]
+
+python3-flake8-isort:
+    pip: ["flake8-isort"]
+
+python3-flake8-quotes:
+    ubuntu:
+        default: ["python3-flake8-quotes"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-flake8-quotes-pip:
+    pip: ["flake8-quotes"]
+
+python3-flaky:
+    ubuntu: ["python3-flaky"]
+
+python3-flask:
+    ubuntu: ["python3-flask"]
+
+python3-flask-bcrypt:
+    ubuntu: ["python3-flask-bcrypt"]
+
+python3-flask-cors:
+    ubuntu:
+        default: ["python3-flask-cors"]
+        bionic: nonexistent
+
+python3-flask-jwt-extended:
+    pip: ["flask-jwt-extended"]
+
+python3-flask-migrate:
+    ubuntu: ["python3-flask-migrate"]
+
+python3-flask-restplus-pip:
+    pip: ["flask-restplus"]
+
+python3-flask-socketio:
+    ubuntu: ["python3-flask-socketio"]
+
+python3-flask-sqlalchemy:
+    ubuntu: ["python3-flask-sqlalchemy"]
+
+python3-flatbuffers:
+    pip: ["flatbuffers"]
+    pip: ["flatbuffers"]
+
+python3-fonttools:
+    ubuntu: ["python3-fonttools"]
+
+python3-formant-pip:
+    pip: ["formant"]
+
+python3-fpdf2-pip:
+    pip: ["fpdf2"]
+
+python3-ftdi1:
+    ubuntu: ["python3-ftdi1"]
+
+python3-funcsigs:
+    ubuntu: ["python3-funcsigs"]
+
+python3-future:
+    ubuntu: ["python3-future"]
+
+python3-gdal:
+    ubuntu: ["python3-gdal"]
+
+python3-gdown-pip:
+    pip: ["gdown"]
+
+python3-geographiclib:
+    ubuntu: ["python3-geographiclib"]
+
+python3-geojson:
+    ubuntu: ["python3-geojson"]
+
+python3-geomag-pip:
+    pip: ["geomag"]
+
+python3-geopandas:
+    ubuntu: ["python3-geopandas"]
+
+python3-geopy:
+    ubuntu: ["python3-geopy"]
+
+python3-gi:
+    ubuntu: ["python3-gi"]
+
+python3-gi-cairo:
+    ubuntu: ["python3-gi-cairo"]
+
+python3-git:
+    ubuntu: ["python3-git"]
+
+python3-github:
+    ubuntu: ["python3-github"]
+
+python3-gitlab:
+    ubuntu: ["python3-gitlab"]
+
+python3-glpk-pip:
+    pip: ["glpk"]
+
+python3-gnupg:
+    ubuntu: ["python3-gnupg"]
+
+python3-google-auth:
+    ubuntu: ["python3-google-auth"]
+
+python3-google-auth-httplib2:
+    ubuntu:
+        default: ["python3-google-auth-httplib2"]
+        bionic: nonexistent
+
+python3-google-auth-oauthlib:
+    ubuntu:
+        default: ["python3-google-auth-oauthlib"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-google-cloud-pubsub-pip:
+    pip: ["google-cloud-pubsub"]
+
+python3-google-cloud-secret-manager-pip:
+    pip: ["google-cloud-secret-manager"]
+
+python3-google-cloud-storage-pip:
+    pip: ["google-cloud-storage"]
+
+python3-google-cloud-texttospeech-pip:
+    pip: ["google-cloud-texttospeech"]
+
+python3-googleapi:
+    ubuntu: ["python3-googleapi"]
+
+python3-gpiozero:
+    ubuntu:
+        default: ["python3-gpiozero"]
+        bionic: nonexistent
+
+python3-gpxpy:
+    ubuntu: ["python3-gpxpy"]
+
+python3-gql-pip:
+    pip: ["gql"]
+
+python3-graphviz:
+    ubuntu: ["python3-graphviz"]
+
+python3-grip:
+    ubuntu: ["grip"]
+
+python3-grpc-tools:
+    ubuntu:
+        default: ["python3-grpc-tools"]
+        bionic: nonexistent
+
+python3-grpcio:
+    ubuntu:
+        default: ["python3-grpcio"]
+        bionic: nonexistent
+
+python3-gtts:
+    ubuntu: ["python3-gtts"]
+
+python3-gurobipy-pip:
+    pip: ["gurobipy"]
+
+python3-gymnasium-pip:
+    pip: ["gymnasium"]
+
+python3-gymnasium-robotics-pip:
+    pip: ["gymnasium-robotics"]
+
+python3-gz-math6:
+    ubuntu:
+        focal: ["python3-gz-math6"]
+        jammy: ["python3-gz-math6"]
+
+python3-gz-sim6:
+    ubuntu:
+        focal: ["python3-gz-sim6"]
+        jammy: ["python3-gz-sim6"]
+
+python3-h5py:
+    ubuntu: ["python3-h5py"]
+
+python3-hidapi:
+    ubuntu: ["python3-hid"]
+
+python3-hidapi-cffi:
+    ubuntu: ["python3-hidapi"]
+
+python3-httplib2:
+    ubuntu: ["python3-httplib2"]
+
+python3-hypothesis:
+    ubuntu: ["python3-hypothesis"]
+
+python3-icecream:
+    ubuntu:
+        default: ["python3-icecream"]
+        focal: nonexistent
+
+python3-ifcfg:
+    ubuntu:
+        bionic: ["python3-ifcfg"]
+        focal: ["python3-ifcfg"]
+
+python3-ignition-gazebo6:
+    ubuntu:
+        focal: ["python3-ignition-gazebo6"]
+        jammy: ["python3-ignition-gazebo6"]
+
+python3-ignition-math6:
+    ubuntu:
+        focal: ["python3-ignition-math6"]
+        jammy: ["python3-ignition-math6"]
+
+python3-imageio:
+    ubuntu: ["python3-imageio"]
+
+python3-img2pdf:
+    ubuntu: ["python3-img2pdf"]
+
+python3-importlib-metadata:
+    pip: ["importlib-metadata"]
+
+python3-importlib-resources:
+    pip: ["importlib-resources"]
+
+python3-inflection:
+    ubuntu: ["python3-inflection"]
+
+python3-inflection-pip:
+    pip: ["inflection"]
+
+python3-influxdb:
+    ubuntu: ["python3-influxdb"]
+
+python3-influxdb-client-pip:
+    pip: ["influxdb-client"]
+
+python3-inject-pip:
+    pip: ["inject"]
+
+python3-inputimeout-pip:
+    pip: ["inputimeout"]
+
+python3-insightface-pip:
+    pip: ["insightface"]
+
+python3-interpreter:
+    ubuntu: ["python3-minimal"]
+
+python3-j1939-pip:
+    pip: ["j1939"]
+
+python3-jinja2:
+    ubuntu: ["python3-jinja2"]
+
+python3-jmespath:
+    ubuntu: ["python3-jmespath"]
+
+python3-joblib:
+    ubuntu: ["python3-joblib"]
+
+python3-jsonpickle:
+    ubuntu: ["python3-jsonpickle"]
+
+python3-jsonschema:
+    ubuntu: ["python3-jsonschema"]
+
+python3-junitparser:
+    ubuntu:
+        default: ["python3-junitparser"]
+        bionic: nonexistent
+
+python3-jupyros-pip:
+    pip: ["jupyros"]
+
+python3-jwt:
+    ubuntu: ["python3-jwt"]
+
+python3-kitchen:
+    ubuntu:
+        default: ["python3-kitchen"]
+
+python3-kivy:
+    ubuntu: ["python3-kivy"]
+
+python3-kiwisolver:
+    pip: ["kiwisolver"]
+
+python3-kml2geojson-pip:
+    pip: ["kml2geojson"]
+
+python3-lark-parser:
+    ubuntu:
+        default: ["python3-lark"]
+        bionic: ["python3-lark-parser"]
+
+python3-lensfun:
+    ubuntu: ["python3-lensfun"]
+
+python3-lgpio:
+    pip: ["lgpio"]
+
+python3-libgpiod:
+    ubuntu:
+        default: ["python3-libgpiod"]
+        bionic: nonexistent
+
+python3-libtmux:
+    ubuntu: ["python3-libtmux"]
+
+python3-lingua-franca-pip:
+    pip: ["lingua-franca"]
+
+python3-lockfile:
+    ubuntu: ["python3-lockfile"]
+
+python3-lttng:
+    ubuntu: ["python3-lttng"]
+
+python3-lxml:
+    ubuntu: ["python3-lxml"]
+
+python3-magic:
+    ubuntu: ["python3-magic"]
+
+python3-mako:
+    ubuntu: ["python3-mako"]
+
+python3-mapbox-earcut-pip:
+    pip: ["mapbox-earcut"]
+
+python3-mapnik:
+    ubuntu: ["python3-mapnik"]
+
+python3-marisa:
+    ubuntu: ["python3-marisa"]
+
+python3-markdown:
+    ubuntu: ["python3-markdown"]
+
+python3-marshmallow:
+    ubuntu: ["python3-marshmallow"]
+
+python3-marshmallow-dataclass-pip:
+    pip: ["marshmallow-dataclass"]
+
+python3-matplotlib:
+    ubuntu: ["python3-matplotlib"]
+
+python3-mavproxy-pip:
+    pip: ["MAVProxy"]
+
+python3-mccabe:
+    ubuntu: ["python3-mccabe"]
+
+python3-mechanize:
+    ubuntu:
+        default: ["python3-mechanize"]
+        bionic: nonexistent
+
+python3-mediapipe-pip:
+    pip: ["mediapipe"]
+
+python3-meshio:
+    ubuntu: ["python3-meshio"]
+
+python3-meson-pip:
+    pip: ["meson"]
+
+python3-minijinja:
+    pip: ["minijinja"]
+    pip: ["minijinja"]
+    pip: ["minijinja"]
+
+python3-minimalmodbus-pip:
+    pip: ["minimalmodbus"]
+
+python3-mistune:
+    ubuntu: ["python3-mistune"]
+
+python3-mlflow:
+    pip: ["mlflow"]
+
+python3-mock:
+    ubuntu: ["python3-mock"]
+
+python3-moonraker-api-pip:
+    pip: ["moonraker-api"]
+
+python3-more-itertools:
+    ubuntu: ["python3-more-itertools"]
+
+python3-moteus-pi3hat-pip:
+    pip: ["moteus-pi3hat"]
+
+python3-moteus-pip:
+    pip: ["moteus"]
+
+python3-motor-pip:
+    pip: ["motor"]
+
+python3-msgpack:
+    ubuntu: ["python3-msgpack"]
+
+python3-msk-pip:
+    pip: ["msk"]
+
+python3-msm-pip:
+    pip: ["msm"]
+
+python3-multimethod-pip:
+    pip: ["multimethod"]
+
+python3-multipledispatch:
+    ubuntu:
+        default: ["python3-multipledispatch"]
+        focal: nonexistent
+
+python3-munkres:
+    ubuntu: ["python3-munkres"]
+
+python3-mycroft-messagebus-client-pip:
+    pip: ["mycroft-messagebus-client"]
+
+python3-mypy:
+    ubuntu: ["python3-mypy"]
+
+python3-mysqldb:
+    ubuntu: ["python3-mysqldb"]
+
+python3-myst-parser-pip:
+    pip: ["myst-parser"]
+
+python3-natsort:
+    ubuntu: ["python3-natsort"]
+
+python3-nclib-pip:
+    pip: ["nclib"]
+
+python3-nep-pip:
+    pip: ["nep"]
+
+python3-nest-asyncio:
+    ubuntu:
+        default: ["python3-nest-asyncio"]
+        focal: nonexistent
+
+python3-netcdf4:
+    ubuntu: ["python3-netcdf4"]
+
+python3-netifaces:
+    ubuntu: ["python3-netifaces"]
+
+python3-networkmanager:
+    ubuntu: ["python3-networkmanager"]
+
+python3-networkx:
+    ubuntu: ["python3-networkx"]
+
+python3-nlopt:
+    ubuntu:
+        default: ["python3-nlopt"]
+        bionic: nonexistent
+
+python3-nmcli-pip:
+    pip: ["nmcli"]
+
+python3-nose:
+    ubuntu: ["python3-nose"]
+
+python3-nose-parameterized:
+    ubuntu: ["python3-nose-parameterized"]
+
+python3-nose-yanc:
+    ubuntu: ["python3-nose-yanc"]
+
+python3-ntplib:
+    ubuntu: ["python3-ntplib"]
+
+python3-numba:
+    ubuntu: ["python3-numba"]
+
+python3-numpy:
+    ubuntu: ["python3-numpy"]
+
+python3-numpy-stl:
+    ubuntu:
+        default: ["python3-numpy-stl"]
+
+python3-nuscenes-devkit-pip:
+    pip: ["nuscenes-devkit"]
+
+python3-nxt-python-pip:
+    pip: ["nxt-python"]
+
+python3-oauth2client:
+    ubuntu: ["python3-oauth2client"]
+
+python3-oct2py-pip:
+    pip: ["oct2py"]
+
+python3-odrive-pip:
+    pip: ["odrive"]
+
+python3-ollama-pip:
+    pip: ["ollama"]
+
+python3-omniorb:
+    pip: ["omniorb"]
+
+python3-onnxruntime-gpu-pip:
+    pip: ["onnxruntime-gpu"]
+
+python3-onnxruntime-openvino-pip:
+    pip: ["onnxruntime-openvino"]
+
+python3-onnxruntime-pip:
+    pip: ["onnxruntime"]
+
+python3-open3d:
+    ubuntu:
+        default: ["python3-open3d"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-open3d-pip:
+    pip: ["open3d"]
+
+python3-openai-pip:
+    pip: ["openai"]
+
+python3-opencv:
+    ubuntu: ["python3-opencv"]
+
+python3-opengl:
+    ubuntu: ["python3-opengl"]
+
+python3-openhsi-pip:
+    pip: ["openhsi"]
+
+python3-openpyxl:
+    ubuntu: ["python3-openpyxl"]
+
+python3-orjson:
+    pip: ["orjson"]
+
+python3-osrf-pycommon:
+    ubuntu: ["python3-osrf-pycommon"]
+
+python3-overrides:
+    pip: ["overrides"]
+
+python3-owlready2-pip:
+    pip: ["owlready2"]
+
+python3-owslib:
+    ubuntu: ["python3-owslib"]
+
+python3-packaging:
+    ubuntu: ["python3-packaging"]
+
+python3-padaos-pip:
+    pip: ["padaos"]
+
+python3-padatious-pip:
+    pip: ["padatious"]
+
+python3-paho-mqtt:
+    ubuntu:
+        default: ["python3-paho-mqtt"]
+
+python3-pandas:
+    ubuntu: ["python3-pandas"]
+
+python3-papermill-pip:
+    pip: ["papermill"]
+
+python3-parameterized:
+    ubuntu: ["python3-parameterized"]
+
+python3-paramiko:
+    ubuntu: ["python3-paramiko"]
+
+python3-parse:
+    ubuntu: ["python3-parse"]
+
+python3-pcg-gazebo-pip:
+    pip: ["pcg-gazebo"]
+
+python3-pep8:
+    ubuntu: ["python3-pep8"]
+
+python3-pep8-naming:
+    ubuntu: ["python3-pep8-naming"]
+
+python3-petact-pip:
+    pip: ["petact"]
+
+python3-pexpect:
+    ubuntu: ["python3-pexpect"]
+
+python3-pickleDB-pip:
+    pip: ["pickleDB"]
+
+python3-piexif:
+    ubuntu: ["python3-piexif"]
+
+python3-pigpio:
+    ubuntu: ["python3-pigpio"]
+
+python3-pika:
+    ubuntu: ["python3-pika"]
+
+python3-pil:
+    ubuntu: ["python3-pil"]
+
+python3-pil-imagetk:
+    ubuntu: ["python3-pil.imagetk"]
+
+python3-pip:
+    ubuntu: ["python3-pip"]
+
+python3-pkg-resources:
+    ubuntu: ["python3-pkg-resources"]
+
+python3-playsound-pip:
+    pip: ["playsound"]
+
+python3-ply:
+    ubuntu: ["python3-ply"]
+
+python3-pocketsphinx-pip:
+    pip: ["pocketsphinx"]
+
+python3-polling2-pip:
+    pip: ["polling2"]
+
+python3-pqdict-pip:
+    pip: ["pqdict"]
+
+python3-pre-commit:
+    pip: ["pre-commit"]
+    pip: ["pre-commit"]
+
+python3-precise-runner-pip:
+    pip: ["precise-runner"]
+
+python3-prettytable:
+    ubuntu: ["python3-prettytable"]
+
+python3-progressbar:
+    ubuntu: ["python3-progressbar"]
+
+python3-prometheus-client:
+    ubuntu: ["python3-prometheus-client"]
+
+python3-prompt-toolkit:
+    ubuntu: ["python3-prompt-toolkit"]
+
+python3-protobuf:
+    ubuntu: ["python3-protobuf"]
+
+python3-psutil:
+    ubuntu: ["python3-psutil"]
+
+python3-psycopg2:
+    ubuntu: ["python3-psycopg2"]
+
+python3-py3exiv2-pip:
+    pip: ["py3exiv2"]
+
+python3-pyads-pip:
+    pip: ["pyads"]
+
+python3-pyassimp:
+    ubuntu:
+        default: ["python3-pyassimp"]
+
+python3-pyaudio:
+    ubuntu: ["python3-pyaudio"]
+
+python3-pybullet-pip:
+    pip: ["pybullet"]
+
+python3-pyclipper:
+    ubuntu: ["python3-pyclipper"]
+
+python3-pycodestyle:
+    ubuntu: ["python3-pycodestyle"]
+
+python3-pycryptodome:
+    ubuntu: ["python3-pycryptodome"]
+
+python3-pydantic:
+    pip: ["pydantic"]
+
+python3-pydbus:
+    ubuntu: ["python3-pydbus"]
+
+python3-pydot:
+    ubuntu: ["python3-pydot"]
+
+python3-pyee:
+    ubuntu: ["python3-pyee"]
+
+python3-pyftdi-pip:
+    pip: ["pyftdi"]
+
+python3-pyftpdlib:
+    ubuntu: ["python3-pyftpdlib"]
+
+python3-pygame:
+    pip: ["pygame"]
+
+python3-pygit2:
+    ubuntu: ["python3-pygit2"]
+
+python3-pygments:
+    ubuntu: ["python3-pygments"]
+
+python3-pygraphviz:
+    ubuntu: ["python3-pygraphviz"]
+
+python3-pyinotify:
+    ubuntu: ["python3-pyinotify"]
+
+python3-pykdl:
+    ubuntu:
+        default: ["python3-pykdl"]
+        bionic: nonexistent
+
+python3-pylatexenc:
+    pip: ["pylatexenc"]
+    pip: ["pylatexenc"]
+
+python3-pylibdmtx:
+    pip: ["pylibdmtx"]
+    pip: ["pylibdmtx"]
+
+python3-pymap3d:
+    ubuntu:
+        default: ["python3-pymap3d"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-pymesh2-pip:
+    pip: ["pymesh2"]
+
+python3-pymodbus:
+    ubuntu:
+        default: ["python3-pymodbus"]
+
+python3-pymodbus-pip:
+    pip: ["pymodbus"]
+
+python3-pymongo:
+    ubuntu: ["python3-pymongo"]
+
+python3-pymongo-pip:
+    pip: ["pymongo"]
+
+python3-pynmea2:
+    ubuntu: ["python3-nmea2"]
+
+python3-pynmeagps-pip:
+    pip: ["pynmeagps"]
+
+python3-pynput:
+    ubuntu:
+        default: ["python3-pynput"]
+        focal: nonexistent
+
+python3-pyosmium:
+    ubuntu: ["python3-pyosmium"]
+
+python3-pyotp:
+    ubuntu: ["python3-pyotp"]
+
+python3-pyparsing:
+    ubuntu: ["python3-pyparsing"]
+
+python3-pypdf:
+    pip: ["pypdf"]
+    pip: ["pypdf"]
+    pip: ["pypdf"]
+
+python3-pypng:
+    ubuntu:
+        default: ["python3-png"]
+
+python3-pyproj:
+    ubuntu: ["python3-pyproj"]
+
+python3-pyqrcode:
+    ubuntu: ["python3-pyqrcode"]
+
+python3-pyqt5:
+    ubuntu: ["pyqt5-dev", "python3-pyqt5", "python3-pyqt5.qtsvg", "python3-sip-dev"]
+
+python3-pyqt5.qtquick:
+    ubuntu: ["python3-pyqt5.qtquick"]
+
+python3-pyqt5.qtwebengine:
+    ubuntu: ["python3-pyqt5.qtwebengine"]
+
+python3-pyqt6.qtmultimedia:
+    ubuntu:
+        default: ["python3-pyqt6.qtmultimedia"]
+        focal: nonexistent
+        jammy: nonexistent
+
+python3-pyqtdarktheme-pip:
+    pip: ["pyqtdarktheme"]
+
+python3-pyqtgraph:
+    ubuntu: ["python3-pyqtgraph"]
+
+python3-pyro-ppl-pip:
+    pip: ["pyro-ppl"]
+
+python3-pyrr-pip:
+    pip: ["pyrr"]
+
+python3-pyside2:
+    ubuntu:
+        default: ["libpyside2-dev", "libshiboken2-dev", "python3-pyside2.qtcore", "python3-pyside2.qtgui", "python3-pyside2.qthelp", "python3-pyside2.qtnetwork", "python3-pyside2.qtprintsupport", "python3-pyside2.qtsvg", "python3-pyside2.qttest", "python3-pyside2.qtwidgets", "python3-pyside2.qtxml", "shiboken2"]
+        bionic: nonexistent
+
+python3-pyside2.qtcore:
+    ubuntu: ["python3-pyside2.qtcore"]
+
+python3-pyside2.qtgui:
+    ubuntu: ["python3-pyside2.qtgui"]
+
+python3-pyside2.qtopengl:
+    ubuntu:
+        default: ["python3-pyside2.qtopengl"]
+        bionic: nonexistent
+
+python3-pyside2.qtqml:
+    ubuntu: ["python3-pyside2.qtqml"]
+
+python3-pyside2.qtquick:
+    ubuntu:
+        default: ["python3-pyside2.qtquick"]
+        bionic: nonexistent
+
+python3-pyside2.qtuitools:
+    ubuntu:
+        default: ["python3-pyside2.qtuitools"]
+        bionic: nonexistent
+
+python3-pyside2.qtwidgets:
+    ubuntu: ["python3-pyside2.qtwidgets"]
+
+python3-pyside6:
+    pip: ["PySide6"]
+    pip: ["PySide6"]
+    pip: ["PySide6"]
+
+python3-pyside6.qtasyncio:
+    ubuntu:
+        default: ["python3-pyside6.qtasyncio"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtcharts:
+    ubuntu:
+        default: ["python3-pyside6.qtcharts"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtconcurrent:
+    ubuntu:
+        default: ["python3-pyside6.qtconcurrent"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtcore:
+    ubuntu:
+        default: ["python3-pyside6.qtcore"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtdatavisualization:
+    ubuntu:
+        default: ["python3-pyside6.qtdatavisualization"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtgui:
+    ubuntu:
+        default: ["python3-pyside6.qtgui"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtqml:
+    ubuntu:
+        default: ["python3-pyside6.qtqml"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qttest:
+    ubuntu:
+        default: ["python3-pyside6.qttest"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pyside6.qtwidgets:
+    ubuntu:
+        default: ["python3-pyside6.qtwidgets"]
+        focal: nonexistent
+        jammy: nonexistent
+        noble: nonexistent
+
+python3-pysnmp:
+    ubuntu: ["python3-pysnmp4"]
+
+python3-pysnmp-mibs:
+    ubuntu: ["python3-pysnmp4-mibs"]
+
+python3-pystemd:
+    pip: ["pystemd"]
+
+python3-pyswarms-pip:
+    pip: ["pyswarms"]
+
+python3-pytest:
+    ubuntu: ["python3-pytest"]
+
+python3-pytest-asyncio:
+    ubuntu:
+        default: ["python3-pytest-asyncio"]
+        bionic: nonexistent
+
+python3-pytest-benchmark:
+    ubuntu: ["python3-pytest-benchmark"]
+
+python3-pytest-cov:
+    ubuntu: ["python3-pytest-cov"]
+
+python3-pytest-mock:
+    ubuntu: ["python3-pytest-mock"]
+
+python3-pytest-order:
+    ubuntu:
+        default: ["python3-pytest-order"]
+        focal: nonexistent
+
+python3-pytest-pylint:
+    ubuntu: ["python3-pytest-pylint"]
+
+python3-pytest-ruff-pip:
+    pip: ["pytest-ruff"]
+
+python3-pytest-timeout:
+    ubuntu: ["python3-pytest-timeout"]
+
+python3-pytest-xdist:
+    ubuntu: ["python3-pytest-xdist"]
+
+python3-pytest-xvfb:
+    ubuntu: ["python3-pytest-xvfb"]
+
+python3-pytorch-pip:
+    pip: ["torch", "torchvision"]
+
+python3-pytrinamic-pip:
+    pip: ["pytrinamic"]
+
+python3-pyudev:
+    ubuntu: ["python3-pyudev"]
+
+python3-pyvista-pip:
+    pip: ["pyvista"]
+
+python3-pyxdg-pip:
+    pip: ["pyxdg"]
+
+python3-qpsolvers-pip:
+    pip: ["qpsolvers"]
+
+python3-qrcode:
+    ubuntu: ["python3-qrcode"]
+
+python3-qt5-bindings:
+    ubuntu:
+        default: ["libpyside2-dev", "libshiboken2-dev", "pyqt5-dev", "python3-pyqt5", "python3-pyqt5.qtsvg", "python3-pyside2.qtsvg", "python3-sip-dev", "shiboken2"]
+        bionic: ["pyqt5-dev", "python3-pyqt5", "python3-pyqt5.qtsvg", "python3-sip-dev"]
+
+python3-qt5-bindings-gl:
+    ubuntu: ["python3-pyqt5.qtopengl"]
+
+python3-qt5-bindings-webkit:
+    ubuntu: ["python3-pyqt5.qtwebkit"]
+
+python3-qtpy:
+    ubuntu: ["python3-qtpy"]
+
+python3-qwt:
+    ubuntu: ["python3-qwt"]
+
+python3-qwt-pip:
+    pip: ["PythonQwt"]
+
+python3-rafcon-pip:
+    pip: ["rafcon"]
+
+python3-rapidfuzz-pip:
+    pip: ["rapidfuzz"]
+
+python3-rasterio:
+    ubuntu: ["python3-rasterio"]
+
+python3-rdflib:
+    ubuntu: ["python3-rdflib"]
+
+python3-reportlab:
+    ubuntu: ["python3-reportlab"]
+
+python3-requests:
+    ubuntu: ["python3-requests"]
+
+python3-requests-futures:
+    ubuntu: ["python3-requests-futures"]
+
+python3-requests-oauthlib:
+    ubuntu: ["python3-requests-oauthlib"]
+
+python3-requests-toolbelt:
+    ubuntu: ["python3-requests-toolbelt"]
+
+python3-retrying:
+    ubuntu: ["python3-retrying"]
+
+python3-rich:
+    pip: ["rich"]
+
+python3-river-pip:
+    pip: ["river"]
+
+python3-rmsd-pip:
+    pip: ["rmsd"]
+
+python3-robodk-pip:
+    pip: ["robodk"]
+
+python3-rocker:
+    ubuntu: ["python3-rocker"]
+
+python3-rosbags-pip:
+    pip: ["rosbags"]
+
+python3-rosdep:
+    ubuntu: ["python3-rosdep"]
+
+python3-rosdep-modules:
+    ubuntu: ["python3-rosdep-modules"]
+
+python3-rosdistro-modules:
+    ubuntu: ["python3-rosdistro-modules"]
+
+python3-rosinstall-generator:
+    ubuntu: ["python3-rosinstall-generator"]
+
+python3-rospkg:
+    ubuntu: ["python3-rospkg"]
+
+python3-rospkg-modules:
+    ubuntu: ["python3-rospkg-modules"]
+
+python3-rsa:
+    ubuntu: ["python3-rsa"]
+
+python3-rtree:
+    ubuntu: ["python3-rtree"]
+
+python3-ruamel.yaml:
+    ubuntu: ["python3-ruamel.yaml"]
+
+python3-ruff-pip:
+    pip: ["ruff"]
+
+python3-sbp-pip:
+    pip: ["sbp"]
+
+python3-schedule:
+    ubuntu: ["python3-schedule"]
+
+python3-schema:
+    ubuntu: ["python3-schema"]
+
+python3-scikit-sparse-pip:
+    pip: ["scikit-sparse"]
+
+python3-scikit-spatial-pip:
+    pip: ["scikit-spatial"]
+
+python3-scipy:
+    ubuntu: ["python3-scipy"]
+
+python3-scp:
+    ubuntu: ["python3-scp"]
+
+python3-seaborn:
+    ubuntu: ["python3-seaborn"]
+
+python3-segno:
+    pip: ["segno"]
+    pip: ["segno"]
+
+python3-selenium:
+    ubuntu: ["python3-selenium"]
+
+python3-semantic-version:
+    ubuntu: ["python3-semantic-version"]
+
+python3-semver:
+    ubuntu: ["python3-semver"]
+
+python3-sense-emu-pip:
+    pip: ["sense-emu"]
+
+python3-sense-hat-pip:
+    pip: ["sense-hat"]
+
+python3-serial:
+    ubuntu: ["python3-serial"]
+
+python3-setuptools:
+    ubuntu: ["python3-setuptools"]
+
+python3-sexpdata:
+    pip: ["sexpdata"]
+
+python3-sh:
+    ubuntu: ["python3-sh"]
+
+python3-shapely:
+    ubuntu: ["python3-shapely"]
+
+python3-sila2lib-pip:
+    pip: ["sila2lib"]
+
+python3-simple-pid-pip:
+    pip: ["simple-pid"]
+
+python3-simplejpeg-pip:
+    pip: ["simplejpeg"]
+
+python3-simplejson:
+    ubuntu: ["python3-simplejson"]
+
+python3-simplification-pip:
+    pip: ["simplification"]
+
+python3-singleton-pattern-decorator-pip:
+    pip: ["singleton-pattern-decorator"]
+
+python3-sip:
+    ubuntu: ["python3-sip-dev"]
+
+python3-siphon-pip:
+    pip: ["siphon"]
+
+python3-six:
+    ubuntu: ["python3-six"]
+
+python3-skimage:
+    ubuntu: ["python3-skimage"]
+
+python3-sklearn:
+    ubuntu: ["python3-sklearn"]
+
+python3-smbus:
+    ubuntu: ["python3-smbus"]
+
+python3-smbus2:
+    ubuntu:
+        default: ["python3-smbus2"]
+        focal: nonexistent
+
+python3-smbus2-pip:
+    pip: ["smbus2"]
+
+python3-smc-pip:
+    pip: ["smc"]
+
+python3-socketio:
+    ubuntu:
+        default: ["python3-socketio"]
+        bionic: nonexistent
+
+python3-sortedcollections-pip:
+    pip: ["sortedcollections"]
+
+python3-sounddevice-pip:
+    pip: ["sounddevice"]
+
+python3-sparkfun-ublox-gps-pip:
+    pip: ["sparkfun-ublox-gps"]
+
+python3-sphinx:
+    ubuntu: ["python3-sphinx"]
+
+python3-sphinx-argparse:
+    ubuntu: ["python3-sphinx-argparse"]
+
+python3-sphinx-autoapi-pip:
+    pip: ["sphinx-autoapi"]
+
+python3-sphinx-rtd-theme:
+    ubuntu: ["python3-sphinx-rtd-theme"]
+
+python3-spidev-pip:
+    pip: ["spidev"]
+
+python3-sqlalchemy:
+    ubuntu: ["python3-sqlalchemy"]
+
+python3-sqlalchemy-utils:
+    ubuntu: ["python3-sqlalchemy-utils"]
+
+python3-sqlite-utils-pip:
+    pip: ["sqlite-utils"]
+
+python3-sqlmodel:
+    pip: ["sqlmodel"]
+    pip: ["sqlmodel"]
+
+python3-squaternion-pip:
+    pip: ["squaternion"]
+
+python3-sshkeyboard-pip:
+    pip: ["sshkeyboard"]
+
+python3-sshtunnel:
+    ubuntu:
+        focal: ["python3-sshtunnel"]
+        jammy: ["python3-sshtunnel"]
+
+python3-stable-baselines3-pip:
+    pip: ["stable-baselines3"]
+
+python3-staticmap-pip:
+    pip: ["staticmap"]
+
+python3-stonesoup-pip:
+    pip: ["stonesoup"]
+
+python3-streamz:
+    pip: ["streamz"]
+
+python3-suas-interop-clients-pip:
+    pip: ["suas-interop-clients"]
+
+python3-svg.path:
+    ubuntu: ["python3-svg.path"]
+
+python3-sympy:
+    ubuntu: ["python3-sympy"]
+
+python3-systemd:
+    ubuntu: ["python3-systemd"]
+
+python3-sysv-ipc:
+    ubuntu: ["python3-sysv-ipc"]
+
+python3-tables:
+    ubuntu: ["python3-tables"]
+
+python3-tabulate:
+    ubuntu: ["python3-tabulate"]
+
+python3-tcr-roboclaw-pip:
+    pip: ["tcr-roboclaw"]
+
+python3-tensorboardX-pip:
+    pip: ["tensorboardX"]
+
+python3-termcolor:
+    ubuntu: ["python3-termcolor"]
+
+python3-texttable:
+    ubuntu: ["python3-texttable"]
+
+python3-textual:
+    ubuntu:
+        default: ["python3-textual"]
+        focal: nonexistent
+
+python3-thop-pip:
+    pip: ["thop"]
+
+python3-thriftpy:
+    ubuntu: ["python3-thriftpy"]
+
+python3-tikzplotlib-pip:
+    pip: ["tikzplotlib"]
+
+python3-tilestache-pip:
+    pip: ["tilestache"]
+
+python3-timm-pip:
+    pip: ["timm"]
+
+python3-tinkerforge-pip:
+    pip: ["tinkerforge"]
+
+python3-tk:
+    ubuntu: ["python3-tk"]
+
+python3-toml:
+    ubuntu: ["python3-toml"]
+
+python3-toppra-pip:
+    pip: ["toppra"]
+
+python3-torch:
+    ubuntu:
+        default: ["python3-torch"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-torchvision:
+    ubuntu:
+        default: ["python3-torchvision"]
+        bionic: nonexistent
+        focal: nonexistent
+
+python3-tornado:
+    ubuntu: ["python3-tornado"]
+
+python3-tqdm:
+    ubuntu:
+        default: ["python3-tqdm"]
+
+python3-transformers-pip:
+    pip: ["transformers"]
+
+python3-transforms3d:
+    pip: ["transforms3d"]
+    pip: ["transforms3d"]
+
+python3-transitions:
+    ubuntu: ["python3-transitions"]
+
+python3-triangle-pip:
+    pip: ["triangle"]
+
+python3-trimesh-pip:
+    pip: ["trimesh"]
+
+python3-twilio:
+    ubuntu: ["python3-twilio"]
+
+python3-twisted:
+    ubuntu: ["python3-twisted"]
+
+python3-typeguard:
+    pip: ["typeguard"]
+
+python3-typeguard-pip:
+    pip: ["typeguard"]
+
+python3-types-pyyaml:
+    pip: ["types-pyyaml"]
+
+python3-typing-extensions:
+    pip: ["typing-extensions"]
+
+python3-tz:
+    ubuntu: ["python3-tz"]
+
+python3-ubjson:
+    ubuntu:
+        default: ["python3-ubjson"]
+
+python3-ujson:
+    ubuntu: ["python3-ujson"]
+
+python3-ultralytics-pip:
+    pip: ["ultralytics"]
+
+python3-unidecode:
+    ubuntu: ["python3-unidecode"]
+
+python3-unidiff:
+    ubuntu: ["python3-unidiff"]
+
+python3-urdfpy-pip:
+    pip: ["urdfpy"]
+
+python3-urllib3:
+    ubuntu: ["python3-urllib3"]
+
+python3-urwid:
+    ubuntu: ["python3-urwid"]
+
+python3-usb:
+    ubuntu: ["python3-usb"]
+
+python3-uvicorn:
+    pip: ["uvicorn"]
+
+python3-uvloop:
+    ubuntu: ["python3-uvloop"]
+
+python3-validators:
+    ubuntu:
+        default: ["python3-validators"]
+        focal: nonexistent
+
+python3-vcstool:
+    ubuntu: ["python3-vcstool"]
+
+python3-vedo-pip:
+    pip: ["vedo"]
+
+python3-venv:
+    ubuntu: ["python3-venv"]
+
+python3-virtualserialports-pip:
+    pip: ["PyVirtualSerialPorts"]
+
+python3-voluptuous:
+    ubuntu: ["python3-voluptuous"]
+
+python3-waitress:
+    ubuntu: ["python3-waitress"]
+
+python3-wand:
+    ubuntu: ["python3-wand"]
+
+python3-watchdog:
+    ubuntu: ["python3-watchdog"]
+
+python3-waymo-open-dataset-tf-2-6-0-pip:
+    pip: ["waymo-open-dataset-tf-2-6-0"]
+
+python3-weasyprint-pip:
+    pip: ["weasyprint"]
+
+python3-webargs:
+    pip: ["webargs"]
+    pip: ["webargs"]
+
+python3-webpy:
+    ubuntu: ["python3-webpy"]
+
+python3-websocket:
+    ubuntu: ["python3-websocket"]
+
+python3-websockets:
+    ubuntu: ["python3-websockets"]
+
+python3-werkzeug:
+    ubuntu: ["python3-werkzeug"]
+
+python3-west-pip:
+    pip: ["west"]
+
+python3-wgconfig-pip:
+    pip: ["wgconfig"]
+
+python3-whichcraft:
+    ubuntu: ["python3-whichcraft"]
+
+python3-wrapt:
+    ubuntu: ["python3-wrapt"]
+
+python3-wxgtk4.0:
+    ubuntu: ["python3-wxgtk4.0"]
+
+python3-xdot:
+    ubuntu: ["xdot"]
+
+python3-xlsxwriter:
+    ubuntu: ["python3-xlsxwriter"]
+
+python3-xmlschema:
+    pip: ["xmlschema"]
+
+python3-xmltodict:
+    ubuntu: ["python3-xmltodict"]
+
+python3-yaml:
+    ubuntu: ["python3-yaml"]
+
+python3-yappi:
+    ubuntu:
+        default: ["python3-yappi"]
+        bionic: nonexistent
+
+python3-yoctopuce-pip:
+    pip: ["yoctopuce"]
+
+python3-yolov5:
+    pip: ["yolov5"]
+
+python3-zmq:
+    ubuntu: ["python3-zmq"]
+
+qdarkstyle-pip:
+    pip: ["qdarkstyle"]
+
+quadprog-pip:
+    pip: ["quadprog"]
+
+rosbag-metadata-pip:
+    pip: ["rosbag-metadata"]
+
+roslibpy-pip:
+    pip: ["roslibpy"]
+
+rpy2:
+    ubuntu: ["python-rpy2"]
+
+sphinxcontrib-bibtex-pip:
+    pip: ["sphinxcontrib-bibtex"]
+
+svgpathtools-pip:
+    pip: ["svgpathtools"]
+
+tilestache:
+    ubuntu: ["tilestache"]
+
+uavcan-pip:
+    pip: ["uavcan"]
+
+urdf2webots-pip:
+    pip: ["urdf2webots"]
+
+virtualenv:
+    ubuntu: ["virtualenv"]
+
+wxpython:
+    ubuntu:
+        default: ["python-wxgtk3.0"]
+
+yapf:
+    ubuntu:
+        bionic: ["yapf"]
+
+yapf3:
+    ubuntu:
+        default: ["yapf3"]
+
+zulip-pip:
+    pip: ["zulip"]
+
+bundler:
+    ubuntu: ["bundler"]
+
+facets:
+    gem: ["facets"]
+
+flexmock:
+    ubuntu: ["ruby-flexmock"]
+
+hoe:
+    ubuntu: ["ruby-hoe"]
+
+metaruby:
+    gem: ["metaruby"]
+
+nokogiri:
+    ubuntu: ["ruby-nokogiri"]
+
+rake:
+    ubuntu: ["rake"]
+
+rake-compiler:
+    ubuntu: ["rake-compiler"]
+
+rdoc:
+    ubuntu: ["ruby"]
+
+rubocop:
+    ubuntu: ["rubocop"]
+
+ruby:
+    ubuntu: ["ruby"]
+
+ruby-backports:
+    ubuntu: ["ruby-backports"]
+
+ruby-dev:
+    ubuntu: ["ruby-dev"]
+
+ruby-ronn:
+    ubuntu: ["ruby-ronn"]
+
+ruby-sass:
+    ubuntu: ["ruby-sass"]
+
+utilrb:
+    gem: ["utilrb"]
+

--- a/ubuntu.osdeps-rolling
+++ b/ubuntu.osdeps-rolling
@@ -2,6 +2,8 @@
 # This file is generated, do not edit!
 # based on https://github.com/ros/rosdistro tag rolling/2025-01-02
 #
+# If you need a refresh, call autoproj reconfigure or delete just this file and run autoproj update --config
+#
 ace:
     ubuntu: ["libace-dev"]
 


### PR DESCRIPTION
The osdep files for the versions are now (again) provided with this package_set.

Updates can be forced by configuration option:
* the user is asked if an update should be forced on initial bootstrap
* "autoproj reconfigure" can be used, just answer the "Force update of the OS Dependency Definitions from rosdep" with yes
* deleting the e.g. ros.osdep-humble files will also trigger an import/update

The files are intentially not updated all the time, as the determination of the latest tag for the rosdistro uses the gitlab api, which has a rate limit, and should not be called too often.

