### PR TITLE
Add ament_lint_{auto,common} as dependencies to ground_segmentation_ros2

### DIFF
--- a/ros-2.autobuild
+++ b/ros-2.autobuild
@@ -31,5 +31,9 @@ metapackage "robot_remote_control", "interaction/libraries/robot_remote_control"
 colcon_package "planning/ugv_nav4d_ros2"
 
 colcon_package "ground_segmentation", move_to: "perception"
-colcon_package "ground_segmentation_ros2", move_to: "perception"
+colcon_package "ground_segmentation_ros2", move_to: "perception" do |pkg|
+    pkg.depends_on "ament_lint_auto"
+    pkg.depends_on "ament_lint_common"
+end
+
 colcon_package "nav2_ground_consistency_costmap_plugin", move_to: "navigation"


### PR DESCRIPTION
I prefer this instead of disabling the tests. I guess always installing the `test_depend`s would usually also not hurt.

N.B. `ground_segmentation` (sans `_ros2`) seems not to actually depend on anything `ament` related, i.e., the `test_depend`s could be removed there.