### PR TITLE
Add ground segmentation and nav2 costmap plugin packages

### DIFF
--- a/ros-2.autobuild
+++ b/ros-2.autobuild
@@ -29,3 +29,7 @@ colcon_package "interaction/libraries/robot_remote_control"
 metapackage "robot_remote_control", "interaction/libraries/robot_remote_control"
 
 colcon_package "planning/ugv_nav4d_ros2"
+
+colcon_package "perception/ground_segmentation"
+colcon_package "perception/ground_segmentation_ros2"
+colcon_package "navigation/nav2_ground_consistency_costmap_plugin"

--- a/ros-2.autobuild
+++ b/ros-2.autobuild
@@ -30,6 +30,6 @@ metapackage "robot_remote_control", "interaction/libraries/robot_remote_control"
 
 colcon_package "planning/ugv_nav4d_ros2"
 
-colcon_package "perception/ground_segmentation"
-colcon_package "perception/ground_segmentation_ros2"
-colcon_package "navigation/nav2_ground_consistency_costmap_plugin"
+colcon_package "ground_segmentation", move_to: "perception"
+colcon_package "ground_segmentation_ros2", move_to: "perception"
+colcon_package "nav2_ground_consistency_costmap_plugin", move_to: "navigation"

--- a/source.yml
+++ b/source.yml
@@ -166,11 +166,11 @@ version_control:
     # github: rock-control/control-trajectory_follower
     # branch: feature/qt5
 
-  - navigation/nav2_ground_consistency_costmap_plugin:
+  - nav2_ground_consistency_costmap_plugin:
     github: dfki-ric/nav2_ground_consistency_costmap_plugin
 
-  - perception/ground_segmentation:
+  - ground_segmentation:
     github: dfki-ric/ground_segmentation
 
-  - perception/ground_segmentation_ros2:
+  - ground_segmentation_ros2:
     github: dfki-ric/ground_segmentation_ros2

--- a/source.yml
+++ b/source.yml
@@ -165,3 +165,12 @@ version_control:
     branch: limit_speed_at_end_of_traj-qt4-qt5
     # github: rock-control/control-trajectory_follower
     # branch: feature/qt5
+
+  - navigation/nav2_ground_consistency_costmap_plugin:
+    github: dfki-ric/nav2_ground_consistency_costmap_plugin
+
+  - perception/ground_segmentation:
+    github: dfki-ric/ground_segmentation
+
+  - perception/ground_segmentation_ros2:
+    github: dfki-ric/ground_segmentation_ros2


### PR DESCRIPTION
Adds three packages to the ROS2 package set:

ground_segmentation - Ground detection library
ground_segmentation_ros2 - ROS2 wrapper for ground segmentation
nav2_ground_consistency_costmap_plugin - Nav2 costmap layer for probabilistic occupancy with ground/obstacle point cloud fusion